### PR TITLE
Submit events to the tracking logs, not just Segment

### DIFF
--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -3,7 +3,10 @@ import React, {
   useEffect, useContext, useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+import {
+  sendTrackEvent,
+  sendTrackingLogEvent,
+} from '@edx/frontend-platform/analytics';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { useSelector } from 'react-redux';
 import { history } from '@edx/frontend-platform';
@@ -69,6 +72,7 @@ function Sequence({
       payload.target_tab = targetIndex + 1;
     }
     sendTrackEvent(eventName, payload);
+    sendTrackingLogEvent(eventName, payload);
   };
 
   const { add, remove } = useContext(UserMessagesContext);


### PR DESCRIPTION
Due to an unfortunate naming choice, we apparently had _not_ been
sending navigation events to the tracking logs' `/track` backend, but
just to the Segment.io tracking backend.

Note: There are still other portions of this repo _outside_ the learning
sequence (Course Tools, Celebration, etc.) that only send to Segment and
not the tracking logs, though maybe this is by design, those being "new"
events?