### PR TITLE
Use prereqSectionName for the name of the prereq section.

### DIFF
--- a/src/courseware/course/sequence/SequenceContent.jsx
+++ b/src/courseware/course/sequence/SequenceContent.jsx
@@ -31,7 +31,7 @@ function SequenceContent({
         <ContentLock
           courseId={courseId}
           sequenceTitle={sequence.title}
-          prereqSectionName={sequence.gatedContent.gatedSectionName}
+          prereqSectionName={sequence.gatedContent.prereqSectionName}
           prereqId={sequence.gatedContent.prereqId}
         />
       </Suspense>

--- a/src/courseware/course/sequence/SequenceContent.test.jsx
+++ b/src/courseware/course/sequence/SequenceContent.test.jsx
@@ -32,7 +32,7 @@ describe('Sequence Content', () => {
     expect(screen.queryByText('Loading locked content messaging...')).not.toBeInTheDocument();
     expect(container.querySelector('svg')).toHaveClass('fa-lock');
     expect(screen.getByText(
-      `You must complete the prerequisite: '${gatedContent.gatedSectionName}' to access this content.`,
+      `You must complete the prerequisite: '${gatedContent.prereqSectionName}' to access this content.`,
     )).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Go To Prerequisite Section' })).toBeInTheDocument();
   });


### PR DESCRIPTION
Surprise, surprise.

Not sure how this wasn’t correct.  The bug results in the content lock UI showing the name of the current section rather than the prerequisite when describing… the prerequisite.