### PR TITLE
[AA-613] Use contains_content_type_gated_content attribute, rather than the graded attribute, to determine if the content type gating paywall should be displayed.

### DIFF
--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -130,7 +130,7 @@ function Unit({
         isBookmarked={unit.bookmarked}
         isProcessing={unit.bookmarkedUpdateState === 'loading'}
       />
-      { contentTypeGatingEnabled && unit.graded && (
+      {contentTypeGatingEnabled && unit.containsContentTypeGatedContent && (
         <Suspense
           fallback={(
             <PageLoading

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -17,10 +17,10 @@ describe('Unit', () => {
     { courseId: courseMetadata.id },
   ), Factory.build(
     'block',
-    { type: 'vertical', graded: true, bookmarked: true },
+    { type: 'vertical', contains_content_type_gated_content: true, bookmarked: true },
     { courseId: courseMetadata.id },
   )];
-  const [unit, gradedUnit] = unitBlocks;
+  const [unit, unitThatContainsGatedContent] = unitBlocks;
 
   beforeAll(async () => {
     await initializeTestStore({ courseMetadata, unitBlocks });
@@ -43,7 +43,7 @@ describe('Unit', () => {
   });
 
   it('renders proper message for gated content', () => {
-    render(<Unit {...mockData} id={gradedUnit.id} />);
+    render(<Unit {...mockData} id={unitThatContainsGatedContent.id} />);
 
     expect(screen.getByText('Loading learning sequence...')).toBeInTheDocument();
     expect(screen.getByText('Loading locked content messaging...')).toBeInTheDocument();

--- a/src/courseware/data/__factories__/sequenceMetadata.factory.js
+++ b/src/courseware/data/__factories__/sequenceMetadata.factory.js
@@ -48,6 +48,7 @@ Factory.define('sequenceMetadata')
       complete: unitBlock.complete || null,
       content: '',
       page_title: unitBlock.display_name,
+      contains_content_type_gated_content: unitBlock.contains_content_type_gated_content,
     }),
   ))
   .attrs({

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -183,6 +183,7 @@ function normalizeSequenceMetadata(sequence) {
       complete: unit.complete,
       title: unit.page_title,
       contentType: unit.type,
+      containsContentTypeGatedContent: unit.contains_content_type_gated_content,
     })),
   };
 }


### PR DESCRIPTION
The issue was that items with the graded attribute are not always going to be paywalled by content type gating.
Check the contains_content_type_gated_content field from the edx-platform PR https://github.com/edx/edx-platform/pull/26143
<img width="1016" alt="Screen Shot 2021-01-26 at 11 12 26 AM" src="https://user-images.githubusercontent.com/5958221/105871655-83d77c00-5fc7-11eb-8292-ef5f33ff044c.png">
<img width="1024" alt="Screen Shot 2021-01-26 at 11 12 53 AM" src="https://user-images.githubusercontent.com/5958221/105871658-84701280-5fc7-11eb-93cb-51344fbddfca.png">
