### PR TITLE
onboarding panel exam release date

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -635,11 +635,10 @@ describe('Outline Tab', () => {
         year: 'numeric',
       }).format(futureReleaseDate);
 
-
       axiosMock.onGet(proctoringInfoUrl).reply(200, {
         onboarding_status: '',
         onboarding_link: 'test',
-        expiration_date: expirationDate.toString(),
+        expiration_date: null,
         onboarding_release_date: futureReleaseDate.toISOString(),
       });
       await fetchAndRender();

--- a/src/course-home/outline-tab/messages.js
+++ b/src/course-home/outline-tab/messages.js
@@ -200,6 +200,10 @@ const messages = defineMessages({
     id: 'learning.proctoringPanel.onboardingButton',
     defaultMessage: 'Complete Onboarding',
   },
+  proctoringOnboardingButtonNotOpen: {
+    id: 'learning.proctoringPanel.onboardingButtonNotOpen',
+    defaultMessage: 'Onboarding Opens: {releaseDate}',
+  },
   proctoringReviewRequirementsButton: {
     id: 'learning.proctoringPanel.reviewRequirementsButton',
     defaultMessage: 'Review instructions and system requirements',

--- a/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
+++ b/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
@@ -125,24 +125,28 @@ function ProctoringInfoPanel({ courseId, intl }) {
                 <p>{intl.formatMessage(messages.proctoringPanelGeneralTime)}</p>
               </>
             )}
-            {isNotYetSubmitted(status) && !isNotYetReleased(releaseDate) && (
-              <Button variant="primary" block href={`${getConfig().LMS_BASE_URL}${link}`}>
-                {intl.formatMessage(messages.proctoringOnboardingButton)}
-              </Button>
-            )}
-            {isNotYetSubmitted(status) && isNotYetReleased(releaseDate) && (
-              <Button variant="secondary" block disabled aria-disabled="true">
-                {intl.formatMessage(
-                  messages.proctoringOnboardingButtonNotOpen,
-                  {
-                    releaseDate: intl.formatDate(releaseDate, {
-                      day: 'numeric',
-                      month: 'short',
-                      year: 'numeric',
-                    }),
-                  },
+            {isNotYetSubmitted(status) && (
+              <>
+                {!isNotYetReleased(releaseDate) && (
+                  <Button variant="primary" block href={`${getConfig().LMS_BASE_URL}${link}`}>
+                    {intl.formatMessage(messages.proctoringOnboardingButton)}
+                  </Button>
                 )}
-              </Button>
+                {isNotYetReleased(releaseDate) && (
+                  <Button variant="secondary" block disabled aria-disabled="true">
+                    {intl.formatMessage(
+                      messages.proctoringOnboardingButtonNotOpen,
+                      {
+                        releaseDate: intl.formatDate(releaseDate, {
+                          day: 'numeric',
+                          month: 'short',
+                          year: 'numeric',
+                        }),
+                      },
+                    )}
+                  </Button>
+                )}
+              </>
             )}
             <Button variant="outline-primary" block href="https://support.edx.org/hc/en-us/sections/115004169247-Taking-Timed-and-Proctored-Exams">
               {intl.formatMessage(messages.proctoringReviewRequirementsButton)}

--- a/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
+++ b/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
@@ -12,6 +12,7 @@ import { getProctoringInfoData } from '../../data/api';
 function ProctoringInfoPanel({ courseId, intl }) {
   const [status, setStatus] = useState('');
   const [link, setLink] = useState('');
+  const [releaseDate, setReleaseDate] = useState(null);
   const [readableStatus, setReadableStatus] = useState('');
 
   const readableStatuses = {
@@ -47,6 +48,14 @@ function ProctoringInfoPanel({ courseId, intl }) {
     return !NO_SHOW_STATES.includes(examStatus);
   }
 
+  function isNotYetReleased(examReleaseDate) {
+    if (!examReleaseDate) {
+      return false;
+    }
+    const now = new Date();
+    return now < examReleaseDate;
+  }
+
   function getBorderClass() {
     let borderClass = '';
     if (readableStatus === readableStatuses.submitted) {
@@ -77,6 +86,7 @@ function ProctoringInfoPanel({ courseId, intl }) {
             } else {
               setReadableStatus(getReadableStatusClass(response.onboarding_status));
             }
+            setReleaseDate(new Date(response.onboarding_release_date));
           }
         },
       );
@@ -115,9 +125,23 @@ function ProctoringInfoPanel({ courseId, intl }) {
                 <p>{intl.formatMessage(messages.proctoringPanelGeneralTime)}</p>
               </>
             )}
-            {isNotYetSubmitted(status) && (
+            {isNotYetSubmitted(status) && !isNotYetReleased(releaseDate) && (
               <Button variant="primary" block href={`${getConfig().LMS_BASE_URL}${link}`}>
                 {intl.formatMessage(messages.proctoringOnboardingButton)}
+              </Button>
+            )}
+            {isNotYetSubmitted(status) && isNotYetReleased(releaseDate) && (
+              <Button variant="secondary" block disabled aria-disabled="true">
+                {intl.formatMessage(
+                  messages.proctoringOnboardingButtonNotOpen,
+                  {
+                    releaseDate: intl.formatDate(releaseDate, {
+                      day: 'numeric',
+                      month: 'short',
+                      year: 'numeric',
+                    }),
+                  },
+                )}
               </Button>
             )}
             <Button variant="outline-primary" block href="https://support.edx.org/hc/en-us/sections/115004169247-Taking-Timed-and-Proctored-Exams">


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

Disable button leading to the onboarding section if that exam has not yet been released. This is not blocked by the API changes and will behave as it does today if a release date is not returned.

Related edx-proctoring PR: https://github.com/edx/edx-proctoring/pull/792

<img width="1533" alt="Screen Shot 2021-03-01 at 1 57 26 PM" src="https://user-images.githubusercontent.com/5661461/109544897-19b66900-7a96-11eb-940b-a396a27faa2a.png">
