### PR TITLE
Reduce min-width of unit buttons in nav

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -186,7 +186,7 @@ $primary: #1176B2;
   .sequence-navigation-tabs {
     .btn {
       flex-basis: 100%;
-      min-width: 4rem;
+      min-width: 2rem;
     }
   }
   .sequence-navigation-dropdown {


### PR DESCRIPTION
Makes space for more units before swapping the display to a dropdown.