### PR TITLE
draft: fix: handle problemsets and videosequences just like sequentials

### DIFF
--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -48,6 +48,8 @@ export function normalizeOutlineBlocks(courseId, blocks) {
         break;
 
       case 'sequential':
+      case 'problemset':
+      case 'videosequence':
         models.sequences[block.id] = {
           complete: block.complete,
           description: block.description,

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -33,6 +33,8 @@ export function normalizeBlocks(courseId, blocks) {
         break;
 
       case 'sequential':
+      case 'problemset':
+      case 'videosequence':
         models.sequences[block.id] = {
           effortActivities: block.effort_activities,
           effortTime: block.effort_time,


### PR DESCRIPTION
problemset and videoset are both aliases to
sequential (e.g. Subsection). They are purely semantic;
they aren't supposed to affect functionality at all
currently.

https://openedx.atlassian.net/browse/TNL-7978