### PR TITLE
Change CoursewareContainer into a class component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@reduxjs/toolkit": "^1.2.3",
     "classnames": "^2.2.6",
     "core-js": "^3.6.2",
+    "lodash.memoize": "^4.1.2",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-break": "^1.3.2",

--- a/src/courseware/data/index.js
+++ b/src/courseware/data/index.js
@@ -9,6 +9,5 @@ export {
 } from './api';
 export {
   sequenceIdsSelector,
-  firstSequenceIdSelector,
 } from './selectors';
 export { reducer } from './slice';

--- a/src/courseware/data/selectors.js
+++ b/src/courseware/data/selectors.js
@@ -10,16 +10,3 @@ export function sequenceIdsSelector(state) {
 
   return sequenceIds;
 }
-
-export function firstSequenceIdSelector(state) {
-  if (state.courseware.courseStatus !== 'loaded') {
-    return null;
-  }
-  const { sectionIds = [] } = state.models.courses[state.courseware.courseId];
-
-  if (sectionIds.length === 0) {
-    return null;
-  }
-
-  return state.models.sections[sectionIds[0]].sequenceIds[0];
-}


### PR DESCRIPTION
I find it much more legible this way.

Some thoughts… as part of refactoring it, I made some of the redux selectors more formal, and made use of `reselect` more thoroughly.  this resulted in a reduction in re-renders from 16 to 12 on your average page load.  It’s also a bit more verbose, accounting for some of the increased line count.

I hadn’t tried it before, but found the `memoize` method of comparing previous props/state to current props/state to be very, very nice.  Much easier than manually comparing props, and much clearer to me than using react hooks’ dependency arrays.

The lack of dependency arrays feels really freeing in general to me.  They’ve been such a source of hard-to-track-down bugs, and the hooks linter does not always suggest the right solution for what belongs in and out of the array.

Function names are nice.  We had a ton of custom hooks in there so that we could put names to otherwise anonymous bits of functionality.

Also note: this component has a test suite.  It passed without any changes. 🥳 :