### PR TITLE
Refer to 'Existing experience' as 'Legacy experience'

### DIFF
--- a/src/instructor-toolbar/InstructorToolbar.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.jsx
@@ -66,7 +66,7 @@ export default function InstructorToolbar(props) {
           )}
           {urlLms && (
             <span className="mx-1 my-1">
-              <a className="btn btn-outline-light" href={urlLms}>Existing experience</a>
+              <a className="btn btn-outline-light" href={urlLms}>Legacy experience</a>
             </span>
           )}
           {urlStudio && (


### PR DESCRIPTION
The new experience is the most common case on edx.org, so "existing" is starting to get misleading.

Also, we decided in standup that "Legacy" is a good term to standardize on for these pre-MFE experiences.