### PR TITLE
Redirect to the current unit’s lmsWebUrl if the MFE is disabled

### DIFF
--- a/src/CoursewareRedirect.jsx
+++ b/src/CoursewareRedirect.jsx
@@ -3,6 +3,7 @@ import { Switch, Route, useRouteMatch } from 'react-router';
 import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PageLoading from './generic/PageLoading';
+import { useModel } from './generic/model-store';
 
 export default () => {
   const { path } = useRouteMatch();
@@ -18,6 +19,18 @@ export default () => {
       />
 
       <Switch>
+        <Route
+          path={`${path}/unit/:unitId`}
+          render={({ match }) => {
+            const { unitId } = match.params;
+            const unit = useModel('units', unitId);
+
+            const lmsWebUrl = unit !== undefined ? unit.lmsWebUrl : null;
+            if (lmsWebUrl) {
+              global.location.assign(lmsWebUrl);
+            }
+          }}
+        />
         <Route
           path={`${path}/course-home/:courseId`}
           render={({ match }) => {

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -193,7 +193,7 @@ class CoursewareContainer extends Component {
         url = '/redirect/dashboard';
         break;
       case 'microfrontend_disabled':
-        url = `/redirect/unit/${routeUnitId}`;
+        url = `/redirect/courseware/${courseId}/unit/${routeUnitId}`;
         break;
       case 'authentication_required':
       case 'enrollment_required':

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -171,7 +171,13 @@ class CoursewareContainer extends Component {
   }
 
   renderDenied() {
-    const { courseId, course } = this.props;
+    const {
+      courseId, course, match: {
+        params: {
+          unitId: routeUnitId,
+        },
+      },
+    } = this.props;
     let url = `/redirect/course-home/${courseId}`;
     switch (course.canLoadCourseware.errorCode) {
       case 'audit_expired':
@@ -185,6 +191,9 @@ class CoursewareContainer extends Component {
       case 'survey_required': // TODO: Redirect to the course survey
       case 'unfulfilled_milestones':
         url = '/redirect/dashboard';
+        break;
+      case 'microfrontend_disabled':
+        url = `/redirect/unit/${routeUnitId}`;
         break;
       case 'authentication_required':
       case 'enrollment_required':

--- a/src/courseware/CoursewareRedirect.jsx
+++ b/src/courseware/CoursewareRedirect.jsx
@@ -1,0 +1,15 @@
+import { getConfig } from '@edx/frontend-platform';
+import { useModel } from '../generic/model-store';
+
+export default function CourseRedirect({ match }) {
+  const { courseId, unitId } = match.params;
+  const unit = useModel('units', unitId);
+
+  const lmsWebUrl = unit !== undefined ? unit.lmsWebUrl : null;
+  if (lmsWebUrl) {
+    global.location.assign(lmsWebUrl);
+  } else {
+    global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${courseId}/courseware/`);
+  }
+  return null;
+}

--- a/src/courseware/CoursewareRedirectLandingPage.jsx
+++ b/src/courseware/CoursewareRedirectLandingPage.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { Switch, Route, useRouteMatch } from 'react-router';
 import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import PageLoading from './generic/PageLoading';
-import { useModel } from './generic/model-store';
+
+import PageLoading from '../generic/PageLoading';
+
+import CoursewareRedirect from './CoursewareRedirect';
 
 export default () => {
   const { path } = useRouteMatch();
+
   return (
     <div className="flex-grow-1">
       <PageLoading srMessage={(
@@ -20,16 +23,8 @@ export default () => {
 
       <Switch>
         <Route
-          path={`${path}/unit/:unitId`}
-          render={({ match }) => {
-            const { unitId } = match.params;
-            const unit = useModel('units', unitId);
-
-            const lmsWebUrl = unit !== undefined ? unit.lmsWebUrl : null;
-            if (lmsWebUrl) {
-              global.location.assign(lmsWebUrl);
-            }
-          }}
+          path={`${path}/courseware/:courseId/unit/:unitId`}
+          component={CoursewareRedirect}
         />
         <Route
           path={`${path}/course-home/:courseId`}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -20,7 +20,7 @@ import './index.scss';
 import './assets/favicon.ico';
 import OutlineTab from './course-home/outline-tab';
 import CoursewareContainer from './courseware';
-import CoursewareRedirect from './CoursewareRedirect';
+import CoursewareRedirectLandingPage from './courseware/CoursewareRedirectLandingPage';
 import DatesTab from './course-home/dates-tab';
 import ProgressTab from './course-home/progress-tab/ProgressTab';
 import { TabContainer } from './tab-page';
@@ -33,7 +33,7 @@ subscribe(APP_READY, () => {
     <AppProvider store={initializeStore()}>
       <UserMessagesProvider>
         <Switch>
-          <Route path="/redirect" component={CoursewareRedirect} />
+          <Route path="/redirect" component={CoursewareRedirectLandingPage} />
           <Route path="/course/:courseId/home">
             <TabContainer tab="outline" fetch={fetchOutlineTab}>
               <OutlineTab />


### PR DESCRIPTION
If we receive an error_code of ‘microfrontend_disabled’ - go to the equivalent unit in the LMS experience.