### PR TITLE
fix: bump frontend-enterprise to 4.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,9 +1417,29 @@
       }
     },
     "@edx/frontend-enterprise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-4.2.2.tgz",
-      "integrity": "sha512-UJOFDsGIgOah+ZOi+MxO7yFRSfvPf5jGQ1fFIHwjnmIuN4qaxSw9uOg4Tggr4I477A/40glV4TpndMMHYarGGA=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise/-/frontend-enterprise-4.2.3.tgz",
+      "integrity": "sha512-znqnP/PVCemhZS0rSwjt+tjrXSPfJqnQ2YHnXlb9O9wJ/JDHIoYs3Nsd0Auo2tuwhtffTQyFwPphoEKEPtJjiw==",
+      "requires": {
+        "query-string": "^6.13.2"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "6.13.2",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
+          "integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
+      }
     },
     "@edx/frontend-platform": {
       "version": "1.5.2",
@@ -6600,8 +6620,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress": {
       "version": "4.2.1",
@@ -19371,6 +19390,11 @@
           }
         }
       }
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@edx/frontend-component-footer": "10.0.11",
     "@edx/frontend-component-header": "2.0.5",
-    "@edx/frontend-enterprise": "4.2.2",
+    "@edx/frontend-enterprise": "4.2.3",
     "@edx/frontend-platform": "1.5.2",
     "@edx/paragon": "12.0.0",
     "@fortawesome/fontawesome-svg-core": "1.2.30",


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-3390

Upgraded frontend-enterprise release: https://github.com/edx/frontend-enterprise/releases/tag/v4.2.3

This fixes an issue for internal/staff users - we now only fetch your preferred enterprise and use that to make a determination about whether or not to show Order History.  Previously, we fetched every enterprise the user is associated with, which for staff users, can be many.

Here's a screen cap of Order History _not_ appearing for my staff user after implementing this change (this is desired):
<img width="733" alt="Screen Shot 2020-09-16 at 9 46 09 AM" src="https://user-images.githubusercontent.com/2307986/93346488-0a05d980-f802-11ea-8993-9730b9637400.png">
