### PR TITLE
AA-195: Don't show schedule banner if no schedule

### DIFF
--- a/src/course-home/dates-banner/DatesBannerContainer.jsx
+++ b/src/course-home/dates-banner/DatesBannerContainer.jsx
@@ -17,6 +17,7 @@ function DatesBannerContainer(props) {
   } = useSelector(state => state.courseHome);
 
   const {
+    courseDateBlocks,
     datesBannerInfo,
   } = useModel(model, courseId);
 
@@ -32,13 +33,14 @@ function DatesBannerContainer(props) {
   } = useModel('courses', courseId);
 
   const dispatch = useDispatch();
+  const hasDeadlines = courseDateBlocks.some(x => x.dateType === 'assignment-due-date');
   const upgradeToCompleteGraded = model === 'dates' && contentTypeGatingEnabled && !missedDeadlines;
   const upgradeToReset = !upgradeToCompleteGraded && missedDeadlines && missedGatedContent;
   const resetDates = !upgradeToCompleteGraded && missedDeadlines && !missedGatedContent;
   const datesBanners = [
     {
       name: 'datesTabInfoBanner',
-      shouldDisplay: model === 'dates' && !missedDeadlines && isSelfPaced,
+      shouldDisplay: model === 'dates' && hasDeadlines && !missedDeadlines && isSelfPaced,
     },
     {
       name: 'upgradeToCompleteGradedBanner',


### PR DESCRIPTION
In some cases (user schedule is close to or past the course end), we don't actually have dates for a course, even if we would normally have them.

When that happens, let's not show a banner saying we made a schedule for the learner.

Related to https://github.com/edx/edx-when/pull/58