### PR TITLE
fix three day streak bug with incorrect variable

### DIFF
--- a/src/shared/streak-celebration/utils.jsx
+++ b/src/shared/streak-celebration/utils.jsx
@@ -19,7 +19,7 @@ function recordModalClosing(metadataModel, celebrations, org, courseId, dispatch
     modelType: metadataModel,
     model: {
       id: courseId,
-      celebrations: { ...celebrations, shouldCelebrateStreak: false },
+      celebrations: { ...celebrations, streakLengthToCelebrate: null },
     },
   }));
 }


### PR DESCRIPTION
As part of addressing the PR feedback, i changed the variable the metadata APIs return from shouldCelebrateStreak to streakLengthToCelebrate, but I missed this spot when renaming the variables. 
this was causing the modal closing to not persist until the page is fully reloaded.