### PR TITLE
Improve access control behavior

### DIFF
--- a/src/CoursewareRedirect.jsx
+++ b/src/CoursewareRedirect.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Switch, Route, useRouteMatch } from 'react-router';
+import { getConfig } from '@edx/frontend-platform';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import PageLoading from './PageLoading';
+
+export default () => {
+  const { path } = useRouteMatch();
+  return (
+    <div className="flex-grow-1">
+      <PageLoading srMessage={(
+        <FormattedMessage
+          id="learn.redirect.interstitial.message"
+          description="The screen-reader message when a page is about to redirect"
+          defaultMessage="Redirecting..."
+        />
+      )}
+      />
+
+      <Switch>
+        <Route
+          path={`${path}/course-home/:courseId`}
+          render={({ match }) => {
+            global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${match.params.courseId}/course/`);
+          }}
+        />
+      </Switch>
+    </div>
+  );
+};

--- a/src/PageLoading.jsx
+++ b/src/PageLoading.jsx
@@ -33,5 +33,5 @@ export default class PageLoading extends Component {
 }
 
 PageLoading.propTypes = {
-  srMessage: PropTypes.string.isRequired,
+  srMessage: PropTypes.node.isRequired,
 };

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -158,7 +158,6 @@ export default function CoursewareContainer() {
   const previousSequenceHandler = usePreviousSequenceHandler(courseId, sequenceId);
   const unitNavigationHandler = useUnitNavigationHandler(courseId, sequenceId, routeUnitId);
 
-  // useAccessDeniedRedirect(courseStatus, courseId);
   useContentRedirect(courseStatus, sequenceStatus);
   useExamRedirect(sequenceId);
   useSavedSequencePosition(courseId, sequenceId, routeUnitId);

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -89,7 +89,7 @@ function useContentRedirect(courseStatus, sequenceStatus) {
   const sequence = useModel('sequences', sequenceId);
   const firstSequenceId = useSelector(firstSequenceIdSelector);
   useEffect(() => {
-    if (courseStatus === 'loaded' && !sequenceId) {
+    if (courseStatus === 'loaded' && !sequenceId && firstSequenceId) {
       // This is a replace because we don't want this change saved in the browser's history.
       history.replace(`/course/${courseId}/${firstSequenceId}`);
     }

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -89,7 +89,7 @@ function useContentRedirect(courseStatus, sequenceStatus) {
   const sequence = useModel('sequences', sequenceId);
   const firstSequenceId = useSelector(firstSequenceIdSelector);
   useEffect(() => {
-    if (courseStatus === 'loaded' && !sequenceId && firstSequenceId) {
+    if (courseStatus === 'loaded' && !sequenceId) {
       // This is a replace because we don't want this change saved in the browser's history.
       history.replace(`/course/${courseId}/${firstSequenceId}`);
     }

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
-import { history, getConfig } from '@edx/frontend-platform';
+import { history } from '@edx/frontend-platform';
 
-import { useRouteMatch } from 'react-router';
+import { useRouteMatch, Redirect } from 'react-router';
 import {
   fetchCourse,
   fetchSequence,
@@ -120,21 +120,6 @@ function useSavedSequencePosition(courseId, sequenceId, unitId) {
   }, [unitId]);
 }
 
-/**
- * Redirects the user away from the app if they don't have access to view this course.
- *
- * @param {*} courseStatus
- * @param {*} course
- */
-function useAccessDeniedRedirect(courseStatus, courseId) {
-  const course = useModel('courses', courseId);
-  useEffect(() => {
-    if (courseStatus === 'loaded' && !course.userHasAccess && !course.isStaff) {
-      global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${course.id}/course/`);
-    }
-  }, [courseStatus, course]);
-}
-
 export default function CoursewareContainer() {
   const { params } = useRouteMatch();
   const {
@@ -173,10 +158,14 @@ export default function CoursewareContainer() {
   const previousSequenceHandler = usePreviousSequenceHandler(courseId, sequenceId);
   const unitNavigationHandler = useUnitNavigationHandler(courseId, sequenceId, routeUnitId);
 
-  useAccessDeniedRedirect(courseStatus, courseId);
+  // useAccessDeniedRedirect(courseStatus, courseId);
   useContentRedirect(courseStatus, sequenceStatus);
   useExamRedirect(sequenceId);
   useSavedSequencePosition(courseId, sequenceId, routeUnitId);
+
+  if (courseStatus === 'denied') {
+    return <Redirect to={`/redirect/course-home/${courseId}`} />;
+  }
 
   return (
     <main className="flex-grow-1 d-flex flex-column">

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -45,7 +45,7 @@ export default function CourseBreadcrumbs({
 
   const links = useMemo(() => {
     if (courseStatus === 'loaded' && sequenceStatus === 'loaded') {
-      return [section, sequence].map((node) => ({
+      return [section, sequence].filter(node => !!node).map((node) => ({
         id: node.id,
         label: node.title,
         url: `${getConfig().LMS_BASE_URL}/courses/${course.id}/course/#${node.id}`,

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -108,7 +108,7 @@ function Sequence({
     );
   }
 
-  const gated = sequence && sequence.gatedContent !== undefined && sequence.gatedContent.gated;
+  const gated = sequence.gatedContent !== undefined && sequence.gatedContent.gated;
 
   if (sequenceStatus === 'loaded') {
     return (
@@ -175,17 +175,12 @@ function Sequence({
     );
   }
 
-  // sequence status 'failed'
-  if (sequenceStatus === 'failed') {
-    return (
-      <p className="text-center py-5 mx-auto" style={{ maxWidth: '30em' }}>
-        {intl.formatMessage(messages['learn.course.load.failure'])}
-      </p>
-    );
-  }
-
-  // any other unexpected sequence status, like sequence has not begun to load
-  return null;
+  // sequence status 'failed' and any other unexpected sequence status.
+  return (
+    <p className="text-center py-5 mx-auto" style={{ maxWidth: '30em' }}>
+      {intl.formatMessage(messages['learn.course.load.failure'])}
+    </p>
+  );
 }
 
 Sequence.propTypes = {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -108,7 +108,7 @@ function Sequence({
     );
   }
 
-  const gated = sequence.gatedContent !== undefined && sequence.gatedContent.gated;
+  const gated = sequence && sequence.gatedContent !== undefined && sequence.gatedContent.gated;
 
   if (sequenceStatus === 'loaded') {
     return (
@@ -175,12 +175,17 @@ function Sequence({
     );
   }
 
-  // sequence status 'failed' and any other unexpected sequence status.
-  return (
-    <p className="text-center py-5 mx-auto" style={{ maxWidth: '30em' }}>
-      {intl.formatMessage(messages['learn.course.load.failure'])}
-    </p>
-  );
+  // sequence status 'failed'
+  if (sequenceStatus === 'failed') {
+    return (
+      <p className="text-center py-5 mx-auto" style={{ maxWidth: '30em' }}>
+        {intl.formatMessage(messages['learn.course.load.failure'])}
+      </p>
+    );
+  }
+
+  // any other unexpected sequence status, like sequence has not begun to load
+  return null;
 }
 
 Sequence.propTypes = {

--- a/src/courseware/data/selectors.js
+++ b/src/courseware/data/selectors.js
@@ -1,22 +1,20 @@
 /* eslint-disable import/prefer-default-export */
 export function sequenceIdsSelector(state) {
-  try {
-    const { sectionIds } = state.models.courses[state.courseware.courseId];
-    const sequenceIds = sectionIds.flatMap(sectionId => state.models.sections[sectionId].sequenceIds);
-    return sequenceIds;
-  } catch (e) {
+  if (state.courseware.courseStatus !== 'loaded') {
     return [];
   }
+  const { sectionIds } = state.models.courses[state.courseware.courseId];
+  let sequenceIds = [];
+  sectionIds.forEach(sectionId => {
+    sequenceIds = [...sequenceIds, ...state.models.sections[sectionId].sequenceIds];
+  });
+  return sequenceIds;
 }
 
 export function firstSequenceIdSelector(state) {
   if (state.courseware.courseStatus !== 'loaded') {
     return null;
   }
-  try {
-    const sectionId = state.models.courses[state.courseware.courseId].sectionIds[0];
-    return state.models.sections[sectionId].sequenceIds[0];
-  } catch (e) {
-    return null;
-  }
+  const sectionId = state.models.courses[state.courseware.courseId].sectionIds[0];
+  return state.models.sections[sectionId].sequenceIds[0];
 }

--- a/src/courseware/data/selectors.js
+++ b/src/courseware/data/selectors.js
@@ -1,20 +1,22 @@
 /* eslint-disable import/prefer-default-export */
 export function sequenceIdsSelector(state) {
-  if (state.courseware.courseStatus !== 'loaded') {
+  try {
+    const { sectionIds } = state.models.courses[state.courseware.courseId];
+    const sequenceIds = sectionIds.flatMap(sectionId => state.models.sections[sectionId].sequenceIds);
+    return sequenceIds;
+  } catch (e) {
     return [];
   }
-  const { sectionIds } = state.models.courses[state.courseware.courseId];
-  let sequenceIds = [];
-  sectionIds.forEach(sectionId => {
-    sequenceIds = [...sequenceIds, ...state.models.sections[sectionId].sequenceIds];
-  });
-  return sequenceIds;
 }
 
 export function firstSequenceIdSelector(state) {
   if (state.courseware.courseStatus !== 'loaded') {
     return null;
   }
-  const sectionId = state.models.courses[state.courseware.courseId].sectionIds[0];
-  return state.models.sections[sectionId].sequenceIds[0];
+  try {
+    const sectionId = state.models.courses[state.courseware.courseId].sectionIds[0];
+    return state.models.sections[sectionId].sequenceIds[0];
+  } catch (e) {
+    return null;
+  }
 }

--- a/src/courseware/data/selectors.js
+++ b/src/courseware/data/selectors.js
@@ -3,11 +3,11 @@ export function sequenceIdsSelector(state) {
   if (state.courseware.courseStatus !== 'loaded') {
     return [];
   }
-  const { sectionIds } = state.models.courses[state.courseware.courseId];
-  let sequenceIds = [];
-  sectionIds.forEach(sectionId => {
-    sequenceIds = [...sequenceIds, ...state.models.sections[sectionId].sequenceIds];
-  });
+  const { sectionIds = [] } = state.models.courses[state.courseware.courseId];
+
+  const sequenceIds = sectionIds
+    .flatMap(sectionId => state.models.sections[sectionId].sequenceIds);
+
   return sequenceIds;
 }
 
@@ -15,6 +15,11 @@ export function firstSequenceIdSelector(state) {
   if (state.courseware.courseStatus !== 'loaded') {
     return null;
   }
-  const sectionId = state.models.courses[state.courseware.courseId].sectionIds[0];
-  return state.models.sections[sectionId].sequenceIds[0];
+  const { sectionIds = [] } = state.models.courses[state.courseware.courseId];
+
+  if (sectionIds.length === 0) {
+    return null;
+  }
+
+  return state.models.sections[sectionIds[0]].sequenceIds[0];
 }

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -4,6 +4,7 @@ import { createSlice } from '@reduxjs/toolkit';
 export const LOADING = 'loading';
 export const LOADED = 'loaded';
 export const FAILED = 'failed';
+export const DENIED = 'denied';
 
 const slice = createSlice({
   name: 'courseware',
@@ -26,6 +27,10 @@ const slice = createSlice({
       state.courseId = payload.courseId;
       state.courseStatus = FAILED;
     },
+    fetchCourseDenied: (state, { payload }) => {
+      state.courseId = payload.courseId;
+      state.courseStatus = DENIED;
+    },
     fetchSequenceRequest: (state, { payload }) => {
       state.sequenceId = payload.sequenceId;
       state.sequenceStatus = LOADING;
@@ -45,6 +50,7 @@ export const {
   fetchCourseRequest,
   fetchCourseSuccess,
   fetchCourseFailure,
+  fetchCourseDenied,
   fetchSequenceRequest,
   fetchSequenceSuccess,
   fetchSequenceFailure,

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -10,7 +10,7 @@ const slice = createSlice({
   initialState: {
     courseStatus: 'loading',
     courseId: null,
-    sequenceStatus: null,
+    sequenceStatus: 'loading',
     sequenceId: null,
   },
   reducers: {

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -10,7 +10,7 @@ const slice = createSlice({
   initialState: {
     courseStatus: 'loading',
     courseId: null,
-    sequenceStatus: 'loading',
+    sequenceStatus: null,
     sequenceId: null,
   },
   reducers: {

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -53,13 +53,12 @@ export function fetchCourse(courseId) {
           modelsMap: units,
         }));
       }
-
-      // Allow blocks api call to fail. course metadata contains the information
-      // about what level of access the user has.
-      if (courseMetadataResult.status === 'fulfilled') {
+      console.log(courseBlocksResult, courseMetadataResult);
+      if (courseMetadataResult.status === 'fulfilled'
+        && courseBlocksResult.status === 'fulfilled') {
         dispatch(fetchCourseSuccess({ courseId }));
       } else {
-        logError(courseMetadataResult.value);
+        logError(courseMetadataResult.reason);
         dispatch(fetchCourseFailure({ courseId }));
       }
     });

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -56,7 +56,8 @@ export function fetchCourse(courseId) {
       }
 
       if (courseMetadataResult.status === 'fulfilled'
-        && courseBlocksResult.status === 'fulfilled') {
+        && courseBlocksResult.status === 'fulfilled'
+        && courseMetadataResult.value.userHasAccess) {
         dispatch(fetchCourseSuccess({ courseId }));
         return;
       }

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -53,7 +53,7 @@ export function fetchCourse(courseId) {
           modelsMap: units,
         }));
       }
-      console.log(courseBlocksResult, courseMetadataResult);
+
       if (courseMetadataResult.status === 'fulfilled'
         && courseBlocksResult.status === 'fulfilled') {
         dispatch(fetchCourseSuccess({ courseId }));

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,6 +19,7 @@ import './index.scss';
 import './assets/favicon.ico';
 import CoursewareContainer from './courseware';
 import CourseHomeContainer from './course-home';
+import CoursewareRedirect from './CoursewareRedirect';
 
 import store from './store';
 
@@ -27,6 +28,7 @@ subscribe(APP_READY, () => {
     <AppProvider store={store}>
       <UserMessagesProvider>
         <Switch>
+          <Route path="/redirect" component={CoursewareRedirect} />
           <Route path="/course/:courseId/home" component={CourseHomeContainer} />
           <Route
             path={[

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -49,6 +49,9 @@ subscribe(APP_INIT_ERROR, (error) => {
 });
 
 initialize({
+  // TODO: Remove this once the course blocks api supports unauthenticated
+  // access and we are prepared to support public courses in this app.
+  requireAuthenticatedUser: true,
   messages: [
     appMessages,
     headerMessages,


### PR DESCRIPTION
**Fixes TNL-7175 - Redirect to course home if a user is not unenrolled and the course is private**
- Require authentication to use the app while course blocks api requires it
- Gracefully handle course blocks api request failures allowing app to proceed to it redirection logic

**Notable changes:**
- selectors related to sequences are more resilient to missing models. In the case the course blocks api returns successfully but empty (in this case of enrolled but course not yet started).
- `fetchCourse` thunk handles failures for fetchCourseMeta and fetchCourseBlocks separately using `Promise.allSettled` instead of `Promise.all`
- `denied` is a new `courseStatus`
- Access denied redirect is done using a component at a new route `redirect/course-home/:courseId`

**Now handles cases** 
- User is unauthenticated > redirect to login
- User is authenticated but not enrolled > redirects to lms course home
- [_Requires server side update_] Current result when an enrolled user attempts to access courseware before the course start date: 
![image](https://user-images.githubusercontent.com/1615421/78184299-3cc83b00-7437-11ea-9399-c15632ecabfe.png)
