### PR TITLE
AA-504: Dates tab rebrand fix

### DIFF
--- a/src/course-home/dates-banner/DatesBanner.jsx
+++ b/src/course-home/dates-banner/DatesBanner.jsx
@@ -23,7 +23,7 @@ function DatesBanner(props) {
         </div>
         {bannerClickHandler && (
           <div className="col-auto col-lg-3 p-lg-0 d-inline-flex align-items-center justify-content-start justify-content-lg-center">
-            <Button variant="outline-primary" className="align-self-center bg-white mt-3 mt-lg-0" onClick={bannerClickHandler}>
+            <Button variant="outline-primary" className="align-self-center mt-3 mt-lg-0" onClick={bannerClickHandler}>
               {intl.formatMessage(messages[`datesBanner.${name}.button`])}
             </Button>
           </div>

--- a/src/course-home/dates-tab/badgelist.jsx
+++ b/src/course-home/dates-tab/badgelist.jsx
@@ -50,6 +50,7 @@ function getBadgeListAndColor(date, intl, item, items) {
       shownForDay: assignments.length && assignments.every(isPastDue),
       shownForItem: x => isLearnerAssignment(x) && isPastDue(x),
       bg: 'bg-dark-200',
+      className: 'text-white',
     },
     {
       message: messages.dueNext,


### PR DESCRIPTION
**Shift due dates button: Regular and Hover State**
<div>
<img width="200" alt="AA-504_ShiftDueDates_Button" src="https://user-images.githubusercontent.com/25124041/101666492-48cfb800-3a1c-11eb-9271-74ed37c83569.png">
<img width="200" alt="AA-504_ShiftDueDates_HoverState" src="https://user-images.githubusercontent.com/25124041/101666488-466d5e00-3a1c-11eb-9739-5fb01a70c367.png">
</div>
<br>

**Past Due pill on Dates Tab**
<img width="312" alt="AA-504_PastDueBadge" src="https://user-images.githubusercontent.com/25124041/101666500-4a00e500-3a1c-11eb-8242-9b5988ff2e7c.png">
