### PR TITLE
Make unitNavigationHandler hook depend on unitId

### DIFF
--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -23,7 +23,7 @@ function useUnitNavigationHandler(courseId, sequenceId, unitId) {
   return useCallback((nextUnitId) => {
     dispatch(checkBlockCompletion(courseId, sequenceId, unitId));
     history.push(`/course/${courseId}/${sequenceId}/${nextUnitId}`);
-  }, [courseId, sequenceId]);
+  }, [courseId, sequenceId, unitId]);
 }
 
 function usePreviousSequence(sequenceId) {


### PR DESCRIPTION
This should fix intermittent bugs in checking block completions. Prior we were checking the completion only for the first unit loaded in a given sequence no matter the current unit.