### PR TITLE
Fix lint warnings; require 0 warnings for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 script:
 - make validate-no-uncommitted-package-lock-changes
 - npm run i18n_extract
-- npm run lint
+- npm run lint -- --max-warnings 0
 - npm run test
 - npm run build
 - npm run is-es5

--- a/src/course-home/progress-tab/Subsection.jsx
+++ b/src/course-home/progress-tab/Subsection.jsx
@@ -24,6 +24,7 @@ function Subsection({
     <section className="my-3 ml-3">
       <div className="row">
         <a className="h6" href={subsection.url}>
+          {/* eslint-disable-next-line react/no-danger */}
           <div dangerouslySetInnerHTML={{ __html: subsection.displayName }} />
           {showTotalScore && <span className="sr-only">{totalScoreSr}</span>}
         </a>

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -140,7 +140,7 @@ function Unit({
           scrolling="no"
           referrerPolicy="origin"
           onLoad={() => {
-            window.onmessage = function (e) {
+            window.onmessage = function handleResetDates(e) {
               if (e.data.event_name) {
                 dispatch(processEvent(e.data, fetchCourse));
               }

--- a/src/toast/LearningToast.jsx
+++ b/src/toast/LearningToast.jsx
@@ -25,9 +25,11 @@ export default function LearningToast({
       }}
     >
       <Toast.Header className="bg-gray-700 border-bottom-0 text-light">
+        {/* eslint-disable-next-line react/no-danger */}
         <div dangerouslySetInnerHTML={{ __html: header }} />
       </Toast.Header>
       <Toast.Body className="bg-gray-700 text-light">
+        {/* eslint-disable-next-line react/no-danger */}
         <div dangerouslySetInnerHTML={{ __html: body }} />
       </Toast.Body>
     </Toast>


### PR DESCRIPTION
A small QoL improvement. `npm lint` warnings are useful, but if we don't require them in Travis, then the list of them will grow and grow until they're not useful any more.

If folks think this looks good then I may upstream it to https://github.com/edx/frontend-template-application

Let me know what you think @edx/teaching-and-learning .