### PR TITLE
Add special_exam_info to our requested_fields when calling the course blocks API.

### DIFF
--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -91,7 +91,7 @@ export async function getCourseBlocks(courseId) {
   url.searchParams.append('course_id', courseId);
   url.searchParams.append('username', username);
   url.searchParams.append('depth', 3);
-  url.searchParams.append('requested_fields', 'children,show_gated_sections,graded');
+  url.searchParams.append('requested_fields', 'children,show_gated_sections,graded,special_exam_info');
 
   const { data } = await getAuthenticatedHttpClient().get(url.href, {});
   return normalizeBlocks(courseId, data.blocks);


### PR DESCRIPTION
Fixes TNL-7613 and TNL-7614

The course blocks API accepts a value of ‘special_exam_info’ in its requested_fields parameter.  This value is necessary to include special exam sequences for non-staff users.  Special exams include timed, proctored, and practice proctored exams.