### PR TITLE
Add Sidebar and SidebarNotificationButton components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13881,6 +13881,11 @@
         }
       }
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@reduxjs/toolkit": "1.3.6",
     "classnames": "2.2.6",
     "core-js": "3.6.5",
+    "js-cookie": "2.2.1",
     "lodash.camelcase": "^4.3.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { useDispatch } from 'react-redux';
+import Cookies from 'js-cookie';
 import { getConfig } from '@edx/frontend-platform';
 
 import { AlertList } from '../../generic/user-messages';
@@ -60,6 +61,11 @@ function Course({
     courseId, sequenceId, unitId, celebrateFirstSection, dispatch, celebrations,
   );
 
+  // In order to see the Value Prop sidebar in prod, a cookie should be set in
+  // the browser console and refresh: document.cookie = 'value_prop_cookie=true';
+  // All of the cookie code temporary and should be removed in REV-2130.
+  const isCookieSet = Cookies.get('value_prop_cookie') === 'true';
+
   const shouldDisplaySidebarButton = useWindowSize().width > 576;
 
   const [sidebarVisible, setSidebar] = useState(false);
@@ -95,8 +101,8 @@ function Course({
           //* * [MM-P2P] Experiment */
           mmp2p={MMP2P}
         />
-        {/* JK: add conditional/cookie to hide/show Sidebar here */}
-        { shouldDisplaySidebarButton ? (
+
+        { shouldDisplaySidebarButton && isCookieSet ? (
           <SidebarNotificationButton
             toggleSidebar={toggleSidebar}
             isSidebarVisible={isSidebarVisible}
@@ -115,6 +121,7 @@ function Course({
         toggleSidebar={toggleSidebar}
         isSidebarVisible={isSidebarVisible}
         sidebarVisible={sidebarVisible}
+        isCookieSet={isCookieSet}
         //* * [MM-P2P] Experiment */
         mmp2p={MMP2P}
       />

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -60,9 +60,7 @@ function Course({
     courseId, sequenceId, unitId, celebrateFirstSection, dispatch, celebrations,
   );
 
-  const windowSize = useWindowSize();
-  const isTabletWidth = windowSize.width < 992;
-  const isMobileWidth = windowSize.width < 576;
+  const shouldDisplaySidebarButton = useWindowSize().width > 576;
 
   const [sidebarVisible, setSidebar] = useState(false);
   const isSidebarVisible = () => sidebarVisible && setSidebar;
@@ -94,12 +92,11 @@ function Course({
           courseId={courseId}
           sectionId={section ? section.id : null}
           sequenceId={sequenceId}
-          isMobileWidth={isMobileWidth}
           //* * [MM-P2P] Experiment */
           mmp2p={MMP2P}
         />
         {/* JK: add conditional/cookie to hide/show Sidebar here */}
-        { !isMobileWidth ? (
+        { shouldDisplaySidebarButton ? (
           <SidebarNotificationButton
             toggleSidebar={toggleSidebar}
             isSidebarVisible={isSidebarVisible}
@@ -118,8 +115,6 @@ function Course({
         toggleSidebar={toggleSidebar}
         isSidebarVisible={isSidebarVisible}
         sidebarVisible={sidebarVisible}
-        isTabletWidth={isTabletWidth}
-        isMobileWidth={isMobileWidth}
         //* * [MM-P2P] Experiment */
         mmp2p={MMP2P}
       />

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -64,7 +64,7 @@ function Course({
   const MMP2P = initCoursewareMMP2P(courseId, sequenceId, unitId);
 
   const windowSize = useWindowSize();
-  const isMobileWidth = windowSize.width <= 576;
+  const isResponsiveWidth = windowSize.width <= 768;
 
   const [sidebarVisible, setSidebar] = useState(false);
   const isSidebarVisible = () => sidebarVisible && setSidebar;
@@ -96,7 +96,7 @@ function Course({
           //* * [MM-P2P] Experiment */
           mmp2p={MMP2P}
         />
-        { !isMobileWidth ? (
+        { !isResponsiveWidth ? (
           <SidebarNotificationButton
             toggleSidebar={toggleSidebar}
             isSidebarVisible={isSidebarVisible}
@@ -115,7 +115,7 @@ function Course({
         toggleSidebar={toggleSidebar}
         isSidebarVisible={isSidebarVisible}
         sidebarVisible={sidebarVisible}
-        isMobileWidth={isMobileWidth}
+        isResponsiveWidth={isResponsiveWidth}
         //* * [MM-P2P] Experiment */
         mmp2p={MMP2P}
       />

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -60,17 +60,18 @@ function Course({
     courseId, sequenceId, unitId, celebrateFirstSection, dispatch, celebrations,
   );
 
-  /** [MM-P2P] Experiment */
-  const MMP2P = initCoursewareMMP2P(courseId, sequenceId, unitId);
-
   const windowSize = useWindowSize();
-  const isResponsiveWidth = windowSize.width <= 768;
+  const isTabletWidth = windowSize.width < 992;
+  const isMobileWidth = windowSize.width < 576;
 
   const [sidebarVisible, setSidebar] = useState(false);
   const isSidebarVisible = () => sidebarVisible && setSidebar;
   const toggleSidebar = () => {
     if (!sidebarVisible) { setSidebar(true); } else { setSidebar(false); }
   };
+
+  /** [MM-P2P] Experiment */
+  const MMP2P = initCoursewareMMP2P(courseId, sequenceId, unitId);
 
   return (
     <>
@@ -93,10 +94,12 @@ function Course({
           courseId={courseId}
           sectionId={section ? section.id : null}
           sequenceId={sequenceId}
+          isMobileWidth={isMobileWidth}
           //* * [MM-P2P] Experiment */
           mmp2p={MMP2P}
         />
-        { !isResponsiveWidth ? (
+        {/* JK: add conditional/cookie to hide/show Sidebar here */}
+        { !isMobileWidth ? (
           <SidebarNotificationButton
             toggleSidebar={toggleSidebar}
             isSidebarVisible={isSidebarVisible}
@@ -115,7 +118,8 @@ function Course({
         toggleSidebar={toggleSidebar}
         isSidebarVisible={isSidebarVisible}
         sidebarVisible={sidebarVisible}
-        isResponsiveWidth={isResponsiveWidth}
+        isTabletWidth={isTabletWidth}
+        isMobileWidth={isMobileWidth}
         //* * [MM-P2P] Experiment */
         mmp2p={MMP2P}
       />

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -61,12 +61,12 @@ function Course({
     courseId, sequenceId, unitId, celebrateFirstSection, dispatch, celebrations,
   );
 
+  // REV-2130 TODO: temporary cookie code that should be removed.
   // In order to see the Value Prop sidebar in prod, a cookie should be set in
   // the browser console and refresh: document.cookie = 'value_prop_cookie=true';
-  // All of the cookie code temporary and should be removed in REV-2130.
   const isCookieSet = Cookies.get('value_prop_cookie') === 'true';
 
-  const shouldDisplaySidebarButton = useWindowSize().width > 576;
+  const shouldDisplaySidebarButton = useWindowSize().width > 575;
 
   const [sidebarVisible, setSidebar] = useState(false);
   const isSidebarVisible = () => sidebarVisible && setSidebar;

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { useDispatch } from 'react-redux';
@@ -13,8 +13,11 @@ import Sequence from './sequence';
 import { CelebrationModal, shouldCelebrateOnSectionLoad } from './celebration';
 import ContentTools from './content-tools';
 import CourseBreadcrumbs from './CourseBreadcrumbs';
+import SidebarNotificationButton from './SidebarNotificationButton';
+
 import CourseSock from '../../generic/course-sock';
 import { useModel } from '../../generic/model-store';
+import useWindowSize from '../../generic/tabs/useWindowSize';
 
 /** [MM-P2P] Experiment */
 import { initCoursewareMMP2P, MMP2PBlockModal } from '../../experiments/mm-p2p';
@@ -60,6 +63,15 @@ function Course({
   /** [MM-P2P] Experiment */
   const MMP2P = initCoursewareMMP2P(courseId, sequenceId, unitId);
 
+  const windowSize = useWindowSize();
+  const isMobileWidth = windowSize.width <= 576;
+
+  const [sidebarVisible, setSidebar] = useState(false);
+  const isSidebarVisible = () => sidebarVisible && setSidebar;
+  const toggleSidebar = () => {
+    if (!sidebarVisible) { setSidebar(true); } else { setSidebar(false); }
+  };
+
   return (
     <>
       <Helmet>
@@ -76,13 +88,22 @@ function Course({
           }}
         />
       )}
-      <CourseBreadcrumbs
-        courseId={courseId}
-        sectionId={section ? section.id : null}
-        sequenceId={sequenceId}
-        //* * [MM-P2P] Experiment */
-        mmp2p={MMP2P}
-      />
+      <div className="breadcrumb-container">
+        <CourseBreadcrumbs
+          courseId={courseId}
+          sectionId={section ? section.id : null}
+          sequenceId={sequenceId}
+          //* * [MM-P2P] Experiment */
+          mmp2p={MMP2P}
+        />
+        { !isMobileWidth ? (
+          <SidebarNotificationButton
+            toggleSidebar={toggleSidebar}
+            isSidebarVisible={isSidebarVisible}
+          />
+        ) : null}
+      </div>
+
       <AlertList topic="sequence" />
       <Sequence
         unitId={unitId}
@@ -91,6 +112,10 @@ function Course({
         unitNavigationHandler={unitNavigationHandler}
         nextSequenceHandler={nextSequenceHandler}
         previousSequenceHandler={previousSequenceHandler}
+        toggleSidebar={toggleSidebar}
+        isSidebarVisible={isSidebarVisible}
+        sidebarVisible={sidebarVisible}
+        isMobileWidth={isMobileWidth}
         //* * [MM-P2P] Experiment */
         mmp2p={MMP2P}
       />

--- a/src/courseware/course/Course.test.jsx
+++ b/src/courseware/course/Course.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Factory } from 'rosie';
+import Cookies from 'js-cookie';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import {
   loadUnit, render, screen, waitFor, getByRole, initializeTestStore, fireEvent,
@@ -90,6 +91,11 @@ describe('Course', () => {
     const toggleSidebar = jest.fn();
     const isSidebarVisible = jest.fn();
 
+    const cookieName = 'value_prop_cookie';
+    Cookies.set = jest.fn();
+    Cookies.get = jest.fn().mockImplementation(() => cookieName);
+    const getSpy = jest.spyOn(Cookies, 'get').mockReturnValueOnce('true');
+
     const courseMetadata = Factory.build('courseMetadata');
     const testStore = await initializeTestStore({ courseMetadata, excludeFetchSequence: true }, false);
     const testData = {
@@ -101,10 +107,8 @@ describe('Course', () => {
 
     const sidebarButton = screen.getByRole('button', { name: /Sidebar notification button/i });
 
-    fireEvent.click(sidebarButton);
-    expect(sidebarButton)
-      .toBeInTheDocument()
-      .toHaveClass('active');
+    expect(getSpy).toBeCalledWith(cookieName);
+    expect(sidebarButton).toBeInTheDocument();
   });
 
   it('displays offer and expiration alert', async () => {

--- a/src/courseware/course/Course.test.jsx
+++ b/src/courseware/course/Course.test.jsx
@@ -105,10 +105,10 @@ describe('Course', () => {
     };
     render(<Course {...testData} courseId={courseMetadata.id} />, { store: testStore });
 
-    const sidebarButton = screen.getByRole('button', { name: /Sidebar notification button/i });
+    const sidebarOpenButton = screen.getByRole('button', { name: /Show sidebar notification/i });
 
     expect(getSpy).toBeCalledWith(cookieName);
-    expect(sidebarButton).toBeInTheDocument();
+    expect(sidebarOpenButton).toBeInTheDocument();
   });
 
   it('displays offer and expiration alert', async () => {

--- a/src/courseware/course/Course.test.jsx
+++ b/src/courseware/course/Course.test.jsx
@@ -19,6 +19,7 @@ describe('Course', () => {
     nextSequenceHandler: () => {},
     previousSequenceHandler: () => {},
     unitNavigationHandler: () => {},
+    toggleSidebar: () => {},
   };
 
   beforeAll(async () => {
@@ -83,6 +84,27 @@ describe('Course', () => {
 
     render(<Course {...mockData} courseId={courseMetadata.id} />, { store: testStore });
     expect(screen.getByRole('button', { name: 'Learn About Verified Certificates' })).toBeInTheDocument();
+  });
+
+  it('displays sidebar notification button', async () => {
+    const toggleSidebar = jest.fn();
+    const isSidebarVisible = jest.fn();
+
+    const courseMetadata = Factory.build('courseMetadata');
+    const testStore = await initializeTestStore({ courseMetadata, excludeFetchSequence: true }, false);
+    const testData = {
+      ...mockData,
+      toggleSidebar,
+      isSidebarVisible,
+    };
+    render(<Course {...testData} courseId={courseMetadata.id} />, { store: testStore });
+
+    const sidebarButton = screen.getByRole('button', { name: /Sidebar notification button/i });
+
+    fireEvent.click(sidebarButton);
+    expect(sidebarButton)
+      .toBeInTheDocument()
+      .toHaveClass('active');
   });
 
   it('displays offer and expiration alert', async () => {

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -40,7 +40,6 @@ export default function CourseBreadcrumbs({
   courseId,
   sectionId,
   sequenceId,
-  isMobileWidth,
   /** [MM-P2P] Experiment */
   mmp2p,
 }) {
@@ -62,7 +61,7 @@ export default function CourseBreadcrumbs({
   }, [courseStatus, sequenceStatus]);
 
   return (
-    <nav aria-label="breadcrumb" className={classNames('my-4 d-inline-block', { 'col-10': !isMobileWidth })}>
+    <nav aria-label="breadcrumb" className={classNames('my-4 d-inline-block col-sm-10')}>
       <ol className="list-unstyled d-flex m-0">
         <CourseBreadcrumb
           url={`${getConfig().LMS_BASE_URL}/courses/${course.id}/course/`}
@@ -103,7 +102,6 @@ CourseBreadcrumbs.propTypes = {
   courseId: PropTypes.string.isRequired,
   sectionId: PropTypes.string,
   sequenceId: PropTypes.string,
-  isMobileWidth: PropTypes.bool,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({
@@ -115,7 +113,6 @@ CourseBreadcrumbs.propTypes = {
 CourseBreadcrumbs.defaultProps = {
   sectionId: null,
   sequenceId: null,
-  isMobileWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {},

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -60,7 +60,7 @@ export default function CourseBreadcrumbs({
   }, [courseStatus, sequenceStatus]);
 
   return (
-    <nav aria-label="breadcrumb" className="my-4">
+    <nav aria-label="breadcrumb" className="my-4 d-inline-block">
       <ol className="list-unstyled d-flex m-0">
         <CourseBreadcrumb
           url={`${getConfig().LMS_BASE_URL}/courses/${course.id}/course/`}

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
@@ -39,6 +40,7 @@ export default function CourseBreadcrumbs({
   courseId,
   sectionId,
   sequenceId,
+  isMobileWidth,
   /** [MM-P2P] Experiment */
   mmp2p,
 }) {
@@ -60,7 +62,7 @@ export default function CourseBreadcrumbs({
   }, [courseStatus, sequenceStatus]);
 
   return (
-    <nav aria-label="breadcrumb" className="my-4 d-inline-block">
+    <nav aria-label="breadcrumb" className={classNames('my-4 d-inline-block', { 'col-10': !isMobileWidth })}>
       <ol className="list-unstyled d-flex m-0">
         <CourseBreadcrumb
           url={`${getConfig().LMS_BASE_URL}/courses/${course.id}/course/`}
@@ -101,6 +103,7 @@ CourseBreadcrumbs.propTypes = {
   courseId: PropTypes.string.isRequired,
   sectionId: PropTypes.string,
   sequenceId: PropTypes.string,
+  isMobileWidth: PropTypes.bool,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({
@@ -112,6 +115,7 @@ CourseBreadcrumbs.propTypes = {
 CourseBreadcrumbs.defaultProps = {
   sectionId: null,
   sequenceId: null,
+  isMobileWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {},

--- a/src/courseware/course/NotificationIcon.jsx
+++ b/src/courseware/course/NotificationIcon.jsx
@@ -9,10 +9,10 @@ import messages from './messages';
 
 function NotificationIcon({ intl, status, notificationColor }) {
   return (
-    <div className="position-relative">
+    <>
       <Icon src={WatchOutline} className="m-0 m-auto" alt={intl.formatMessage(messages.notificationButton)} />
-      {status === 'active' ? <span className={classNames(notificationColor, 'rounded-circle p-1 position-absolute')} style={{ top: '0.1rem', right: '0.55rem' }} /> : null }
-    </div>
+      {status === 'active' ? <span className={classNames(notificationColor, 'rounded-circle p-1 position-absolute')} style={{ top: '0.3rem', right: '0.55rem' }} /> : null }
+    </>
   );
 }
 

--- a/src/courseware/course/NotificationIcon.jsx
+++ b/src/courseware/course/NotificationIcon.jsx
@@ -10,8 +10,10 @@ import messages from './messages';
 function NotificationIcon({ intl, status, notificationColor }) {
   return (
     <>
-      <Icon src={WatchOutline} className="m-0 m-auto" alt={intl.formatMessage(messages.notificationButton)} />
-      {status === 'active' ? <span className={classNames(notificationColor, 'rounded-circle p-1 position-absolute')} style={{ top: '0.3rem', right: '0.55rem' }} /> : null }
+      <Icon src={WatchOutline} className="m-0 m-auto" alt={intl.formatMessage(messages.openSidebarButton)} />
+      {status === 'active'
+        ? <span className={classNames(notificationColor, 'rounded-circle p-1 position-absolute')} style={{ top: '0.3rem', right: '0.55rem' }} />
+        : null}
     </>
   );
 }

--- a/src/courseware/course/NotificationIcon.jsx
+++ b/src/courseware/course/NotificationIcon.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Icon } from '@edx/paragon';
+import { WatchOutline } from '@edx/paragon/icons';
+
+import messages from './messages';
+
+function NotificationIcon({ intl, status, notificationColor }) {
+  return (
+    <div className="position-relative">
+      <Icon src={WatchOutline} className="m-0 m-auto" alt={intl.formatMessage(messages.notificationButton)} />
+      {status === 'active' ? <span className={classNames(notificationColor, 'rounded-circle p-1 position-absolute')} style={{ top: '0.1rem', right: '0.55rem' }} /> : null }
+    </div>
+  );
+}
+
+NotificationIcon.propTypes = {
+  intl: intlShape.isRequired,
+  status: PropTypes.string.isRequired,
+  notificationColor: PropTypes.string.isRequired,
+};
+
+export default injectIntl(NotificationIcon);

--- a/src/courseware/course/Sidebar.jsx
+++ b/src/courseware/course/Sidebar.jsx
@@ -12,7 +12,7 @@ function Sidebar({
 }) {
   const shouldDisplayFullScreen = useWindowSize().width < 992;
   return (
-    <div className="sidebar-container ml-0 ml-lg-4">
+    <section className="sidebar-container ml-0 ml-lg-4" aria-label={intl.formatMessage(messages.sidebarNotification)}>
       {shouldDisplayFullScreen ? (
         <div className="mobile-close-container" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.responsiveCloseSidebar)}>
           <Icon src={ArrowBackIos} />
@@ -20,17 +20,17 @@ function Sidebar({
         </div>
       ) : null}
       <div className="sidebar-header px-3">
-        <span>{intl.formatMessage(messages.notification)}</span>
+        <span>{intl.formatMessage(messages.notificationTitle)}</span>
         {shouldDisplayFullScreen
           ? null
-          : <Icon src={Close} className="close-btn" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.closeButton)} />}
+          : <Icon src={Close} className="close-btn" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.closeSidebarButton)} />}
       </div>
       <div className="sidebar-divider" />
       <div className="sidebar-content">
         {/* REV-2130 TODO: add conditional here to display expiration box or display below message */}
-        <p>You have no new notifications at this time.</p>
+        <p>{intl.formatMessage(messages.noNotificationsMessage)}</p>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/courseware/course/Sidebar.jsx
+++ b/src/courseware/course/Sidebar.jsx
@@ -5,49 +5,43 @@ import { Icon } from '@edx/paragon';
 import { ArrowBackIos, Close } from '@edx/paragon/icons';
 import './Sidebar.scss';
 import messages from './messages';
+import useWindowSize from '../../generic/tabs/useWindowSize';
 
 function Sidebar({
-  intl, sidebarVisible, toggleSidebar, isTabletWidth,
+  intl, toggleSidebar,
 }) {
+  const shouldDisplayFullScreen = useWindowSize().width < 992;
   return (
-    sidebarVisible ? (
-      <div className="sidebar-container ml-0 ml-lg-4">
-        {isTabletWidth
-          ? (
-            <div className="mobile-close-container" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.responsiveCloseSidebar)}>
-              <Icon src={ArrowBackIos} />
-              <span className="mobile-close">{intl.formatMessage(messages.responsiveCloseSidebar)}</span>
-            </div>
-          )
-          : null}
-        <div className="sidebar-header px-3">
-          <span>{intl.formatMessage(messages.notification)}</span>
-          {!isTabletWidth
-            ? <Icon src={Close} className="close-btn" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.closeButton)} />
-            : null}
+    <div className="sidebar-container ml-0 ml-lg-4">
+      {shouldDisplayFullScreen ? (
+        <div className="mobile-close-container" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.responsiveCloseSidebar)}>
+          <Icon src={ArrowBackIos} />
+          <span className="mobile-close">{intl.formatMessage(messages.responsiveCloseSidebar)}</span>
         </div>
-        <div className="sidebar-divider" />
-        <div className="sidebar-content">
-          {/* JK: add conditional here */}
-          <p>You have no new notifications at this time.</p>
-          {/* expiration box to be inserted here */}
-        </div>
+      ) : null}
+      <div className="sidebar-header px-3">
+        <span>{intl.formatMessage(messages.notification)}</span>
+        {shouldDisplayFullScreen
+          ? null
+          : <Icon src={Close} className="close-btn" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.closeButton)} />}
       </div>
-    ) : null
+      <div className="sidebar-divider" />
+      <div className="sidebar-content">
+        {/* JK: add conditional here */}
+        <p>You have no new notifications at this time.</p>
+        {/* expiration box to be inserted here */}
+      </div>
+    </div>
   );
 }
 
 Sidebar.propTypes = {
   intl: intlShape.isRequired,
   toggleSidebar: PropTypes.func,
-  sidebarVisible: PropTypes.bool,
-  isTabletWidth: PropTypes.bool,
 };
 
 Sidebar.defaultProps = {
   toggleSidebar: null,
-  sidebarVisible: null,
-  isTabletWidth: null,
 };
 
 export default injectIntl(Sidebar);

--- a/src/courseware/course/Sidebar.jsx
+++ b/src/courseware/course/Sidebar.jsx
@@ -7,12 +7,12 @@ import './Sidebar.scss';
 import messages from './messages';
 
 function Sidebar({
-  intl, sidebarVisible, toggleSidebar, isResponsiveWidth,
+  intl, sidebarVisible, toggleSidebar, isTabletWidth,
 }) {
   return (
     sidebarVisible ? (
       <div className="sidebar-container ml-0 ml-lg-4">
-        {isResponsiveWidth
+        {isTabletWidth
           ? (
             <div className="mobile-close-container" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.responsiveCloseSidebar)}>
               <Icon src={ArrowBackIos} />
@@ -22,12 +22,16 @@ function Sidebar({
           : null}
         <div className="sidebar-header px-3">
           <span>{intl.formatMessage(messages.notification)}</span>
-          {!isResponsiveWidth
+          {!isTabletWidth
             ? <Icon src={Close} className="close-btn" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.closeButton)} />
             : null}
         </div>
         <div className="sidebar-divider" />
-        {/* expiration box to be inserted here */}
+        <div className="sidebar-content">
+          {/* JK: add conditional here */}
+          <p>You have no new notifications at this time.</p>
+          {/* expiration box to be inserted here */}
+        </div>
       </div>
     ) : null
   );
@@ -37,13 +41,13 @@ Sidebar.propTypes = {
   intl: intlShape.isRequired,
   toggleSidebar: PropTypes.func,
   sidebarVisible: PropTypes.bool,
-  isResponsiveWidth: PropTypes.bool,
+  isTabletWidth: PropTypes.bool,
 };
 
 Sidebar.defaultProps = {
   toggleSidebar: null,
   sidebarVisible: null,
-  isResponsiveWidth: null,
+  isTabletWidth: null,
 };
 
 export default injectIntl(Sidebar);

--- a/src/courseware/course/Sidebar.jsx
+++ b/src/courseware/course/Sidebar.jsx
@@ -27,9 +27,8 @@ function Sidebar({
       </div>
       <div className="sidebar-divider" />
       <div className="sidebar-content">
-        {/* JK: add conditional here */}
+        {/* REV-2130 TODO: add conditional here to display expiration box or display below message */}
         <p>You have no new notifications at this time.</p>
-        {/* expiration box to be inserted here */}
       </div>
     </div>
   );

--- a/src/courseware/course/Sidebar.jsx
+++ b/src/courseware/course/Sidebar.jsx
@@ -7,12 +7,12 @@ import './Sidebar.scss';
 import messages from './messages';
 
 function Sidebar({
-  intl, sidebarVisible, toggleSidebar, isMobileWidth,
+  intl, sidebarVisible, toggleSidebar, isResponsiveWidth,
 }) {
   return (
     sidebarVisible ? (
-      <div className="sidebar-container ml-0 ml-sm-4">
-        {isMobileWidth
+      <div className="sidebar-container ml-0 ml-lg-4">
+        {isResponsiveWidth
           ? (
             <div className="mobile-close-container" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.responsiveCloseSidebar)}>
               <Icon src={ArrowBackIos} />
@@ -22,7 +22,7 @@ function Sidebar({
           : null}
         <div className="sidebar-header px-3">
           <span>{intl.formatMessage(messages.notification)}</span>
-          {!isMobileWidth
+          {!isResponsiveWidth
             ? <Icon src={Close} className="close-btn" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.closeButton)} />
             : null}
         </div>
@@ -35,9 +35,15 @@ function Sidebar({
 
 Sidebar.propTypes = {
   intl: intlShape.isRequired,
-  toggleSidebar: PropTypes.func.isRequired,
-  sidebarVisible: PropTypes.bool.isRequired,
-  isMobileWidth: PropTypes.bool.isRequired,
+  toggleSidebar: PropTypes.func,
+  sidebarVisible: PropTypes.bool,
+  isResponsiveWidth: PropTypes.bool,
+};
+
+Sidebar.defaultProps = {
+  toggleSidebar: null,
+  sidebarVisible: null,
+  isResponsiveWidth: null,
 };
 
 export default injectIntl(Sidebar);

--- a/src/courseware/course/Sidebar.jsx
+++ b/src/courseware/course/Sidebar.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Icon } from '@edx/paragon';
+import { ArrowBackIos, Close } from '@edx/paragon/icons';
+import './Sidebar.scss';
+import messages from './messages';
+
+function Sidebar({
+  intl, sidebarVisible, toggleSidebar, isMobileWidth,
+}) {
+  return (
+    sidebarVisible ? (
+      <div className="sidebar-container ml-0 ml-sm-4">
+        {isMobileWidth
+          ? (
+            <div className="mobile-close-container" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.responsiveCloseSidebar)}>
+              <Icon src={ArrowBackIos} />
+              <span className="mobile-close">{intl.formatMessage(messages.responsiveCloseSidebar)}</span>
+            </div>
+          )
+          : null}
+        <div className="sidebar-header px-3">
+          <span>{intl.formatMessage(messages.notification)}</span>
+          {!isMobileWidth
+            ? <Icon src={Close} className="close-btn" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.closeButton)} />
+            : null}
+        </div>
+        <div className="sidebar-divider" />
+        {/* expiration box to be inserted here */}
+      </div>
+    ) : null
+  );
+}
+
+Sidebar.propTypes = {
+  intl: intlShape.isRequired,
+  toggleSidebar: PropTypes.func.isRequired,
+  sidebarVisible: PropTypes.bool.isRequired,
+  isMobileWidth: PropTypes.bool.isRequired,
+};
+
+export default injectIntl(Sidebar);

--- a/src/courseware/course/Sidebar.scss
+++ b/src/courseware/course/Sidebar.scss
@@ -4,11 +4,12 @@
 @import "~@edx/brand/paragon/overrides";
 
 .sidebar-container {
-    border: 1px solid $gray-200;
-    width: 330px;
+    border: 1px solid $light-400;
+    border-radius: 4px;
+    width: 20rem;
     vertical-align: top;
 
-    @media (max-width: map-get($grid-breakpoints, 'md')) {
+    @media (max-width: map-get($grid-breakpoints, 'lg')) {
         position: fixed; 
         top: 0; 
         bottom: 0; 
@@ -19,6 +20,7 @@
         background-color: white;
         margin: 0;
         border: none;
+        border-radius: 0;
     }
 }
 
@@ -35,27 +37,33 @@
 }
 
 .sidebar-divider {
+    width: 100.5%;
     height: 0.5rem;
     background: $gray-100;
-    border-top: 1px solid $gray-200;
-    border-bottom: 1px solid $gray-200;
+    border: 1px solid $light-400;
+    border-left: 0;
+}
+
+.sidebar-content {
+    padding: 1rem;
+    font-size: 0.875rem;
 }
 
 .mobile-close-container {
     padding-top: 0.5rem;
     padding-bottom: 0.75rem;
-    border-bottom: 1px solid $gray-200;
+    border-bottom: 1px solid $light-400;
 
     span {
         display: inline-block;
     }
     svg {
-        margin-top: 7px;
-        margin-left: 15px;
+        top: 0.4rem;
+        left: 0.8rem;
     }
 }
 
 .mobile-close {
     font-weight: 500;
-    margin-left: 1.5rem;
+    margin-left: 1.2rem;
 }

--- a/src/courseware/course/Sidebar.scss
+++ b/src/courseware/course/Sidebar.scss
@@ -4,7 +4,7 @@
 @import "~@edx/brand/paragon/overrides";
 
 .sidebar-container {
-    border: 1px solid rgb(225, 221, 219);
+    border: 1px solid $gray-200;
     width: 330px;
     vertical-align: top;
 
@@ -23,9 +23,7 @@
 }
 
 .sidebar-header {
-    padding-top: 14px;
-    padding-bottom: 10px;
-    font-size: 1rem;
+    padding: 0.625rem 0;
 
     span {
         display: inline-block;
@@ -38,15 +36,15 @@
 
 .sidebar-divider {
     height: 0.5rem;
-    background: rgb(249, 249, 249);
-    border-top: 1px solid rgb(225, 221, 219);
-    border-bottom: 1px solid rgb(225, 221, 219);
+    background: $gray-100;
+    border-top: 1px solid $gray-200;
+    border-bottom: 1px solid $gray-200;
 }
 
 .mobile-close-container {
     padding-top: 0.5rem;
     padding-bottom: 0.75rem;
-    border-bottom: 1px solid #E4E4E4;
+    border-bottom: 1px solid $gray-200;
 
     span {
         display: inline-block;

--- a/src/courseware/course/Sidebar.scss
+++ b/src/courseware/course/Sidebar.scss
@@ -1,0 +1,63 @@
+@import "~@edx/brand/paragon/fonts";
+@import "~@edx/brand/paragon/variables";
+@import "~@edx/paragon/scss/core/core";
+@import "~@edx/brand/paragon/overrides";
+
+.sidebar-container {
+    border: 1px solid rgb(225, 221, 219);
+    width: 330px;
+    vertical-align: top;
+
+    @media (max-width: map-get($grid-breakpoints, 'md')) {
+        position: fixed; 
+        top: 0; 
+        bottom: 0; 
+        left: 0; 
+        right: 0;
+        width: 100%;
+        height: 100%;
+        background-color: white;
+        margin: 0;
+        border: none;
+    }
+}
+
+.sidebar-header {
+    padding-top: 14px;
+    padding-bottom: 10px;
+    font-size: 1rem;
+
+    span {
+        display: inline-block;
+    }
+}
+
+.close-btn {
+    float: right;
+}
+
+.sidebar-divider {
+    height: 0.5rem;
+    background: rgb(249, 249, 249);
+    border-top: 1px solid rgb(225, 221, 219);
+    border-bottom: 1px solid rgb(225, 221, 219);
+}
+
+.mobile-close-container {
+    padding-top: 0.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #E4E4E4;
+
+    span {
+        display: inline-block;
+    }
+    svg {
+        margin-top: 7px;
+        margin-left: 15px;
+    }
+}
+
+.mobile-close {
+    font-weight: 500;
+    margin-left: 1.5rem;
+}

--- a/src/courseware/course/Sidebar.test.jsx
+++ b/src/courseware/course/Sidebar.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Factory } from 'rosie';
+import {
+  render, initializeTestStore, screen, fireEvent, waitFor,
+} from '../../setupTest';
+import Sidebar from './Sidebar';
+
+describe('Sidebar', () => {
+  let mockData;
+  const courseMetadata = Factory.build('courseMetadata');
+
+  beforeEach(async () => {
+    mockData = {
+      sidebarVisible: false,
+      toggleSidebar: () => {},
+      isResponsiveWidth: false,
+    };
+  });
+
+  it('renders sidebar', async () => {
+    const testStore = await initializeTestStore({ courseMetadata, excludeFetchSequence: true }, false);
+    const testData = { ...mockData, sidebarVisible: true };
+    const { container } = render(<Sidebar {...testData} />, { store: testStore });
+
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveTextContent('Notifications');
+  });
+
+  it('renders sidebar and mobile close button at responsive width', async () => {
+    const sidebarVisible = true;
+    const isResponsiveWidth = true;
+    const toggleSidebar = jest.fn();
+    const testStore = await initializeTestStore({ courseMetadata, excludeFetchSequence: true }, false);
+    const testData = {
+      ...mockData,
+      sidebarVisible,
+      isResponsiveWidth,
+      toggleSidebar,
+    };
+    render(<Sidebar {...testData} />, { store: testStore });
+
+    const responsiveCloseButton = screen.getByRole('button', { name: 'Back to course' });
+    await waitFor(() => expect(responsiveCloseButton).toBeInTheDocument());
+
+    fireEvent.click(responsiveCloseButton);
+    expect(toggleSidebar).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/courseware/course/Sidebar.test.jsx
+++ b/src/courseware/course/Sidebar.test.jsx
@@ -32,7 +32,7 @@ describe('Sidebar', () => {
   });
 
   it('renders no notifications message', async () => {
-    // JK: add conditional if "no notifications"/upgradeable
+    // REV-2130 TODO: add conditional if no expiration box/upgradeable
     const testData = { ...mockData };
     const { container } = render(<Sidebar {...testData} />);
 

--- a/src/courseware/course/Sidebar.test.jsx
+++ b/src/courseware/course/Sidebar.test.jsx
@@ -13,7 +13,7 @@ describe('Sidebar', () => {
     mockData = {
       sidebarVisible: false,
       toggleSidebar: () => {},
-      isResponsiveWidth: false,
+      shouldDisplayFullScreen: false,
     };
   });
 
@@ -28,13 +28,13 @@ describe('Sidebar', () => {
 
   it('renders sidebar and mobile close button at responsive width', async () => {
     const sidebarVisible = true;
-    const isResponsiveWidth = true;
+    const shouldDisplayFullScreen = true;
     const toggleSidebar = jest.fn();
     const testStore = await initializeTestStore({ courseMetadata, excludeFetchSequence: true }, false);
     const testData = {
       ...mockData,
       sidebarVisible,
-      isResponsiveWidth,
+      shouldDisplayFullScreen,
       toggleSidebar,
     };
     render(<Sidebar {...testData} />, { store: testStore });

--- a/src/courseware/course/SidebarNotificationButton.jsx
+++ b/src/courseware/course/SidebarNotificationButton.jsx
@@ -10,11 +10,18 @@ import messages from './messages';
 
 function SidebarNotificationButton({ intl, toggleSidebar, isSidebarVisible }) {
   return (
-    <div className={classNames('sidebar-notification-btn-container', { active: isSidebarVisible() })} data-testid="SidebarButton" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.notificationButton)}>
-      <div className="sidebar-notification-btn">
-        <Icon src={WatchOutline} className="sidebar-notification-icon" alt={intl.formatMessage(messages.notificationButton)} />
-        <span className="notification-dot p-1" />
-      </div>
+    <div
+      className={classNames('sidebar-notification-btn-container', { active: isSidebarVisible() })}
+      data-testid="SidebarButton"
+      role="button"
+      tabIndex="0"
+      onClick={() => { toggleSidebar(); }}
+      onKeyDown={() => { toggleSidebar(); }}
+      alt={intl.formatMessage(messages.notificationButton)}
+    >
+      <Icon src={WatchOutline} className="sidebar-notification-icon" alt={intl.formatMessage(messages.notificationButton)} />
+      {/* JK: add conditional for icon with red dot */}
+      <span className="notification-dot p-1" />
     </div>
   );
 }

--- a/src/courseware/course/SidebarNotificationButton.jsx
+++ b/src/courseware/course/SidebarNotificationButton.jsx
@@ -12,7 +12,6 @@ function SidebarNotificationButton({ intl, toggleSidebar, isSidebarVisible }) {
     <button
       className={classNames('sidebar-notification-btn', { active: isSidebarVisible() })}
       type="button"
-      data-testid="SidebarButton"
       onClick={() => { toggleSidebar(); }}
       alt={intl.formatMessage(messages.notificationButton)}
     >

--- a/src/courseware/course/SidebarNotificationButton.jsx
+++ b/src/courseware/course/SidebarNotificationButton.jsx
@@ -10,7 +10,7 @@ import messages from './messages';
 
 function SidebarNotificationButton({ intl, toggleSidebar, isSidebarVisible }) {
   return (
-    <div className={classNames('sidebar-notification-btn-container', { active: isSidebarVisible() })} onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0">
+    <div className={classNames('sidebar-notification-btn-container', { active: isSidebarVisible() })} data-testid="SidebarButton" onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0" alt={intl.formatMessage(messages.notificationButton)}>
       <div className="sidebar-notification-btn">
         <Icon src={WatchOutline} className="sidebar-notification-icon" alt={intl.formatMessage(messages.notificationButton)} />
         <span className="notification-dot p-1" />

--- a/src/courseware/course/SidebarNotificationButton.jsx
+++ b/src/courseware/course/SidebarNotificationButton.jsx
@@ -16,7 +16,9 @@ function SidebarNotificationButton({ intl, toggleSidebar, isSidebarVisible }) {
       onClick={() => { toggleSidebar(); }}
       alt={intl.formatMessage(messages.notificationButton)}
     >
-      <NotificationIcon status="active" notificationColor="bg-danger-500" />
+      <div className="position-relative d-flex align-items-center" style={{ width: '2.4rem', height: '2rem' }}>
+        <NotificationIcon status="active" notificationColor="bg-danger-500" />
+      </div>
     </button>
   );
 }

--- a/src/courseware/course/SidebarNotificationButton.jsx
+++ b/src/courseware/course/SidebarNotificationButton.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Icon } from '@edx/paragon';
+import { WatchOutline } from '@edx/paragon/icons';
+
+import './SidebarNotificationButton.scss';
+import messages from './messages';
+
+function SidebarNotificationButton({ intl, toggleSidebar, isSidebarVisible }) {
+  return (
+    <div className={classNames('sidebar-notification-btn-container', { active: isSidebarVisible() })} onClick={() => { toggleSidebar(); }} onKeyDown={() => { toggleSidebar(); }} role="button" tabIndex="0">
+      <div className="sidebar-notification-btn">
+        <Icon src={WatchOutline} className="sidebar-notification-icon" alt={intl.formatMessage(messages.notificationButton)} />
+        <span className="notification-dot p-1" />
+      </div>
+    </div>
+  );
+}
+
+SidebarNotificationButton.propTypes = {
+  intl: intlShape.isRequired,
+  toggleSidebar: PropTypes.func.isRequired,
+  isSidebarVisible: PropTypes.func.isRequired,
+};
+
+export default injectIntl(SidebarNotificationButton);

--- a/src/courseware/course/SidebarNotificationButton.jsx
+++ b/src/courseware/course/SidebarNotificationButton.jsx
@@ -2,27 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Icon } from '@edx/paragon';
-import { WatchOutline } from '@edx/paragon/icons';
 
+import NotificationIcon from './NotificationIcon';
 import './SidebarNotificationButton.scss';
 import messages from './messages';
 
 function SidebarNotificationButton({ intl, toggleSidebar, isSidebarVisible }) {
   return (
-    <div
-      className={classNames('sidebar-notification-btn-container', { active: isSidebarVisible() })}
+    <button
+      className={classNames('sidebar-notification-btn', { active: isSidebarVisible() })}
+      type="button"
       data-testid="SidebarButton"
-      role="button"
-      tabIndex="0"
       onClick={() => { toggleSidebar(); }}
-      onKeyDown={() => { toggleSidebar(); }}
       alt={intl.formatMessage(messages.notificationButton)}
     >
-      <Icon src={WatchOutline} className="sidebar-notification-icon" alt={intl.formatMessage(messages.notificationButton)} />
-      {/* JK: add conditional for icon with red dot */}
-      <span className="notification-dot p-1" />
-    </div>
+      <NotificationIcon status="active" notificationColor="bg-danger-500" />
+    </button>
   );
 }
 

--- a/src/courseware/course/SidebarNotificationButton.jsx
+++ b/src/courseware/course/SidebarNotificationButton.jsx
@@ -13,9 +13,10 @@ function SidebarNotificationButton({ intl, toggleSidebar, isSidebarVisible }) {
       className={classNames('sidebar-notification-btn', { active: isSidebarVisible() })}
       type="button"
       onClick={() => { toggleSidebar(); }}
-      alt={intl.formatMessage(messages.notificationButton)}
+      aria-label={intl.formatMessage(messages.openSidebarButton)}
     >
-      <div className="position-relative d-flex align-items-center" style={{ width: '2.4rem', height: '2rem' }}>
+      <div className="icon-container">
+        {/* REV-2130 TODO: add logic for status "active" if red dot should display */}
         <NotificationIcon status="active" notificationColor="bg-danger-500" />
       </div>
     </button>

--- a/src/courseware/course/SidebarNotificationButton.scss
+++ b/src/courseware/course/SidebarNotificationButton.scss
@@ -13,7 +13,7 @@
 
     @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
         border: none;
-        margin: 0.3rem 1.25rem 0 1.25rem;
+        margin: 0.3rem 1.25rem 0 0.25rem;
         top: 0.1rem;
         right: -3rem;
     }
@@ -21,4 +21,12 @@
 
 .active {
     border-bottom: 3px solid $primary-700;
+}
+
+.icon-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 2.4rem;
+    height: 2rem;
 }

--- a/src/courseware/course/SidebarNotificationButton.scss
+++ b/src/courseware/course/SidebarNotificationButton.scss
@@ -4,15 +4,19 @@
 @import "~@edx/brand/paragon/overrides";
 
 .sidebar-notification-btn-container {
-    border: 1px solid $gray-200;
-    width: 54px;
-    height: 40px;
+    border: 1px solid $light-400;
+    width: 3.375rem;
+    height: 2.5rem;
     float: right;
     margin-top: 0.625rem;
 
-    @media (max-width: map-get($grid-breakpoints, 'md')) {
+    position: relative;
+    display: flex;
+	align-items: center;
+
+    @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
         border: none;
-        margin: 5px 20px 0 20px;
+        margin: 0.3rem 1.25rem 0 1.25rem;
     }
 }
 
@@ -20,25 +24,19 @@
     border-bottom: 3px solid $primary-700;
 }
 
-.sidebar-notification-btn {
-    position: relative;
-}
-
 .sidebar-notification-icon {
-    top: 7px;
-    bottom: 13px;
+    position: absolute;
     margin: 0 auto;
-    width: 1.25rem;
 }
 
 .notification-dot {
-    right: 15px;
-    top: 0.5rem;
     background-color: $danger-500;
     border-radius: 50%;
     position: absolute;
-    display: inline-block;
-    @media (max-width: map-get($grid-breakpoints, 'md')) {
-        right: 7px;
+    right: 1rem;
+    top: 0.5rem;
+
+    @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
+        right: 0.5rem;
     }
 }

--- a/src/courseware/course/SidebarNotificationButton.scss
+++ b/src/courseware/course/SidebarNotificationButton.scss
@@ -3,16 +3,15 @@
 @import "~@edx/paragon/scss/core/core";
 @import "~@edx/brand/paragon/overrides";
 
-.sidebar-notification-btn-container {
+.sidebar-notification-btn {
     border: 1px solid $light-400;
+    background: none;
     width: 3.375rem;
     height: 2.5rem;
-    float: right;
     margin-top: 0.625rem;
 
-    position: relative;
-    display: flex;
-	align-items: center;
+    position: absolute;
+    right: 0;
 
     @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
         border: none;
@@ -22,21 +21,4 @@
 
 .active {
     border-bottom: 3px solid $primary-700;
-}
-
-.sidebar-notification-icon {
-    position: absolute;
-    margin: 0 auto;
-}
-
-.notification-dot {
-    background-color: $danger-500;
-    border-radius: 50%;
-    position: absolute;
-    right: 1rem;
-    top: 0.5rem;
-
-    @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
-        right: 0.5rem;
-    }
 }

--- a/src/courseware/course/SidebarNotificationButton.scss
+++ b/src/courseware/course/SidebarNotificationButton.scss
@@ -6,8 +6,6 @@
 .sidebar-notification-btn {
     border: 1px solid $light-400;
     background: none;
-    width: 3.375rem;
-    height: 2.5rem;
     margin-top: 0.625rem;
 
     position: absolute;
@@ -16,6 +14,8 @@
     @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
         border: none;
         margin: 0.3rem 1.25rem 0 1.25rem;
+        top: 0.1rem;
+        right: -3rem;
     }
 }
 

--- a/src/courseware/course/SidebarNotificationButton.scss
+++ b/src/courseware/course/SidebarNotificationButton.scss
@@ -8,7 +8,7 @@
     width: 54px;
     height: 40px;
     float: right;
-    margin-top: 10px;
+    margin-top: 0.625rem;
 
     @media (max-width: map-get($grid-breakpoints, 'md')) {
         border: none;
@@ -28,7 +28,7 @@
     top: 7px;
     bottom: 13px;
     margin: 0 auto;
-    width: 20px;
+    width: 1.25rem;
 }
 
 .notification-dot {

--- a/src/courseware/course/SidebarNotificationButton.scss
+++ b/src/courseware/course/SidebarNotificationButton.scss
@@ -1,0 +1,44 @@
+@import "~@edx/brand/paragon/fonts";
+@import "~@edx/brand/paragon/variables";
+@import "~@edx/paragon/scss/core/core";
+@import "~@edx/brand/paragon/overrides";
+
+.sidebar-notification-btn-container {
+    border: 1px solid $gray-200;
+    width: 54px;
+    height: 40px;
+    float: right;
+    margin-top: 10px;
+
+    @media (max-width: map-get($grid-breakpoints, 'md')) {
+        border: none;
+        margin: 5px 20px 0 20px;
+    }
+}
+
+.active {
+    border-bottom: 3px solid $primary-700;
+}
+
+.sidebar-notification-btn {
+    position: relative;
+}
+
+.sidebar-notification-icon {
+    top: 7px;
+    bottom: 13px;
+    margin: 0 auto;
+    width: 20px;
+}
+
+.notification-dot {
+    right: 15px;
+    top: 0.5rem;
+    background-color: $danger-500;
+    border-radius: 50%;
+    position: absolute;
+    display: inline-block;
+    @media (max-width: map-get($grid-breakpoints, 'md')) {
+        right: 7px;
+    }
+}

--- a/src/courseware/course/messages.js
+++ b/src/courseware/course/messages.js
@@ -1,0 +1,26 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  notificationButton: {
+    id: 'sidebar.notificationButton',
+    defaultMessage: 'Sidebar notification button',
+    description: 'Button to open the sidebar',
+  },
+  closeButton: {
+    id: 'sidebar.closeButton',
+    defaultMessage: 'Close',
+    description: 'Button for the learner to close the sidebar',
+  },
+  responsiveCloseSidebar: {
+    id: 'sidebar.responsiveCloseSidebar',
+    defaultMessage: 'Back to course',
+    description: 'Responsive link for the learner to go back to course and close sidebar',
+  },
+  notification: {
+    id: 'sidebar.notification',
+    defaultMessage: 'Notifications',
+    description: 'Text displayed for sidebar notifications',
+  },
+});
+
+export default messages;

--- a/src/courseware/course/messages.js
+++ b/src/courseware/course/messages.js
@@ -1,25 +1,35 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
-  notificationButton: {
-    id: 'sidebar.notificationButton',
-    defaultMessage: 'Sidebar notification button',
-    description: 'Button to open the sidebar',
+  sidebarNotification: {
+    id: 'sidebar.notification.container',
+    defaultMessage: 'Sidebar notification',
+    description: 'Sidebar notification section container',
   },
-  closeButton: {
-    id: 'sidebar.closeButton',
-    defaultMessage: 'Close',
+  openSidebarButton: {
+    id: 'sidebar.open.button',
+    defaultMessage: 'Show sidebar notification',
+    description: 'Button to open the sidebar and show notifications',
+  },
+  closeSidebarButton: {
+    id: 'sidebar.close.button',
+    defaultMessage: 'Close sidebar notification',
     description: 'Button for the learner to close the sidebar',
   },
   responsiveCloseSidebar: {
-    id: 'sidebar.responsiveCloseSidebar',
+    id: 'sidebar.responsive.close.button',
     defaultMessage: 'Back to course',
-    description: 'Responsive link for the learner to go back to course and close sidebar',
+    description: 'Responsive button for the learner to go back to course and close the sidebar',
   },
-  notification: {
-    id: 'sidebar.notification',
+  notificationTitle: {
+    id: 'sidebar.notification.title',
     defaultMessage: 'Notifications',
-    description: 'Text displayed for sidebar notifications',
+    description: 'Title text displayed for sidebar notifications',
+  },
+  noNotificationsMessage: {
+    id: 'sidebar.notification.no.message',
+    defaultMessage: 'You have no new notifications at this time.',
+    description: 'Text displayed when the learner has no notifications',
   },
 });
 

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -3,6 +3,7 @@ import React, {
   useEffect, useContext, useState,
 } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import {
   sendTrackEvent,
   sendTrackingLogEvent,
@@ -20,6 +21,8 @@ import messages from './messages';
 import { SequenceNavigation, UnitNavigation } from './sequence-navigation';
 import SequenceContent from './SequenceContent';
 import Sidebar from '../Sidebar';
+import SidebarNotificationButton from '../SidebarNotificationButton';
+import useWindowSize from '../../../generic/tabs/useWindowSize';
 
 /** [MM-P2P] Experiment */
 import { isMobile } from '../../../experiments/mm-p2p/utils';
@@ -36,8 +39,6 @@ function Sequence({
   toggleSidebar,
   sidebarVisible,
   isSidebarVisible,
-  isTabletWidth,
-  isMobileWidth,
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
@@ -147,11 +148,13 @@ function Sequence({
     history.push(`/course/${courseId}/course-end`);
   };
 
+  const shouldDisplaySidebarButton = useWindowSize().width < 576;
+
   if (sequenceStatus === 'loaded') {
     return (
       <div>
         <div className="sequence-container" style={{ display: 'inline-flex', flexDirection: 'row' }}>
-          <div className="sequence" style={{ width: '100%' }}>
+          <div className={classNames('sequence', { 'position-relative': shouldDisplaySidebarButton })} style={{ width: '100%' }}>
             <SequenceNavigation
               sequenceId={sequenceId}
               unitId={unitId}
@@ -175,8 +178,15 @@ function Sequence({
               goToCourseExitPage={() => goToCourseExitPage()}
               toggleSidebar={toggleSidebar}
               isSidebarVisible={isSidebarVisible}
-              isMobileWidth={isMobileWidth}
             />
+
+            {shouldDisplaySidebarButton ? (
+              <SidebarNotificationButton
+                toggleSidebar={toggleSidebar}
+                isSidebarVisible={isSidebarVisible}
+              />
+            ) : null}
+
             <div className="unit-container flex-grow-1">
               <SequenceContent
                 courseId={courseId}
@@ -204,11 +214,13 @@ function Sequence({
               )}
             </div>
           </div>
-          <Sidebar
-            toggleSidebar={toggleSidebar}
-            sidebarVisible={sidebarVisible}
-            isTabletWidth={isTabletWidth}
-          />
+
+          {sidebarVisible ? (
+            <Sidebar
+              toggleSidebar={toggleSidebar}
+              sidebarVisible={sidebarVisible}
+            />
+          ) : null }
 
           {/** [MM-P2P] Experiment */}
           {(mmp2p.state.isEnabled && mmp2p.flyover.isVisible) && (
@@ -241,8 +253,6 @@ Sequence.propTypes = {
   toggleSidebar: PropTypes.func,
   sidebarVisible: PropTypes.bool,
   isSidebarVisible: PropTypes.func,
-  isTabletWidth: PropTypes.bool,
-  isMobileWidth: PropTypes.bool,
 
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
@@ -264,8 +274,6 @@ Sequence.defaultProps = {
   toggleSidebar: null,
   sidebarVisible: null,
   isSidebarVisible: null,
-  isTabletWidth: null,
-  isMobileWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -36,7 +36,7 @@ function Sequence({
   toggleSidebar,
   sidebarVisible,
   isSidebarVisible,
-  isMobileWidth,
+  isResponsiveWidth,
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
@@ -174,7 +174,7 @@ function Sequence({
               goToCourseExitPage={() => goToCourseExitPage()}
               toggleSidebar={toggleSidebar}
               isSidebarVisible={isSidebarVisible}
-              isMobileWidth={isMobileWidth}
+              isResponsiveWidth={isResponsiveWidth}
             />
             <div className="unit-container flex-grow-1">
               <SequenceContent
@@ -203,11 +203,10 @@ function Sequence({
               )}
             </div>
           </div>
-
           <Sidebar
             toggleSidebar={toggleSidebar}
             sidebarVisible={sidebarVisible}
-            isMobileWidth={isMobileWidth}
+            isResponsiveWidth={isResponsiveWidth}
           />
 
           {/** [MM-P2P] Experiment */}
@@ -238,10 +237,10 @@ Sequence.propTypes = {
   nextSequenceHandler: PropTypes.func.isRequired,
   previousSequenceHandler: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
-  toggleSidebar: PropTypes.func.isRequired,
-  sidebarVisible: PropTypes.bool.isRequired,
-  isSidebarVisible: PropTypes.func.isRequired,
-  isMobileWidth: PropTypes.bool.isRequired,
+  toggleSidebar: PropTypes.func,
+  sidebarVisible: PropTypes.bool,
+  isSidebarVisible: PropTypes.func,
+  isResponsiveWidth: PropTypes.bool,
 
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
@@ -260,6 +259,10 @@ Sequence.propTypes = {
 Sequence.defaultProps = {
   sequenceId: null,
   unitId: null,
+  toggleSidebar: null,
+  sidebarVisible: null,
+  isSidebarVisible: null,
+  isResponsiveWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -39,6 +39,7 @@ function Sequence({
   toggleSidebar,
   sidebarVisible,
   isSidebarVisible,
+  isCookieSet,
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
@@ -176,11 +177,10 @@ function Sequence({
                 handlePrevious();
               }}
               goToCourseExitPage={() => goToCourseExitPage()}
-              toggleSidebar={toggleSidebar}
-              isSidebarVisible={isSidebarVisible}
+              isCookieSet={isCookieSet}
             />
 
-            {shouldDisplaySidebarButton ? (
+            {shouldDisplaySidebarButton && isCookieSet ? (
               <SidebarNotificationButton
                 toggleSidebar={toggleSidebar}
                 isSidebarVisible={isSidebarVisible}
@@ -253,6 +253,7 @@ Sequence.propTypes = {
   toggleSidebar: PropTypes.func,
   sidebarVisible: PropTypes.bool,
   isSidebarVisible: PropTypes.func,
+  isCookieSet: PropTypes.bool,
 
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
@@ -274,6 +275,7 @@ Sequence.defaultProps = {
   toggleSidebar: null,
   sidebarVisible: null,
   isSidebarVisible: null,
+  isCookieSet: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -19,6 +19,7 @@ import CourseLicense from '../course-license';
 import messages from './messages';
 import { SequenceNavigation, UnitNavigation } from './sequence-navigation';
 import SequenceContent from './SequenceContent';
+import Sidebar from '../Sidebar';
 
 /** [MM-P2P] Experiment */
 import { isMobile } from '../../../experiments/mm-p2p/utils';
@@ -32,6 +33,10 @@ function Sequence({
   nextSequenceHandler,
   previousSequenceHandler,
   intl,
+  toggleSidebar,
+  sidebarVisible,
+  isSidebarVisible,
+  isMobileWidth,
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
@@ -167,6 +172,9 @@ function Sequence({
                 handlePrevious();
               }}
               goToCourseExitPage={() => goToCourseExitPage()}
+              toggleSidebar={toggleSidebar}
+              isSidebarVisible={isSidebarVisible}
+              isMobileWidth={isMobileWidth}
             />
             <div className="unit-container flex-grow-1">
               <SequenceContent
@@ -196,6 +204,12 @@ function Sequence({
             </div>
           </div>
 
+          <Sidebar
+            toggleSidebar={toggleSidebar}
+            sidebarVisible={sidebarVisible}
+            isMobileWidth={isMobileWidth}
+          />
+
           {/** [MM-P2P] Experiment */}
           {(mmp2p.state.isEnabled && mmp2p.flyover.isVisible) && (
             isMobile()
@@ -224,6 +238,10 @@ Sequence.propTypes = {
   nextSequenceHandler: PropTypes.func.isRequired,
   previousSequenceHandler: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
+  toggleSidebar: PropTypes.func.isRequired,
+  sidebarVisible: PropTypes.bool.isRequired,
+  isSidebarVisible: PropTypes.func.isRequired,
+  isMobileWidth: PropTypes.bool.isRequired,
 
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -36,7 +36,8 @@ function Sequence({
   toggleSidebar,
   sidebarVisible,
   isSidebarVisible,
-  isResponsiveWidth,
+  isTabletWidth,
+  isMobileWidth,
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
@@ -174,7 +175,7 @@ function Sequence({
               goToCourseExitPage={() => goToCourseExitPage()}
               toggleSidebar={toggleSidebar}
               isSidebarVisible={isSidebarVisible}
-              isResponsiveWidth={isResponsiveWidth}
+              isMobileWidth={isMobileWidth}
             />
             <div className="unit-container flex-grow-1">
               <SequenceContent
@@ -206,7 +207,7 @@ function Sequence({
           <Sidebar
             toggleSidebar={toggleSidebar}
             sidebarVisible={sidebarVisible}
-            isResponsiveWidth={isResponsiveWidth}
+            isTabletWidth={isTabletWidth}
           />
 
           {/** [MM-P2P] Experiment */}
@@ -240,7 +241,8 @@ Sequence.propTypes = {
   toggleSidebar: PropTypes.func,
   sidebarVisible: PropTypes.bool,
   isSidebarVisible: PropTypes.func,
-  isResponsiveWidth: PropTypes.bool,
+  isTabletWidth: PropTypes.bool,
+  isMobileWidth: PropTypes.bool,
 
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
@@ -262,7 +264,8 @@ Sequence.defaultProps = {
   toggleSidebar: null,
   sidebarVisible: null,
   isSidebarVisible: null,
-  isResponsiveWidth: null,
+  isTabletWidth: null,
+  isMobileWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/Sequence.test.jsx
+++ b/src/courseware/course/sequence/Sequence.test.jsx
@@ -28,6 +28,7 @@ describe('Sequence', () => {
       unitNavigationHandler: () => {},
       nextSequenceHandler: () => {},
       previousSequenceHandler: () => {},
+      sidebarVisible: false,
     };
   });
 
@@ -127,6 +128,16 @@ describe('Sequence', () => {
     await waitFor(() => expect(screen.queryByText('Loading learning sequence...')).not.toBeInTheDocument());
     // At this point there will be 2 `Previous` and 2 `Next` buttons.
     expect(screen.getAllByRole('button', { name: /previous|next/i }).length).toEqual(4);
+  });
+
+  it('renders sidebar in sequence', async () => {
+    const testData = {
+      ...mockData,
+      sidebarVisible: true,
+    };
+
+    render(<Sequence {...testData} />);
+    expect(await screen.findByText('Notifications')).toBeInTheDocument();
   });
 
   describe('sequence and unit navigation buttons', () => {

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -95,7 +95,6 @@ function SequenceNavigation({
 
       {/** [MM-P2P] Experiment */}
       { mmp2p.state.isEnabled && <MMP2PFlyoverTriggerMobile options={mmp2p} /> }
-      <div className="rev1512ToggleFlyoverSequenceLocation" />
     </nav>
   );
 }

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -30,7 +30,7 @@ function SequenceNavigation({
   goToCourseExitPage,
   toggleSidebar,
   isSidebarVisible,
-  isMobileWidth,
+  isResponsiveWidth,
   mmp2p,
 }) {
   const sequence = useModel('sequences', sequenceId);
@@ -71,7 +71,7 @@ function SequenceNavigation({
     const disabled = isLastUnit && !exitActive;
     return (
       <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled}>
-        {!isMobileWidth ? buttonText : null}
+        {!isResponsiveWidth ? buttonText : null}
         <FontAwesomeIcon icon={faChevronRight} className="ml-2" size="sm" />
       </Button>
     );
@@ -81,12 +81,12 @@ function SequenceNavigation({
     <nav className={classNames('sequence-navigation', className)}>
       <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit}>
         <FontAwesomeIcon icon={faChevronLeft} className="mr-2" size="sm" />
-        {!isMobileWidth ? intl.formatMessage(messages.previousButton) : null}
+        {!isResponsiveWidth ? intl.formatMessage(messages.previousButton) : null}
       </Button>
       {renderUnitButtons()}
       {renderNextButton()}
 
-      {isMobileWidth ? (
+      {isResponsiveWidth ? (
         <SidebarNotificationButton
           toggleSidebar={toggleSidebar}
           isSidebarVisible={isSidebarVisible}
@@ -109,9 +109,9 @@ SequenceNavigation.propTypes = {
   nextSequenceHandler: PropTypes.func.isRequired,
   previousSequenceHandler: PropTypes.func.isRequired,
   goToCourseExitPage: PropTypes.func.isRequired,
-  toggleSidebar: PropTypes.func.isRequired,
-  isSidebarVisible: PropTypes.func.isRequired,
-  isMobileWidth: PropTypes.bool.isRequired,
+  toggleSidebar: PropTypes.func,
+  isSidebarVisible: PropTypes.func,
+  isResponsiveWidth: PropTypes.bool,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({
@@ -123,6 +123,9 @@ SequenceNavigation.propTypes = {
 SequenceNavigation.defaultProps = {
   className: null,
   unitId: null,
+  toggleSidebar: null,
+  isSidebarVisible: null,
+  isResponsiveWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -13,6 +13,7 @@ import SequenceNavigationTabs from './SequenceNavigationTabs';
 import { useSequenceNavigationMetadata } from './hooks';
 import { useModel } from '../../../../generic/model-store';
 import { LOADED } from '../../../data/slice';
+import SidebarNotificationButton from '../../SidebarNotificationButton';
 
 import messages from './messages';
 /** [MM-P2P] Experiment */
@@ -27,6 +28,9 @@ function SequenceNavigation({
   nextSequenceHandler,
   previousSequenceHandler,
   goToCourseExitPage,
+  toggleSidebar,
+  isSidebarVisible,
+  isMobileWidth,
   mmp2p,
 }) {
   const sequence = useModel('sequences', sequenceId);
@@ -67,7 +71,7 @@ function SequenceNavigation({
     const disabled = isLastUnit && !exitActive;
     return (
       <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled}>
-        {buttonText}
+        {!isMobileWidth ? buttonText : null}
         <FontAwesomeIcon icon={faChevronRight} className="ml-2" size="sm" />
       </Button>
     );
@@ -77,10 +81,17 @@ function SequenceNavigation({
     <nav className={classNames('sequence-navigation', className)}>
       <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit}>
         <FontAwesomeIcon icon={faChevronLeft} className="mr-2" size="sm" />
-        {intl.formatMessage(messages.previousButton)}
+        {!isMobileWidth ? intl.formatMessage(messages.previousButton) : null}
       </Button>
       {renderUnitButtons()}
       {renderNextButton()}
+
+      {isMobileWidth ? (
+        <SidebarNotificationButton
+          toggleSidebar={toggleSidebar}
+          isSidebarVisible={isSidebarVisible}
+        />
+      ) : null}
 
       {/** [MM-P2P] Experiment */}
       { mmp2p.state.isEnabled && <MMP2PFlyoverTriggerMobile options={mmp2p} /> }
@@ -98,6 +109,9 @@ SequenceNavigation.propTypes = {
   nextSequenceHandler: PropTypes.func.isRequired,
   previousSequenceHandler: PropTypes.func.isRequired,
   goToCourseExitPage: PropTypes.func.isRequired,
+  toggleSidebar: PropTypes.func.isRequired,
+  isSidebarVisible: PropTypes.func.isRequired,
+  isMobileWidth: PropTypes.bool.isRequired,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -30,7 +30,7 @@ function SequenceNavigation({
   goToCourseExitPage,
   toggleSidebar,
   isSidebarVisible,
-  isResponsiveWidth,
+  isMobileWidth,
   mmp2p,
 }) {
   const sequence = useModel('sequences', sequenceId);
@@ -71,8 +71,8 @@ function SequenceNavigation({
     const disabled = isLastUnit && !exitActive;
     return (
       <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled}>
-        {!isResponsiveWidth ? buttonText : null}
-        <FontAwesomeIcon icon={faChevronRight} className="ml-2" size="sm" />
+        {!isMobileWidth ? buttonText : null}
+        <FontAwesomeIcon icon={faChevronRight} className="mx-3 mr-sm-0 ml-sm-2" size="sm" />
       </Button>
     );
   };
@@ -80,13 +80,13 @@ function SequenceNavigation({
   return sequenceStatus === LOADED && (
     <nav className={classNames('sequence-navigation', className)}>
       <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit}>
-        <FontAwesomeIcon icon={faChevronLeft} className="mr-2" size="sm" />
-        {!isResponsiveWidth ? intl.formatMessage(messages.previousButton) : null}
+        <FontAwesomeIcon icon={faChevronLeft} className="mx-3 ml-sm-0 mr-sm-2" size="sm" />
+        {!isMobileWidth ? intl.formatMessage(messages.previousButton) : null}
       </Button>
       {renderUnitButtons()}
       {renderNextButton()}
 
-      {isResponsiveWidth ? (
+      {isMobileWidth ? (
         <SidebarNotificationButton
           toggleSidebar={toggleSidebar}
           isSidebarVisible={isSidebarVisible}
@@ -110,7 +110,7 @@ SequenceNavigation.propTypes = {
   goToCourseExitPage: PropTypes.func.isRequired,
   toggleSidebar: PropTypes.func,
   isSidebarVisible: PropTypes.func,
-  isResponsiveWidth: PropTypes.bool,
+  isMobileWidth: PropTypes.bool,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({
@@ -124,7 +124,7 @@ SequenceNavigation.defaultProps = {
   unitId: null,
   toggleSidebar: null,
   isSidebarVisible: null,
-  isResponsiveWidth: null,
+  isMobileWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -78,7 +78,7 @@ function SequenceNavigation({
   };
 
   return sequenceStatus === LOADED && (
-    <nav className={classNames('sequence-navigation', className, { 'mr-4': !shouldDisplaySidebarButton && isCookieSet })}>
+    <nav className={classNames('sequence-navigation', className)} style={{ width: shouldDisplaySidebarButton ? '90%' : null }}>
       <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit}>
         <FontAwesomeIcon icon={faChevronLeft} className="mx-3 ml-sm-0 mr-sm-2" size="sm" />
         {shouldDisplaySidebarButton ? null : intl.formatMessage(messages.previousButton)}

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -28,6 +28,7 @@ function SequenceNavigation({
   nextSequenceHandler,
   previousSequenceHandler,
   goToCourseExitPage,
+  isCookieSet,
   mmp2p,
 }) {
   const sequence = useModel('sequences', sequenceId);
@@ -40,7 +41,7 @@ function SequenceNavigation({
     sequence.gatedContent !== undefined && sequence.gatedContent.gated
   ) : undefined;
 
-  const shouldDisplaySidebarButton = useWindowSize().width > 576;
+  const shouldDisplaySidebarButton = useWindowSize().width < 576 && isCookieSet;
 
   const renderUnitButtons = () => {
     if (isLocked) {
@@ -70,17 +71,17 @@ function SequenceNavigation({
     const disabled = isLastUnit && !exitActive;
     return (
       <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled}>
-        {shouldDisplaySidebarButton ? buttonText : null}
+        {shouldDisplaySidebarButton ? null : buttonText}
         <FontAwesomeIcon icon={faChevronRight} className="mx-3 mr-sm-0 ml-sm-2" size="sm" />
       </Button>
     );
   };
 
   return sequenceStatus === LOADED && (
-    <nav className={classNames('sequence-navigation', className, { 'mr-4': !shouldDisplaySidebarButton })}>
+    <nav className={classNames('sequence-navigation', className, { 'mr-4': !shouldDisplaySidebarButton && isCookieSet })}>
       <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit}>
         <FontAwesomeIcon icon={faChevronLeft} className="mx-3 ml-sm-0 mr-sm-2" size="sm" />
-        {shouldDisplaySidebarButton ? intl.formatMessage(messages.previousButton) : null}
+        {shouldDisplaySidebarButton ? null : intl.formatMessage(messages.previousButton)}
       </Button>
       {renderUnitButtons()}
       {renderNextButton()}
@@ -100,6 +101,7 @@ SequenceNavigation.propTypes = {
   nextSequenceHandler: PropTypes.func.isRequired,
   previousSequenceHandler: PropTypes.func.isRequired,
   goToCourseExitPage: PropTypes.func.isRequired,
+  isCookieSet: PropTypes.bool,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({
@@ -111,6 +113,7 @@ SequenceNavigation.propTypes = {
 SequenceNavigation.defaultProps = {
   className: null,
   unitId: null,
+  isCookieSet: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -12,8 +12,8 @@ import UnitButton from './UnitButton';
 import SequenceNavigationTabs from './SequenceNavigationTabs';
 import { useSequenceNavigationMetadata } from './hooks';
 import { useModel } from '../../../../generic/model-store';
+import useWindowSize from '../../../../generic/tabs/useWindowSize';
 import { LOADED } from '../../../data/slice';
-import SidebarNotificationButton from '../../SidebarNotificationButton';
 
 import messages from './messages';
 /** [MM-P2P] Experiment */
@@ -28,9 +28,6 @@ function SequenceNavigation({
   nextSequenceHandler,
   previousSequenceHandler,
   goToCourseExitPage,
-  toggleSidebar,
-  isSidebarVisible,
-  isMobileWidth,
   mmp2p,
 }) {
   const sequence = useModel('sequences', sequenceId);
@@ -42,6 +39,8 @@ function SequenceNavigation({
   const isLocked = sequenceStatus === LOADED ? (
     sequence.gatedContent !== undefined && sequence.gatedContent.gated
   ) : undefined;
+
+  const shouldDisplaySidebarButton = useWindowSize().width > 576;
 
   const renderUnitButtons = () => {
     if (isLocked) {
@@ -71,27 +70,20 @@ function SequenceNavigation({
     const disabled = isLastUnit && !exitActive;
     return (
       <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled}>
-        {!isMobileWidth ? buttonText : null}
+        {shouldDisplaySidebarButton ? buttonText : null}
         <FontAwesomeIcon icon={faChevronRight} className="mx-3 mr-sm-0 ml-sm-2" size="sm" />
       </Button>
     );
   };
 
   return sequenceStatus === LOADED && (
-    <nav className={classNames('sequence-navigation', className)}>
+    <nav className={classNames('sequence-navigation', className, { 'mr-4': !shouldDisplaySidebarButton })}>
       <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit}>
         <FontAwesomeIcon icon={faChevronLeft} className="mx-3 ml-sm-0 mr-sm-2" size="sm" />
-        {!isMobileWidth ? intl.formatMessage(messages.previousButton) : null}
+        {shouldDisplaySidebarButton ? intl.formatMessage(messages.previousButton) : null}
       </Button>
       {renderUnitButtons()}
       {renderNextButton()}
-
-      {isMobileWidth ? (
-        <SidebarNotificationButton
-          toggleSidebar={toggleSidebar}
-          isSidebarVisible={isSidebarVisible}
-        />
-      ) : null}
 
       {/** [MM-P2P] Experiment */}
       { mmp2p.state.isEnabled && <MMP2PFlyoverTriggerMobile options={mmp2p} /> }
@@ -108,9 +100,6 @@ SequenceNavigation.propTypes = {
   nextSequenceHandler: PropTypes.func.isRequired,
   previousSequenceHandler: PropTypes.func.isRequired,
   goToCourseExitPage: PropTypes.func.isRequired,
-  toggleSidebar: PropTypes.func,
-  isSidebarVisible: PropTypes.func,
-  isMobileWidth: PropTypes.bool,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({
@@ -122,9 +111,6 @@ SequenceNavigation.propTypes = {
 SequenceNavigation.defaultProps = {
   className: null,
   unitId: null,
-  toggleSidebar: null,
-  isSidebarVisible: null,
-  isMobileWidth: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -29,6 +29,7 @@ describe('Sequence Navigation', () => {
       onNavigate: () => {},
       nextSequenceHandler: () => {},
       goToCourseExitPage: () => {},
+      isMobileWidth: false,
     };
   });
 
@@ -161,5 +162,18 @@ describe('Sequence Navigation', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
     expect(nextSequenceHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders sidebar notification button in sequence', async () => {
+    const toggleSidebar = jest.fn();
+    const isSidebarVisible = jest.fn();
+    const isMobileWidth = true;
+    render(<SequenceNavigation {...mockData} {...{ toggleSidebar, isSidebarVisible, isMobileWidth }} />);
+
+    const sidebarButton = screen.getByRole('button', { name: /Sidebar notification button/i });
+
+    expect(sidebarButton).toBeInTheDocument();
+    fireEvent.click(sidebarButton);
+    expect(toggleSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -29,7 +29,7 @@ describe('Sequence Navigation', () => {
       onNavigate: () => {},
       nextSequenceHandler: () => {},
       goToCourseExitPage: () => {},
-      isResponsiveWidth: false,
+      shouldDisplaySidebarButton: false,
     };
   });
 
@@ -167,8 +167,8 @@ describe('Sequence Navigation', () => {
   it('renders sidebar notification button in sequence', async () => {
     const toggleSidebar = jest.fn();
     const isSidebarVisible = jest.fn();
-    const isResponsiveWidth = true;
-    render(<SequenceNavigation {...mockData} {...{ toggleSidebar, isSidebarVisible, isResponsiveWidth }} />);
+    const shouldDisplaySidebarButton = true;
+    render(<SequenceNavigation {...mockData} {...{ toggleSidebar, isSidebarVisible, shouldDisplaySidebarButton }} />);
 
     const sidebarButton = screen.getByRole('button', { name: /Sidebar notification button/i });
 

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -29,7 +29,6 @@ describe('Sequence Navigation', () => {
       onNavigate: () => {},
       nextSequenceHandler: () => {},
       goToCourseExitPage: () => {},
-      shouldDisplaySidebarButton: false,
     };
   });
 
@@ -162,18 +161,5 @@ describe('Sequence Navigation', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
     expect(nextSequenceHandler).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders sidebar notification button in sequence', async () => {
-    const toggleSidebar = jest.fn();
-    const isSidebarVisible = jest.fn();
-    const shouldDisplaySidebarButton = true;
-    render(<SequenceNavigation {...mockData} {...{ toggleSidebar, isSidebarVisible, shouldDisplaySidebarButton }} />);
-
-    const sidebarButton = screen.getByRole('button', { name: /Sidebar notification button/i });
-
-    expect(sidebarButton).toBeInTheDocument();
-    fireEvent.click(sidebarButton);
-    expect(toggleSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -29,7 +29,7 @@ describe('Sequence Navigation', () => {
       onNavigate: () => {},
       nextSequenceHandler: () => {},
       goToCourseExitPage: () => {},
-      isMobileWidth: false,
+      isResponsiveWidth: false,
     };
   });
 
@@ -167,8 +167,8 @@ describe('Sequence Navigation', () => {
   it('renders sidebar notification button in sequence', async () => {
     const toggleSidebar = jest.fn();
     const isSidebarVisible = jest.fn();
-    const isMobileWidth = true;
-    render(<SequenceNavigation {...mockData} {...{ toggleSidebar, isSidebarVisible, isMobileWidth }} />);
+    const isResponsiveWidth = true;
+    render(<SequenceNavigation {...mockData} {...{ toggleSidebar, isSidebarVisible, isResponsiveWidth }} />);
 
     const sidebarButton = screen.getByRole('button', { name: /Sidebar notification button/i });
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -94,6 +94,12 @@
   }
 }
 
+.breadcrumb-container {
+  @media (min-width: map-get($grid-breakpoints, 'sm')) {
+    max-width: 1440px;
+  }
+}
+
 .sequence-container {
   display: flex;
   flex-direction: column;
@@ -361,6 +367,8 @@
 
 // Import component-specific sass files
 @import 'courseware/course/celebration/CelebrationModal.scss';
+@import 'courseware/course/Sidebar.scss';
+@import 'courseware/course/SidebarNotificationButton.scss';
 @import 'shared/streak-celebration/StreakCelebrationModal.scss';
 @import 'courseware/course/content-tools/calculator/calculator.scss';
 @import 'courseware/course/content-tools/contentTools.scss';

--- a/src/index.scss
+++ b/src/index.scss
@@ -95,6 +95,8 @@
 }
 
 .breadcrumb-container {
+  position: relative;
+
   @media (min-width: map-get($grid-breakpoints, 'sm')) {
     max-width: 1440px;
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -251,6 +251,7 @@
   }
 
   .previous-btn, .next-btn {
+    border: 1px solid $light-400 !important;
     color: $gray-700;
     display: inline-flex;
     justify-content: center;


### PR DESCRIPTION
**_EDIT: build is failing for unknown reasons, I made a duplicate of this PR and divided the commit that was failing at unrelated tests, and all of them passed. Duplicate PR here https://github.com/edx/frontend-app-learning/pull/414_**

[REV-2125](https://openedx.atlassian.net/browse/REV-2125).

For Value Prop implementation, we will implement a sidebar that is triggered on click of a button with upgrade messaging and CTA. Pls note this ticket does not cover adding the upgrade messaging and CTA, it only covers adding the button trigger and sidebar component. 

Large screen size (> 992px):
<img width="1225" alt="Screen Shot 2021-04-08 at 12 49 43 PM" src="https://user-images.githubusercontent.com/13632680/114065766-0488e300-9869-11eb-95f7-6ea984e27c9d.png">
<img width="1224" alt="Screen Shot 2021-04-08 at 12 49 51 PM" src="https://user-images.githubusercontent.com/13632680/114065759-02268900-9869-11eb-9fc3-983ed7ddd98b.png">

Responsive at medium screen sizes (> 576px and < 992px): it has the button like large and above screen size, but the sidebar behaves in full width mode like for small screens. 
<img width="948" alt="Screen Shot 2021-04-08 at 12 57 28 PM" src="https://user-images.githubusercontent.com/13632680/114066914-38b0d380-986a-11eb-851b-0979e76a00ee.png">
<img width="947" alt="Screen Shot 2021-04-08 at 12 57 37 PM" src="https://user-images.githubusercontent.com/13632680/114066910-38183d00-986a-11eb-807e-f59005cbdbd0.png">

Responsive at small screen sizes (< 576px):
<img width="953" alt="Screen Shot 2021-04-08 at 1 03 12 PM" src="https://user-images.githubusercontent.com/13632680/114067415-cbea0900-986a-11eb-81c2-e7e5ab4c490d.png">
<img width="953" alt="Screen Shot 2021-04-08 at 1 02 26 PM" src="https://user-images.githubusercontent.com/13632680/114067353-ba086600-986a-11eb-9c94-3e32dc5d7f59.png">


