### PR TITLE
Don't show verified-only badge on Today

### DIFF
--- a/src/dates-tab/badgelist.jsx
+++ b/src/dates-tab/badgelist.jsx
@@ -66,7 +66,7 @@ function getBadgeListAndColor(date, intl, item, items) {
     },
     {
       message: messages.verifiedOnly,
-      shownForDay: items.every(x => !hasAccess(x)),
+      shownForDay: items.length && items.every(x => !hasAccess(x)),
       shownForItem: x => !hasAccess(x),
       icon: faLock,
       bg: 'bg-dark-500',


### PR DESCRIPTION
If the Today date entry on the dates tab doesn't have any items, we were showing the Verified Only badge. This fixes that mistake.