### PR TITLE
Fix IE11 layout issue by setting header flex-basis to auto

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -32,7 +32,7 @@ $primary: #1176B2;
     flex-grow: 1;
   }
   header {
-    flex: 0;
+    flex: 0 0 auto;
 
     .logo {
       display: block;


### PR DESCRIPTION
- Before
<img width="1592" alt="Screen Shot 2020-05-04 at 4 05 46 PM" src="https://user-images.githubusercontent.com/1615421/81008563-2429b700-8e21-11ea-932c-ac5d91638737.png">

- After
<img width="1592" alt="Screen Shot 2020-05-04 at 4 04 59 PM" src="https://user-images.githubusercontent.com/1615421/81008524-14aa6e00-8e21-11ea-9b93-b7fcecb048e1.png">
