### PR TITLE
fix: Ensure lmsWebUrl is loaded in useExamRedirect

### DIFF
--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -89,7 +89,7 @@ function useExamRedirect(sequenceId) {
   const sequence = useModel('sequences', sequenceId);
   const sequenceStatus = useSelector(state => state.courseware.sequenceStatus);
   useEffect(() => {
-    if (sequenceStatus === 'loaded' && sequence.isTimeLimited) {
+    if (sequenceStatus === 'loaded' && sequence.isTimeLimited && sequence.lmsWebUrl !== undefined) {
       global.location.assign(sequence.lmsWebUrl);
     }
   }, [sequenceStatus, sequence]);


### PR DESCRIPTION
The sequence.lmsWebUrl variable is loaded as part of the course blocks API.  The status of that API’s request is stored in courseStatus.

The useEffect hook in useExamRedirect didn’t ensure that courseStatus was equal to “loaded”.  This meant that if the sequence loaded first, it might attempt to redirect to sequence.lmsWebUrl even though that variable is still undefined.

When global.location.assign() is given `undefined` as a value, it tacks it onto the end of the URL and calls it a day.  After that, we’ve got a badly formed URL.