### PR TITLE
Change design of tabs

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -89,12 +89,15 @@ $primary: #1176B2;
     border-right: 0;
     border-radius: 0;
 
-    &:hover,
+    &:hover {
+      background: theme-color('gray', 100);
+    }
+
     &:focus,
     &.active {
-      font-weight: $font-weight-normal;
+      font-weight: $font-weight-bold;
       color: theme-color('primary', 500);
-      border-bottom-color: theme-color('primary', 500);
+      background: theme-color('primary', 200);
     }
   }
 }
@@ -142,25 +145,16 @@ $primary: #1176B2;
     color: theme-color('gray', 400);
     white-space: nowrap;
 
-    &:hover,
+    &:hover {
+      background: theme-color('gray', 100);
+    }
+
     &:focus,
     &.active {
-      color: theme-color('gray', 700);
+      color: theme-color('primary', 500);
+      background: theme-color('primary', 200);
     }
-    &:focus {
-      z-index: 1;
-    }
-    &.active {
-      &:after {
-        content: '';
-        position: absolute;
-        bottom: -1px;
-        left: 0;
-        right: 0;
-        height: 2px;
-        background: $primary;
-      }
-    }
+
     &.complete {
       background-color: #EEF7E5;
       color: $success;


### PR DESCRIPTION
Improved course tabs and unit tabs design. Implemented designs with Google apps reference.

Changed following things in both tabs

- Background color light theme
- Text color theme color
- Removed underline
- Hover color light gray

Visuals
<img width="446" alt="Screenshot 2020-11-15 at 1 40 10 PM" src="https://user-images.githubusercontent.com/20799038/99180125-991f6700-2749-11eb-93ac-1a89e862957f.png">
<img width="1196" alt="Screenshot 2020-11-15 at 1 40 23 PM" src="https://user-images.githubusercontent.com/20799038/99180128-9ae92a80-2749-11eb-8f0b-50abe52106d5.png">