### PR TITLE
[MST-666] Add otherCourseApproved and expiringSoon statuses to proctoring panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@reduxjs/toolkit": "1.3.6",
     "classnames": "2.2.6",
     "core-js": "3.6.5",
+    "lodash.camelcase": "^4.3.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-break": "1.3.2",

--- a/src/course-home/outline-tab/messages.js
+++ b/src/course-home/outline-tab/messages.js
@@ -140,6 +140,14 @@ const messages = defineMessages({
     id: 'learning.proctoringPanel.status.error',
     defaultMessage: 'Error',
   },
+  otherCourseApprovedProctoringStatus: {
+    id: 'learning.proctoringPanel.status.otherCourseApproved',
+    defaultMessage: 'Approved in Another Course',
+  },
+  expiringSoonProctoringStatus: {
+    id: 'learning.proctoringPanel.status.expiringSoon',
+    defaultMessage: 'Expiring Soon',
+  },
   proctoringCurrentStatus: {
     id: 'learning.proctoringPanel.status',
     defaultMessage: 'Current Onboarding Status:',
@@ -167,6 +175,14 @@ const messages = defineMessages({
   errorProctoringMessage: {
     id: 'learning.proctoringPanel.message.error',
     defaultMessage: 'An error has occurred during your onboarding exam. Please retry onboarding.',
+  },
+  otherCourseApprovedProctoringMessage: {
+    id: 'learning.proctoringPanel.message.otherCourseApproved',
+    defaultMessage: 'Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, it is highly recommended that you complete this course’s onboarding exam in order to ensure that your device still meets the requirements for proctoring.',
+  },
+  expiringSoonProctoringMessage: {
+    id: 'learning.proctoringPanel.message.expiringSoon',
+    defaultMessage: 'Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, your onboarding status is expiring soon. Please complete onboarding again to ensure that you will be able to continue taking proctored exams.',
   },
   proctoringPanelGeneralInfo: {
     id: 'learning.proctoringPanel.generalInfo',


### PR DESCRIPTION
Related PR: https://github.com/edx/edx-proctoring/pull/794

* Added two new statuses to the proctoring info panel:
    - `otherCourseApproved`: The user has no onboarding attempts in the current course, but they have at least one verified attempt in a different course.
    - `expiringSoon`: Same as above, but the attempt is expiring within 28 days.
* Converted readable status strings in the proctoring info panel to constants.

---
![Screen Shot 2021-02-26 at 2 01 52 PM](https://user-images.githubusercontent.com/10442143/109352677-314ce200-7849-11eb-841d-dffcdb2e5183.png)
---
![Screen Shot 2021-02-26 at 2 02 58 PM](https://user-images.githubusercontent.com/10442143/109352688-3447d280-7849-11eb-9058-69fe06f6dba4.png)
---