### PR TITLE
fix: Pull lms_base_url out of vertical data from the blocks API

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -64,9 +64,9 @@ function Course({
           courseTitle={title}
         />
         {isStaff && (
-        <InstructorToolbar
-          unitId={unitId}
-        />
+          <InstructorToolbar
+            unitId={unitId}
+          />
         )}
         <CourseTabsNavigation tabs={tabs} activeTabSlug="courseware" />
         <div className="container-fluid">

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -65,6 +65,7 @@ function normalizeBlocks(courseId, blocks) {
         models.units[block.id] = {
           id: block.id,
           title: block.display_name,
+          lmsWebUrl: block.lms_web_url,
         };
         break;
       default:


### PR DESCRIPTION
TNL-7170

lms_base_url becomes lmsBaseUrl in the app and is then used by the InstructorToolbar to link the user back to the LMS.  If it isn’t present, the toolbar hides itself.  This puts it back.