### PR TITLE
TNL-7409 Fix checkBlockCompletion parameters

### DIFF
--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -125,9 +125,15 @@ class CoursewareContainer extends Component {
 
   handleUnitNavigationClick = (nextUnitId) => {
     const {
-      courseId, sequenceId, unitId,
+      courseId, sequenceId,
+      match: {
+        params: {
+          unitId: routeUnitId,
+        },
+      },
     } = this.props;
-    this.props.checkBlockCompletion(courseId, sequenceId, unitId);
+
+    this.props.checkBlockCompletion(courseId, sequenceId, routeUnitId);
     history.push(`/course/${courseId}/${sequenceId}/${nextUnitId}`);
   }
 
@@ -256,7 +262,6 @@ CoursewareContainer.propTypes = {
   courseId: PropTypes.string,
   sequenceId: PropTypes.string,
   firstSequenceId: PropTypes.string,
-  unitId: PropTypes.string,
   courseStatus: PropTypes.oneOf(['loaded', 'loading', 'failed', 'denied']).isRequired,
   sequenceStatus: PropTypes.oneOf(['loaded', 'loading', 'failed']).isRequired,
   nextSequence: sequenceShape,
@@ -273,7 +278,6 @@ CoursewareContainer.defaultProps = {
   courseId: null,
   sequenceId: null,
   firstSequenceId: null,
-  unitId: null,
   nextSequence: null,
   previousSequence: null,
   course: null,
@@ -353,13 +357,12 @@ const firstSequenceIdSelector = createSelector(
 
 const mapStateToProps = (state) => {
   const {
-    courseId, sequenceId, unitId, courseStatus, sequenceStatus,
+    courseId, sequenceId, courseStatus, sequenceStatus,
   } = state.courseware;
 
   return {
     courseId,
     sequenceId,
-    unitId,
     courseStatus,
     sequenceStatus,
     course: currentCourseSelector(state),

--- a/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
@@ -60,7 +60,11 @@ export default function UnitNavigation(props) {
 
 UnitNavigation.propTypes = {
   sequenceId: PropTypes.string.isRequired,
-  unitId: PropTypes.string.isRequired,
+  unitId: PropTypes.string,
   onClickPrevious: PropTypes.func.isRequired,
   onClickNext: PropTypes.func.isRequired,
+};
+
+UnitNavigation.defaultProps = {
+  unitId: null,
 };


### PR DESCRIPTION
We were assuming a prop named unitId existed in CoursewareContainer - it doesn’t.  unitId is not in redux.  What we do have, is the unitId in the route params - what we refer to as routeUnitId.  If we use this instead of the non-existent unitId, then life is good.

I wrote a test (that breaks!) prior to implementing the fix.  The fix satisfies the test. :tada: