### PR TITLE
Only redirect if the user has no access and isn’t staff

### DIFF
--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -129,7 +129,7 @@ function useSavedSequencePosition(courseId, sequenceId, unitId) {
 function useAccessDeniedRedirect(courseStatus, courseId) {
   const course = useModel('courses', courseId);
   useEffect(() => {
-    if (courseStatus === 'loaded' && !course.userHasAccess) {
+    if (courseStatus === 'loaded' && !course.userHasAccess && !course.isStaff) {
       global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${course.id}/course/`);
     }
   }, [courseStatus, course]);


### PR DESCRIPTION
TNL-7129

This adds a third clause to our useAccessDeniedRedirect hook, which makes sure the user doesn’t have staff access (instead of normal, enrolled access) prior to redirecting.

As an aside, this redirection approach - irrespective of this PR - is not great.  The UI mostly renders prior to this redirect happening.  It would be better of this hook returned something that would help prevent the UI from rendering while the redirect is in progress.  As it stands, a redirected user will see a flash of the page content prior to being booted.  Not wonderful.