### PR TITLE
Add suppression to username in header

### DIFF
--- a/src/course-header/Header.jsx
+++ b/src/course-header/Header.jsx
@@ -88,7 +88,7 @@ function Header({
         <Dropdown className="user-dropdown">
           <Dropdown.Toggle variant="light">
             <FontAwesomeIcon icon={faUserCircle} className="d-md-none" size="lg" />
-            <span className="d-none d-md-inline">
+            <span data-hj-suppress className="d-none d-md-inline">
               {authenticatedUser.username}
             </span>
           </Dropdown.Toggle>


### PR DESCRIPTION
Hotjar is a behavior analytics tool that analyses website use, providing feedback through tools such as heatmaps, session recordings, and surveys. Before we enable hotjar we have to suppress all PII and sensitive information so that screen recorder doesn’t capture it. Adding a `data-hj-suppress` attribute around the sensitive data marks the field as suppressed for hotjar and shows asterisks instead of text.
<img width="733" alt="Screenshot 2020-09-16 at 10 03 02 AM" src="https://user-images.githubusercontent.com/40633976/93294490-10955080-f804-11ea-9d39-dff3458741fa.png">


Suppressed username from header

Ticket: [VAN-144](https://openedx.atlassian.net/browse/VAN-144)