### PR TITLE
Do not assume HTML blocks are units

### DIFF
--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -34,7 +34,6 @@ export function normalizeBlocks(courseId, blocks) {
           unitIds: block.children || [],
         };
         break;
-      case 'html':
       case 'vertical':
         models.units[block.id] = {
           graded: block.graded,
@@ -44,7 +43,7 @@ export function normalizeBlocks(courseId, blocks) {
         };
         break;
       default:
-        logError(`Unexpected course block type: ${block.type} with ID ${block.id}.  Expected block types are course, chapter, sequential, vertical, and html.`);
+        logError(`Unexpected course block type: ${block.type} with ID ${block.id}.  Expected block types are course, chapter, sequential, and vertical.`);
     }
   });
 


### PR DESCRIPTION
Please see [Dave's comment on a previous PR](https://github.com/edx/frontend-app-learning/pull/104#issuecomment-656325354) for context.

```
After further conversation, we decide that
we shouldn't just treat HTML blocks as units.
We've been making the assumption that Verticals
occupy the Unit-level, and we shouldn't break that
assumption for this specific case.

Reverts part of e04f588d1f3219d1566ca4e440d1653b9c414587.
However, the error handling changes remain.
```