### PR TITLE
AA-326: hide dates banner if the upgrade link is null

### DIFF
--- a/src/course-home/dates-banner/DatesBannerContainer.jsx
+++ b/src/course-home/dates-banner/DatesBannerContainer.jsx
@@ -45,12 +45,14 @@ function DatesBannerContainer(props) {
     },
     {
       name: 'upgradeToCompleteGradedBanner',
-      shouldDisplay: upgradeToCompleteGraded,
+      // verifiedUpgradeLink can be null if we've passed the upgrade deadline
+      shouldDisplay: upgradeToCompleteGraded && verifiedUpgradeLink,
       clickHandler: () => global.location.replace(verifiedUpgradeLink),
     },
     {
       name: 'upgradeToResetBanner',
-      shouldDisplay: upgradeToReset,
+      // verifiedUpgradeLink can be null if we've passed the upgrade deadline
+      shouldDisplay: upgradeToReset && verifiedUpgradeLink,
       clickHandler: () => global.location.replace(verifiedUpgradeLink),
     },
     {


### PR DESCRIPTION
This will prevent a pointless & broken button when the upgrade deadline has passed for the course.