### PR TITLE
AA-449: Show discounted price in upgrade buttons & course exit

### DIFF
--- a/src/alerts/offer-alert/OfferAlert.jsx
+++ b/src/alerts/offer-alert/OfferAlert.jsx
@@ -6,6 +6,7 @@ import {
 import { Hyperlink } from '@edx/paragon';
 
 import { Alert, ALERT_TYPES } from '../../generic/user-messages';
+import { FormattedPricing } from '../../generic/upgrade-button';
 import messages from './messages';
 
 function OfferAlert({ intl, payload }) {
@@ -20,25 +21,11 @@ function OfferAlert({ intl, payload }) {
 
   const {
     code,
-    discountedPrice,
     expirationDate,
-    originalPrice,
     percentage,
     upgradeUrl,
   } = offer;
   const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
-
-  const fullPricing = (
-    <>
-      <span className="sr-only">
-        {intl.formatMessage(messages.srPrices, { discountedPrice, originalPrice })}
-      </span>
-      <span aria-hidden="true">
-        {/* the price discount and price original classes can be removed post REV-1512 experiment */}
-        <span className="price discount">{discountedPrice}</span> <del className="price original">{originalPrice}</del>
-      </span>
-    </>
-  );
 
   return (
     <Alert type={ALERT_TYPES.INFO}>
@@ -57,7 +44,7 @@ function OfferAlert({ intl, payload }) {
                 {...timezoneFormatArgs}
               />
             ),
-            fullPricing,
+            fullPricing: <FormattedPricing offer={offer} />,
             percentage,
           }}
         />

--- a/src/alerts/offer-alert/messages.js
+++ b/src/alerts/offer-alert/messages.js
@@ -1,10 +1,6 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
-  srPrices: {
-    id: 'learning.offer.screenReaderPrices',
-    defaultMessage: 'Original price: {originalPrice}, discount price: {discountedPrice}',
-  },
   upgradeNow: {
     id: 'learning.offer.upgradeNow',
     defaultMessage: 'Upgrade now',

--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -185,7 +185,7 @@ function OutlineTab({ intl }) {
           </div>
         )}
       </div>
-      {canShowUpgradeSock && <CourseSock ref={courseSock} verifiedMode={verifiedMode} />}
+      {canShowUpgradeSock && <CourseSock ref={courseSock} offer={offer} verifiedMode={verifiedMode} />}
     </>
   );
 }

--- a/src/course-home/outline-tab/widgets/UpgradeCard.jsx
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.jsx
@@ -7,11 +7,13 @@ import { Button } from '@edx/paragon';
 
 import messages from '../messages';
 import { useModel } from '../../../generic/model-store';
