### PR TITLE
[BD-29] [TNL-7288] Fix front-end behavior when the course has no sections or no subsections in the first section

### DIFF
--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -115,7 +115,7 @@ function useContentRedirect(courseStatus, sequenceStatus) {
         // This is a replace because we don't want this change saved in the browser's history.
         if (data.sectionId && data.unitId) {
           history.replace(`/course/${courseId}/${data.sectionId}/${data.unitId}`);
-        } else {
+        } else if (firstSequenceId) {
           history.replace(`/course/${courseId}/${firstSequenceId}`);
         }
       });

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -100,6 +100,9 @@ function Sequence({
   }, [unit]);
 
   if (sequenceStatus === 'loading') {
+    if (!sequence) {
+      return (<div> {intl.formatMessage(messages['learn.sequence.no.content'])} </div>);
+    }
     return (
       <PageLoading
         srMessage={intl.formatMessage(messages['learn.loading.learning.sequence'])}

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -110,7 +110,7 @@ function Sequence({
     );
   }
 
-  const gated = sequence.gatedContent !== undefined && sequence.gatedContent.gated;
+  const gated = sequence && sequence.gatedContent !== undefined && sequence.gatedContent.gated;
 
   if (sequenceStatus === 'loaded') {
     return (

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -100,7 +100,7 @@ function Sequence({
   }, [unit]);
 
   if (sequenceStatus === 'loading') {
-    if (!sequence) {
+    if (!sequenceId) {
       return (<div> {intl.formatMessage(messages['learn.sequence.no.content'])} </div>);
     }
     return (

--- a/src/courseware/course/sequence/SequenceContent.jsx
+++ b/src/courseware/course/sequence/SequenceContent.jsx
@@ -38,7 +38,8 @@ function SequenceContent({
     );
   }
 
-  if (unitId === null) {
+  const unit = useModel('units', unitId);
+  if (!unitId || !unit) {
     return (
       <div>
         {intl.formatMessage(messages['learn.sequence.no.content'])}

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -95,10 +95,6 @@ function Unit({
     return () => global.removeEventListener('message', messageEventListenerRef.current);
   }, [id, setIframeHeight, hasLoaded, iframeHeight, setHasLoaded, onLoaded]);
 
-  if (!unit) {
-    return (<div> {intl.formatMessage(messages['learn.sequence.no.content'])} </div>);
-  }
-
   return (
     <div className="unit">
       <h2 className="mb-0 h4">{unit.title}</h2>

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -95,6 +95,10 @@ function Unit({
     return () => global.removeEventListener('message', messageEventListenerRef.current);
   }, [id, setIframeHeight, hasLoaded, iframeHeight, setHasLoaded, onLoaded]);
 
+  if (!unit) {
+    return (<div> {intl.formatMessage(messages['learn.sequence.no.content'])} </div>);
+  }
+
   return (
     <div className="unit">
       <h2 className="mb-0 h4">{unit.title}</h2>


### PR DESCRIPTION
This PR fixes the behavior of the front end when the course has no sections or the first section of the course has no subsections. It now displays the same "no content" message as when the subsection has no units.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-2596

**Dependencies**: https://github.com/edx/edx-platform/pull/24340

**Screenshots**: N/A?

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. In studio, create a new course but do no add any sections
2. In lms, go to the blank course and start it.
3. Then click on "View In The New Experience"
4. without this PR, the browser will be redirected to a url ending in `.../null` and an "unexpected error" message will be displayed, breaking the interface. After this patch, no redirection will occur and a "no content" message will be displayed without breaking the interface.
5. In studio, add a section to the new course.
6. back in the lms, reload the page (remove `null` from the url if necessary). Before this PR, the url will be redirected such that it ends in `.../undefined` and the unexpected error message will once again be shown, breaking the interface. After the PR, again no redirection and the *no content* message will be shown.
7. In stuido, add a subsection to the course's section.
8. back in the lms, reload the page (remove `undefined` if necessary). Both with and without this patch, the url is redirected to the full sequence id and the "no content" message is shown without breaking the interface. That is, this behavior is unchanged.
9. Adding a unit causes the unit to be shown as epected. Adding subsequent sections, even ones with no subsections, does not seem to cause breakage.

**Author notes and concerns**: none at this time

**Reviewers**
- [ ] @Agrendalath
- [ ] edX reviewer[s] TBD

