### PR TITLE
If the user does not have access to the course, then redirect to the course outline.

### DIFF
--- a/src/courseware/CourseContainer.jsx
+++ b/src/courseware/CourseContainer.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { history } from '@edx/frontend-platform';
+import { history, getConfig } from '@edx/frontend-platform';
 import { fetchCourseMetadata } from '../data/course-meta/thunks';
 import { fetchCourseBlocks } from '../data/course-blocks/thunks';
 
@@ -41,6 +41,12 @@ function CourseContainer(props) {
     }
   }, [courseUsageKey, courseId, sequenceId]);
 
+  useEffect(() => {
+    if (metadataLoaded && !metadata.userHasAccess) {
+      global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${courseUsageKey}/course/`);
+    }
+  }, [metadataLoaded]);
+
   if (!courseId || !sequenceId) {
     return (
       <PageLoading
@@ -75,6 +81,7 @@ CourseContainer.propTypes = {
     org: PropTypes.string,
     number: PropTypes.string,
     name: PropTypes.string,
+    userHasAccess: PropTypes.bool,
     tabs: PropTypes.arrayOf(PropTypes.shape({
       priority: PropTypes.number,
       slug: PropTypes.string,

--- a/src/data/course-meta/thunks.js
+++ b/src/data/course-meta/thunks.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/prefer-default-export */
+import { getConfig } from '@edx/frontend-platform';
 import {
   fetchCourseMetadataRequest,
   fetchCourseMetadataSuccess,
@@ -13,7 +14,12 @@ export function fetchCourseMetadata(courseUsageKey) {
     dispatch(fetchCourseMetadataRequest({ courseUsageKey }));
     try {
       const courseMetadata = await getCourseMetadata(courseUsageKey);
-      dispatch(fetchCourseMetadataSuccess(courseMetadata));
+
+      if (!courseMetadata.userHasAccess) {
+        global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${courseUsageKey}/course/`);
+      } else {
+        dispatch(fetchCourseMetadataSuccess(courseMetadata));
+      }
     } catch (error) {
       dispatch(fetchCourseMetadataFailure(error));
     }

--- a/src/data/course-meta/thunks.js
+++ b/src/data/course-meta/thunks.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/prefer-default-export */
-import { getConfig } from '@edx/frontend-platform';
 import {
   fetchCourseMetadataRequest,
   fetchCourseMetadataSuccess,
@@ -14,12 +13,7 @@ export function fetchCourseMetadata(courseUsageKey) {
     dispatch(fetchCourseMetadataRequest({ courseUsageKey }));
     try {
       const courseMetadata = await getCourseMetadata(courseUsageKey);
-
-      if (!courseMetadata.userHasAccess) {
-        global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${courseUsageKey}/course/`);
-      } else {
-        dispatch(fetchCourseMetadataSuccess(courseMetadata));
-      }
+      dispatch(fetchCourseMetadataSuccess(courseMetadata));
     } catch (error) {
       dispatch(fetchCourseMetadataFailure(error));
     }


### PR DESCRIPTION
In a subsequent PR, if this API call is made on the course outline page in the MFE, we’ll need to be able to prevent the redirect.  But that view of the MFE doesn’t exist yet.