### PR TITLE
[REV-1512] Add back classes to first purchase offer banner that are used in the REV-1512 optimizely test

### DIFF
--- a/src/alerts/offer-alert/OfferAlert.jsx
+++ b/src/alerts/offer-alert/OfferAlert.jsx
@@ -34,14 +34,16 @@ function OfferAlert({ intl, payload }) {
         {intl.formatMessage(messages.srPrices, { discountedPrice, originalPrice })}
       </span>
       <span aria-hidden="true">
-        {discountedPrice} <del>{originalPrice}</del>
+        {/* the price discount and price original classes can be removed post REV-1512 experiment */}
+        <span className="price discount">{discountedPrice}</span> <del className="price original">{originalPrice}</del>
       </span>
     </>
   );
 
   return (
     <Alert type={ALERT_TYPES.INFO}>
-      <span className="font-weight-bold">
+      {/* the first-purchase-offer-banner class can be removed post REV-1512 experiment */}
+      <span className="font-weight-bold first-purchase-offer-banner">
         <FormattedMessage
           id="learning.offer.header"
           defaultMessage="Upgrade by {date} and save {percentage}% [{fullPricing}]"


### PR DESCRIPTION
These classes were being used to set some of the discount info in our optimizely test, looks like they were removed in https://github.com/edx/frontend-app-learning/pull/306