### PR TITLE
Updated build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Introduction
 
 React app for edX learning.
 
-.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-learning.svg?branch=master
-   :target: https://travis-ci.org/edx/frontend-app-learning
+.. |Build Status| image:: https://api.travis-ci.com/edx/frontend-app-learning.svg?branch=master
+   :target: https://travis-ci.com/edx/frontend-app-learning
 .. |Coveralls| image:: https://img.shields.io/coveralls/edx/frontend-app-learning.svg?branch=master
    :target: https://coveralls.io/github/edx/frontend-app-learning
 .. |npm_version| image:: https://img.shields.io/npm/v/@edx/frontend-app-learning.svg


### PR DESCRIPTION
Updated the README.rst file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089 