### PR TITLE
AA-306: Update twitter hashtag for celebrations

### DIFF
--- a/src/courseware/course/celebration/SocialIcons.jsx
+++ b/src/courseware/course/celebration/SocialIcons.jsx
@@ -54,7 +54,7 @@ function SocialIcons({ courseId, intl }) {
         <TwitterShareButton
           beforeOnClick={() => logClick('twitter')}
           className="ml-2"
-          hashtags={['mooc']}
+          hashtags={['myedxjourney']}
           title={intl.formatMessage(messages.social, { platform: `@${twitterAccount}`, title })}
           url={marketingUrl}
         >
@@ -73,7 +73,7 @@ function SocialIcons({ courseId, intl }) {
       </FacebookShareButton>
       <EmailShareButton
         beforeOnClick={() => logClick('email')}
-        body={intl.formatMessage(messages.emailBody)}
+        body={`${intl.formatMessage(messages.emailBody)}\n\n`}
         className="ml-2"
         subject={intl.formatMessage(messages.emailSubject, { platform: getConfig().SITE_NAME, title })}
         url={marketingUrl}

--- a/src/courseware/course/celebration/messages.js
+++ b/src/courseware/course/celebration/messages.js
@@ -20,7 +20,7 @@ const messages = defineMessages({
   },
   emailSubject: {
     id: 'learning.celebration.emailSubject',
-    defaultMessage: "I'm on my way to completing {title} online with @edxonline!",
+    defaultMessage: "I'm on my way to completing {title} online with {platform}!",
     description: 'Subject when sharing course progress via email',
   },
   forward: {


### PR DESCRIPTION
It's now #myedxjourney instead of #mooc.

Also, fixed the wording of the email share option.