### PR TITLE
Avoid redundant paragon sass import

### DIFF
--- a/src/courseware/course/celebration/CelebrationModal.jsx
+++ b/src/courseware/course/celebration/CelebrationModal.jsx
@@ -10,8 +10,6 @@ import messages from './messages';
 import SocialIcons from './SocialIcons';
 import { recordFirstSectionCelebration } from './utils';
 
-import './CelebrationModal.scss';
-
 function CelebrationModal({
   courseId, intl, open, ...rest
 }) {

--- a/src/courseware/course/celebration/CelebrationModal.scss
+++ b/src/courseware/course/celebration/CelebrationModal.scss
@@ -1,5 +1,4 @@
-@import '~@edx/paragon/scss/edx/theme.scss';
-
+// Should be scoped better, but Modal doesn't seem to pass down classnames or ids
 .modal {
   text-align: center;
 

--- a/src/courseware/course/content-tools/ContentTools.jsx
+++ b/src/courseware/course/content-tools/ContentTools.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import Calculator from './calculator';
 import NotesVisibility from './notes-visibility';
-import './contentTools.scss';
 
 export default function ContentTools({
   course,

--- a/src/courseware/course/content-tools/calculator/Calculator.jsx
+++ b/src/courseware/course/content-tools/calculator/Calculator.jsx
@@ -10,7 +10,6 @@ import {
   faCalculator, faQuestionCircle, faTimesCircle, faEquals,
 } from '@fortawesome/free-solid-svg-icons';
 import messages from './messages';
-import './calculator.scss';
 
 class Calculator extends Component {
   constructor(props) {

--- a/src/dates-tab/Badge.jsx
+++ b/src/dates-tab/Badge.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import './Badge.scss';
-
 export default function Badge({ children, className }) {
   return (
     <span className={classNames('dates-badge badge align-text-bottom font-italic ml-2 px-2', className)}>

--- a/src/dates-tab/Day.jsx
+++ b/src/dates-tab/Day.jsx
@@ -9,8 +9,6 @@ import { useModel } from '../model-store';
 import { getBadgeListAndColor } from './badgelist';
 import { isLearnerAssignment } from './utils';
 
-import './Day.scss';
-
 function Day({
   date, first, intl, items, last,
 }) {

--- a/src/index.scss
+++ b/src/index.scss
@@ -306,3 +306,10 @@ $primary: #1176B2;
     flex-basis: 25%;
   }
 }
+
+// Import component-specific sass files
+@import 'courseware/course/celebration/CelebrationModal.scss';
+@import 'courseware/course/content-tools/calculator/calculator.scss';
+@import 'courseware/course/content-tools/contentTools.scss';
+@import 'dates-tab/Badge.scss';
+@import 'dates-tab/Day.scss';


### PR DESCRIPTION
Move all scss imports into the main index.scss. This will let them all know about existing sass variables and avoid duplicate imports.