+import { UpgradeButton } from '../../../generic/upgrade-button';
 import VerifiedCert from '../../../generic/assets/edX_certificate.png';
 
 function UpgradeCard({ courseId, intl, onLearnMore }) {
   const { org } = useModel('courses', courseId);
   const {
+    offer,
     verifiedMode,
   } = useModel('outline', courseId);
 
@@ -44,16 +46,11 @@ function UpgradeCard({ courseId, intl, onLearnMore }) {
         style={{ width: '124px' }}
       />
       <div className="float-right d-flex flex-column align-items-center">
-        <Button
-          variant="success"
-          href={verifiedMode.upgradeUrl}
+        <UpgradeButton
+          offer={offer}
           onClick={logClick}
-        >
-          {intl.formatMessage(messages.upgradeButton, {
-            price: verifiedMode.price,
-            symbol: verifiedMode.currencySymbol,
-          })}
-        </Button>
+          verifiedMode={verifiedMode}
+        />
         {onLearnMore && (
           <Button
             variant="link"

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -114,7 +114,7 @@ function Course({
           open
         />
       )}
-      {canShowUpgradeSock && <CourseSock verifiedMode={verifiedMode} />}
+      {canShowUpgradeSock && <CourseSock offer={offer} verifiedMode={verifiedMode} />}
       <ContentTools course={course} />
     </>
   );

--- a/src/generic/course-sock/CourseSock.jsx
+++ b/src/generic/course-sock/CourseSock.jsx
@@ -4,12 +4,12 @@ import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import LearnerQuote1 from './assets/learner-quote.png';
 import LearnerQuote2 from './assets/learner-quote2.png';
+import { UpgradeButton } from '../upgrade-button';
 import VerifiedCert from '../assets/edX_certificate.png';
 
 export default class CourseSock extends Component {
   constructor(props) {
     super(props);
-    this.verifiedMode = props.verifiedMode;
     this.state = { showUpsell: false };
     this.sockElement = React.createRef();
   }
@@ -31,7 +31,7 @@ export default class CourseSock extends Component {
   }
 
   render() {
-    if (!this.verifiedMode) {
+    if (!this.props.verifiedMode) {
       return null;
     }
 
@@ -65,22 +65,14 @@ export default class CourseSock extends Component {
                 </div>
                 <div className="position-relative flex-grow-1 d-flex flex-column justify-content-end align-items-md-end">
                   <div style={{ position: 'sticky', bottom: '4rem' }}>
-                    <a
-                      href={this.verifiedMode.upgradeUrl}
-                      className="btn btn-success btn-lg btn-upgrade focusable mb-3"
+                    <UpgradeButton
+                      size="lg"
+                      offer={this.props.offer}
+                      verifiedMode={this.props.verifiedMode}
+                      className="mb-3"
                       data-creative="original_sock"
                       data-position="sock"
-                    >
-                      <FormattedMessage
-                        id="coursesock.upsell.upgrade"
-                        defaultMessage="Upgrade ({symbol}{price} {currency})"
-                        values={{
-                          symbol: this.verifiedMode.currencySymbol,
-                          price: this.verifiedMode.price,
-                          currency: this.verifiedMode.currency,
-                        }}
-                      />
-                    </a>
+                    />
                   </div>
                 </div>
               </div>
@@ -215,12 +207,11 @@ export default class CourseSock extends Component {
   }
 }
 
+CourseSock.defaultProps = {
+  offer: null,
+};
+
 CourseSock.propTypes = {
-  verifiedMode: PropTypes.shape({
-    price: PropTypes.number,
-    currency: PropTypes.string,
-    currencySymbol: PropTypes.string,
-    sku: PropTypes.string,
-    upgradeUrl: PropTypes.string,
-  }).isRequired,
+  offer: PropTypes.shape({}),
+  verifiedMode: PropTypes.shape({}).isRequired,
 };

--- a/src/generic/course-sock/CourseSock.test.jsx
+++ b/src/generic/course-sock/CourseSock.test.jsx
@@ -32,8 +32,8 @@ describe('Course Sock', () => {
     fireEvent.click(upsellButton);
 
     expect(screen.getByText('edX Verified Certificate')).toBeInTheDocument();
-    const { currencySymbol, price, currency } = mockData.verifiedMode;
-    expect(screen.getByText(`Upgrade (${currencySymbol}${price} ${currency})`)).toBeInTheDocument();
+    const { currencySymbol, price } = mockData.verifiedMode;
+    expect(screen.getByText(`Upgrade (${currencySymbol}${price})`)).toBeInTheDocument();
 
     fireEvent.click(upsellButton);
     expect(screen.queryByText('edX Verified Certificate')).not.toBeInTheDocument();

--- a/src/generic/upgrade-button/FormattedPricing.jsx
+++ b/src/generic/upgrade-button/FormattedPricing.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+
+import messages from './messages';
+
+function FormattedPricing(props) {
+  const {
+    inline,
+    intl,
+    offer,
+    verifiedMode,
+  } = props;
+
+  if (!offer) {
+    const {
+      currencySymbol,
+      price,
+    } = verifiedMode;
+    return `${currencySymbol}${price}`;
+  }
+
+  const {
+    discountedPrice,
+    originalPrice,
+  } = offer;
+
+  // The inline style is meant for being embedded in a sentence - it bolds the discount and leaves the original price
+  // as a parenthetical. The normal styling is more suited for a button, where the price and discount are side by side.
+  if (inline) {
+    return (
+      <>
+        <span className="font-weight-bold">{discountedPrice}</span>
+        &nbsp;(
+        <span className="sr-only">
+          {intl.formatMessage(messages.srInlinePrices, { originalPrice })}
+        </span>
+        <span aria-hidden="true">
+          <del>{originalPrice}</del>
+        </span>
+        )
+      </>
+    );
+  }
+
+  return (
+    <>
+      <span className="sr-only">
+        {intl.formatMessage(messages.srPrices, { discountedPrice, originalPrice })}
+      </span>
+      <span aria-hidden="true">
+        {/* the price discount and price original classes can be removed post REV-1512 experiment */}
+        <span className="price discount">{discountedPrice}</span> <del className="price original">{originalPrice}</del>
+      </span>
+    </>
+  );
+}
+
+FormattedPricing.defaultProps = {
+  inline: false,
+  offer: null,
+  verifiedMode: null,
+};
+
+FormattedPricing.propTypes = {
+  inline: PropTypes.bool,
+  intl: intlShape.isRequired,
+  offer: PropTypes.shape({
+    discountedPrice: PropTypes.string.isRequired,
+    originalPrice: PropTypes.string.isRequired,
+    upgradeUrl: PropTypes.string.isRequired,
+  }),
+  verifiedMode: PropTypes.shape({
+    currencySymbol: PropTypes.string.isRequired,
+    price: PropTypes.number.isRequired,
+    upgradeUrl: PropTypes.string.isRequired,
+  }),
+};
+
+export default injectIntl(FormattedPricing);

--- a/src/generic/upgrade-button/UpgradeButton.jsx
+++ b/src/generic/upgrade-button/UpgradeButton.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Button } from '@edx/paragon';
+
+import FormattedPricing from './FormattedPricing';
+
+function UpgradeButton(props) {
+  const {
+    intl,
+    offer,
+    onClick,
+    verifiedMode,
+    ...rest
+  } = props;
+
+  // Prefer offer's url in case it is ever different (though it is not at time of this writing)
+  const url = offer ? offer.upgradeUrl : verifiedMode.upgradeUrl;
+
+  return (
+    <Button
+      variant="success"
+      href={url}
+      onClick={onClick}
+      {...rest}
+    >
+      <FormattedMessage
+        id="learning.upgradeButton.buttonText"
+        defaultMessage="Upgrade ({pricing})"
+        values={{
+          pricing: (
+            <FormattedPricing
+              offer={offer}
+              verifiedMode={verifiedMode}
+            />
+          ),
+        }}
+      />
+    </Button>
+  );
+}
+
+UpgradeButton.defaultProps = {
+  offer: null,
+  onClick: null,
+};
+
+UpgradeButton.propTypes = {
+  intl: intlShape.isRequired,
+  offer: PropTypes.shape({
+    upgradeUrl: PropTypes.string.isRequired,
+  }),
+  onClick: PropTypes.func,
+  verifiedMode: PropTypes.shape({
+    upgradeUrl: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default injectIntl(UpgradeButton);

--- a/src/generic/upgrade-button/index.js
+++ b/src/generic/upgrade-button/index.js
@@ -1,0 +1,7 @@
+import FormattedPricing from './FormattedPricing';
+import UpgradeButton from './UpgradeButton';
+
+export {
+  FormattedPricing,
+  UpgradeButton,
+};

--- a/src/generic/upgrade-button/messages.js
+++ b/src/generic/upgrade-button/messages.js
@@ -1,0 +1,14 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  srPrices: {
+    id: 'learning.offer.screenReaderPrices', // historic id
+    defaultMessage: 'Original price: {originalPrice}, discount price: {discountedPrice}',
+  },
+  srInlinePrices: {
+    id: 'learning.upgradeButton.screenReaderInlinePrices',
+    defaultMessage: 'Original price: {originalPrice}',
+  },
+});
+
+export default messages;


### PR DESCRIPTION
If an offer is active for the user, show the discounted price (and a struck-out original price) on upgrade buttons in the course sock and outline sidebar.

Also show the discount code and price in the course exit upgrade screen.

https://openedx.atlassian.net/browse/AA-449

![Screenshot from 2020-12-15 12-10-56](https://user-images.githubusercontent.com/1196901/102247952-a22d6080-3ece-11eb-9867-8a43000e11fd.png)
![Screenshot from 2020-12-15 11-36-24](https://user-images.githubusercontent.com/1196901/102244095-e23e1480-3ec9-11eb-9251-cf0daf47dd7a.png)
![Screenshot from 2020-12-15 11-36-40](https://user-images.githubusercontent.com/1196901/102244094-e23e1480-3ec9-11eb-9b22-babe717d3e5d.png)