### PR TITLE
feat: handle courseware paths more liberally

### DIFF
--- a/docs/decisions/0002-courseware-page-decisions.md
+++ b/docs/decisions/0002-courseware-page-decisions.md
@@ -37,6 +37,9 @@ Today, if the URL only specifies the course ID, we need to pick a sequence to sh
 
 Similarly, if the URL doesn't contain a unit ID, we use the `position` field of the sequence to determine which unit we want to display from that sequence.  If the position isn't specified in the sequence, we choose the first unit of the sequence.  After determining which unit to display, we update the URL to match.  After the URL is updated, the application will attempt to load that unit via an iFrame.
 
+_This URL scheme has been expanded upon in
+[ADR #8: Liberal courseware path handling](./0008-liberal-courseware-path-handling.md)._
+
 ## "Container" components vs. display components
 
 This application makes use of a few "container" components at the top level - CoursewareContainer and CourseHomeContainer.

--- a/docs/decisions/0008-liberal-courseware-path-handling.md
+++ b/docs/decisions/0008-liberal-courseware-path-handling.md
@@ -1,0 +1,90 @@
+# Liberal courseware path handling
+
+## Status
+
+Accepted
+
+_This updates some of the content in [ADR #2: Courseware page decisions](./0002-courseware-page-decisions.md)._
+
+## Context
+
+The courseware container currently accepts three path forms:
+
+1. `/course/:courseId`
+2. `/course/:courseId/:sequenceId`
+3. `/course/:courseId/:sequenceId/:unitId`
+
+Forms #1 and #2 are always redirected to Form #3 via simple set of rules:
+
+* If the sequenceId is not specified, choose the first sequence in the course.
+* If the unitId is not specified, choose the active unit in the sequence,
+  or the first unit if none are active.
+
+Thus, Form #3 is effectively the canonoical path;
+all Learning MFE units should be served from it.
+We acknowledge that the best user experience is to link directly to the canonoical
+path when possible, since it skips the redirection steps.
+Still, there are times when it is necessary or prudent to link just to a course or
+a sequence.
+
+Through recent work in the LMS, we are realizing that there are _also_ times where it
+would be simpler or more performant to link a user to an
+_entire section without specifying a squence_ or to a
+_unit without including the sequence_.
+Specifically, this capability would let as avoid further modulestore or
+block transformer queries in order to discern the course structure when trying to
+direct a learner to a section or unit.
+Futhermore, we hypothesize that being able to build a Learning MFE courseware link
+with just a unit ID or a section ID will be a nice simplifying quality for future
+development or debugging.
+
+## Decision
+
+The courseware container will accept five total path forms:
+
+1. `/course/:courseId`
+2. `/course/:courseId/:sectionId`
+3. `/course/:courseId/:sectionId/:unitId`
+4. `/course/:courseId/:sequenceId`
+5. `/course/:courseId/:unitId`
+6. `/course/:courseId/:sequenceId/:unitId`
+
+The redirection rules are as follows:
+
+* Forms #1 redirects to Form #4 by selecting the first sequence in the course.
+* Form #2 redirects to Form #4 by selecting to the first sequence in the section.
+* Form #3 redirects to Form #5 by dropping the section ID.
+* Form #4 redirects to Form #6 by choosing the active unit in the sequence
+  (or the first unit, if none are active).
+* Form #5 redirects to Form #6 by filling in the ID of the sequence that the
+  specified unit belongs to (in the edge case where the unit belongs to multiple
+  sequences, the first sequence is selected).
+
+As before, Form #5 is the canonocial courseware path, which is always redirected to
+by any of the other courseware path forms.
+
+## Consequences
+
+The above decision is implemented.
+
+## Further work
+
+At some point, we may decide to further extend the URL scheme to be
+more human-readable.
+
+We can't make UsageKeys themselves more readable because they're tied to student state,
+but we could introduce a new optional `slug` field on Sequences,
+which would be captured and propagated to the learning_sequences API.
+We could eventually do something similar to Units, since those slugs only have to be sequence-local.
+
+So eventually, URLs could look less like:
+
+```
+
+https://learning.edx.org/course/course-v1:edX+DemoX.1+2T2019/block-v1:edX+DemoX.1+2T2019+type@sequential+block@e0a61b3d5a2046949e76d12cac5df493/block-v1:edX+DemoX.1+2T2019+type@vertical+block@52dbad5a28e140f291a476f92ce11996
+```
+
+And more like:
+```
+https://learning.edx.org/course/course-v1:edX+DemoX.1+2T2019/Being_Social/Teams
+```

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -141,6 +141,9 @@ class CoursewareContainer extends Component {
     // All courseware URLs should normalize to the format /course/:courseId/:sequenceId/:unitId
     // via the series of redirection rules below.
     // See docs/decisions/0008-liberal-courseware-path-handling.md for more context.
+    // (It would be ideal to move this logic into the thunks layer and perform
+    //  all URL-changing checks at once. This should be done once the MFE is moved
+    //  to the new Outlines API. See TNL-8182.)
 
     // Check resume redirect:
     //   /course/:courseId -> /course/:courseId/:sequenceId/:unitId

--- a/src/courseware/CoursewareContainer.test.jsx
+++ b/src/courseware/CoursewareContainer.test.jsx
@@ -141,7 +141,7 @@ describe('CoursewareContainer', () => {
       courseBlocks = result.courseBlocks;
       unitBlocks = result.unitBlocks;
       // eslint-disable-next-line prefer-destructuring
-      sequenceBlock = result.sequenceBlock[0];
+      sequenceBlock = result.sequenceBlocks[0];
 
       sequenceMetadata = Factory.build(
         'sequenceMetadata',
@@ -334,7 +334,9 @@ describe('CoursewareContainer', () => {
         },
       });
       const courseId = courseMetadata.id;
-      const { courseBlocks, unitBlocks, sequenceBlock } = buildSimpleCourseBlocks(courseId, courseMetadata.name);
+      const { courseBlocks, unitBlocks, sequenceBlocks: [sequenceBlock] } = buildSimpleCourseBlocks(
+        courseId, courseMetadata.name,
+      );
       const sequenceMetadata = Factory.build(
         'sequenceMetadata',
         {},

--- a/src/courseware/course/sequence/Sequence.test.jsx
+++ b/src/courseware/course/sequence/Sequence.test.jsx
@@ -40,29 +40,29 @@ describe('Sequence', () => {
   });
 
   it('renders correctly for gated content', async () => {
-    const sequenceBlock = [Factory.build(
+    const sequenceBlocks = [Factory.build(
       'block',
       { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
       { courseId: courseMetadata.id },
     )];
     const gatedContent = {
       gated: true,
-      prereq_id: `${sequenceBlock[0].id}-prereq`,
-      prereq_section_name: `${sequenceBlock[0].display_name}-prereq`,
-      gated_section_name: sequenceBlock[0].display_name,
+      prereq_id: `${sequenceBlocks[0].id}-prereq`,
+      prereq_section_name: `${sequenceBlocks[0].display_name}-prereq`,
+      gated_section_name: sequenceBlocks[0].display_name,
     };
     const sequenceMetadata = [Factory.build(
       'sequenceMetadata',
       { gated_content: gatedContent },
-      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlock[0] },
+      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlocks[0] },
     )];
     const testStore = await initializeTestStore(
       {
-        courseMetadata, unitBlocks, sequenceBlock, sequenceMetadata,
+        courseMetadata, unitBlocks, sequenceBlocks, sequenceMetadata,
       }, false,
     );
     const { container } = render(
-      <Sequence {...mockData} {...{ sequenceId: sequenceBlock[0].id }} />,
+      <Sequence {...mockData} {...{ sequenceId: sequenceBlocks[0].id }} />,
       { store: testStore },
     );
 
@@ -83,7 +83,7 @@ describe('Sequence', () => {
     // application redirects away from the page.  Note that this component is not responsible for
     // that redirect behavior, so there's no record of it here.
     // See CoursewareContainer.jsx "checkExamRedirect" function.
-    const sequenceBlock = [Factory.build(
+    const sequenceBlocks = [Factory.build(
       'block',
       { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
       { courseId: courseMetadata.id },
@@ -91,15 +91,15 @@ describe('Sequence', () => {
     const sequenceMetadata = [Factory.build(
       'sequenceMetadata',
       { is_time_limited: true },
-      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlock[0] },
+      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlocks[0] },
     )];
     const testStore = await initializeTestStore(
       {
-        courseMetadata, unitBlocks, sequenceBlock, sequenceMetadata,
+        courseMetadata, unitBlocks, sequenceBlocks, sequenceMetadata,
       }, false,
     );
     const { container } = render(
-      <Sequence {...mockData} {...{ sequenceId: sequenceBlock[0].id }} />,
+      <Sequence {...mockData} {...{ sequenceId: sequenceBlocks[0].id }} />,
       { store: testStore },
     );
 
@@ -131,7 +131,7 @@ describe('Sequence', () => {
 
   describe('sequence and unit navigation buttons', () => {
     let testStore;
-    const sequenceBlock = [Factory.build(
+    const sequenceBlocks = [Factory.build(
       'block',
       { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
       { courseId: courseMetadata.id },
@@ -142,7 +142,7 @@ describe('Sequence', () => {
     )];
 
     beforeAll(async () => {
-      testStore = await initializeTestStore({ courseMetadata, unitBlocks, sequenceBlock }, false);
+      testStore = await initializeTestStore({ courseMetadata, unitBlocks, sequenceBlocks }, false);
     });
 
     beforeEach(() => {
@@ -152,7 +152,7 @@ describe('Sequence', () => {
     it('navigates to the previous sequence if the unit is the first in the sequence', async () => {
       const testData = {
         ...mockData,
-        sequenceId: sequenceBlock[1].id,
+        sequenceId: sequenceBlocks[1].id,
         previousSequenceHandler: jest.fn(),
       };
       render(<Sequence {...testData} />, { store: testStore });
@@ -187,7 +187,7 @@ describe('Sequence', () => {
       const testData = {
         ...mockData,
         unitId: unitBlocks[unitBlocks.length - 1].id,
-        sequenceId: sequenceBlock[0].id,
+        sequenceId: sequenceBlocks[0].id,
         nextSequenceHandler: jest.fn(),
       };
       render(<Sequence {...testData} />, { store: testStore });
@@ -222,7 +222,7 @@ describe('Sequence', () => {
       const testData = {
         ...mockData,
         unitId: unitBlocks[unitNumber].id,
-        sequenceId: sequenceBlock[0].id,
+        sequenceId: sequenceBlocks[0].id,
         unitNavigationHandler: jest.fn(),
         previousSequenceHandler: jest.fn(),
         nextSequenceHandler: jest.fn(),
@@ -246,7 +246,7 @@ describe('Sequence', () => {
       const testData = {
         ...mockData,
         unitId: unitBlocks[0].id,
-        sequenceId: sequenceBlock[0].id,
+        sequenceId: sequenceBlocks[0].id,
         unitNavigationHandler: jest.fn(),
         previousSequenceHandler: jest.fn(),
       };
@@ -265,7 +265,7 @@ describe('Sequence', () => {
       const testData = {
         ...mockData,
         unitId: unitBlocks[unitBlocks.length - 1].id,
-        sequenceId: sequenceBlock[sequenceBlock.length - 1].id,
+        sequenceId: sequenceBlocks[sequenceBlocks.length - 1].id,
         unitNavigationHandler: jest.fn(),
         nextSequenceHandler: jest.fn(),
       };
@@ -281,7 +281,7 @@ describe('Sequence', () => {
     });
 
     it('handles the navigation buttons for empty sequence', async () => {
-      const testSequenceBlock = [Factory.build(
+      const testSequenceBlocks = [Factory.build(
         'block',
         { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
         { courseId: courseMetadata.id },
@@ -294,18 +294,18 @@ describe('Sequence', () => {
         { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
         { courseId: courseMetadata.id },
       )];
-      const testSequenceMetadata = testSequenceBlock.map(block => Factory.build(
+      const testSequenceMetadata = testSequenceBlocks.map(block => Factory.build(
         'sequenceMetadata',
         {},
         { courseId: courseMetadata.id, unitBlocks: block.children.length ? unitBlocks : [], sequenceBlock: block },
       ));
       const innerTestStore = await initializeTestStore({
-        courseMetadata, unitBlocks, sequenceBlock: testSequenceBlock, sequenceMetadata: testSequenceMetadata,
+        courseMetadata, unitBlocks, sequenceBlocks: testSequenceBlocks, sequenceMetadata: testSequenceMetadata,
       }, false);
       const testData = {
         ...mockData,
         unitId: unitBlocks[0].id,
-        sequenceId: testSequenceBlock[1].id,
+        sequenceId: testSequenceBlocks[1].id,
         unitNavigationHandler: jest.fn(),
         previousSequenceHandler: jest.fn(),
         nextSequenceHandler: jest.fn(),
@@ -356,7 +356,7 @@ describe('Sequence', () => {
       const testData = {
         ...mockData,
         unitId: unitBlocks[currentTabNumber - 1].id,
-        sequenceId: sequenceBlock[0].id,
+        sequenceId: sequenceBlocks[0].id,
         unitNavigationHandler: jest.fn(),
       };
       render(<Sequence {...testData} />, { store: testStore });

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -46,7 +46,7 @@ describe('Sequence Navigation', () => {
   });
 
   it('renders locked button for gated content', async () => {
-    const sequenceBlock = [Factory.build(
+    const sequenceBlocks = [Factory.build(
       'block',
       { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
       { courseId: courseMetadata.id },
@@ -54,12 +54,12 @@ describe('Sequence Navigation', () => {
     const sequenceMetadata = [Factory.build(
       'sequenceMetadata',
       { gated_content: { gated: true } },
-      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlock[0] },
+      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlocks[0] },
     )];
-    const testStore = await initializeTestStore({ unitBlocks, sequenceBlock, sequenceMetadata }, false);
+    const testStore = await initializeTestStore({ unitBlocks, sequenceBlocks, sequenceMetadata }, false);
     const testData = {
       ...mockData,
-      sequenceId: sequenceBlock[0].id,
+      sequenceId: sequenceBlocks[0].id,
       onNavigate: jest.fn(),
     };
     render(<SequenceNavigation {...testData} />, { store: testStore });

--- a/src/courseware/data/__factories__/sequenceMetadata.factory.js
+++ b/src/courseware/data/__factories__/sequenceMetadata.factory.js
@@ -75,8 +75,8 @@ export default function buildSimpleCourseAndSequenceMetadata(options = {}) {
   });
   const courseId = courseMetadata.id;
   const simpleCourseBlocks = buildSimpleCourseBlocks(courseId, courseMetadata.name, options);
-  const { unitBlocks, sequenceBlock } = simpleCourseBlocks;
-  const sequenceMetadata = options.sequenceMetadata || sequenceBlock.map(block => Factory.build(
+  const { unitBlocks, sequenceBlocks } = simpleCourseBlocks;
+  const sequenceMetadata = options.sequenceMetadata || sequenceBlocks.map(block => Factory.build(
     'sequenceMetadata',
     {},
     {

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -164,6 +164,7 @@ function normalizeSequenceMetadata(sequence) {
   return {
     sequence: {
       id: sequence.item_id,
+      blockType: sequence.tag,
       unitIds: sequence.items.map(unit => unit.id),
       bannerText: sequence.banner_text,
       format: sequence.format,

--- a/src/courseware/data/redux.test.js
+++ b/src/courseware/data/redux.test.js
@@ -115,6 +115,22 @@ describe('Data layer integration tests', () => {
       expect(store.getState().courseware.sequenceStatus).toEqual('failed');
     });
 
+    it('Should result in fetch failure if a non-sequential block is returned', async () => {
+      const sectionMetadata = {
+        ...sequenceMetadata,
+        // 'chapter' is the block_type of a Section, which the sequence metadata
+        // API will happily return if requested, since SectionBlock is implemented
+        // as a subclass of SequenceBlock.
+        tag: 'chapter',
+      };
+      axiosMock.onGet(sequenceUrl).reply(200, sectionMetadata);
+
+      await executeThunk(thunks.fetchSequence(sequenceId), store.dispatch);
+
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(store.getState().courseware.sequenceStatus).toEqual('failed');
+    });
+
     it('Should fetch and normalize metadata, and then update existing models with sequence metadata', async () => {
       axiosMock.onGet(courseUrl).reply(200, courseMetadata);
       axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);

--- a/src/courseware/data/redux.test.js
+++ b/src/courseware/data/redux.test.js
@@ -24,18 +24,18 @@ describe('Data layer integration tests', () => {
   // building minimum set of api responses to test all thunks
   const courseMetadata = Factory.build('courseMetadata');
   const courseId = courseMetadata.id;
-  const { courseBlocks, unitBlocks, sequenceBlock } = buildSimpleCourseBlocks(courseId);
+  const { courseBlocks, unitBlocks, sequenceBlocks } = buildSimpleCourseBlocks(courseId);
   const sequenceMetadata = Factory.build(
     'sequenceMetadata',
     {},
-    { courseId, unitBlocks, sequenceBlock: sequenceBlock[0] },
+    { courseId, unitBlocks, sequenceBlock: sequenceBlocks[0] },
   );
 
   let courseUrl = `${courseBaseUrl}/${courseId}`;
   courseUrl = appendBrowserTimezoneToUrl(courseUrl);
 
   const sequenceUrl = `${sequenceBaseUrl}/${sequenceMetadata.item_id}`;
-  const sequenceId = sequenceBlock[0].id;
+  const sequenceId = sequenceBlocks[0].id;
   const unitId = unitBlocks[0].id;
 
   let store;

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -132,7 +132,7 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
   axiosMock.reset();
 
   const {
-    courseBlocks, sequenceBlock, courseMetadata, sequenceMetadata,
+    courseBlocks, sequenceBlocks, courseMetadata, sequenceMetadata,
   } = buildSimpleCourseAndSequenceMetadata(options);
 
   let forbiddenCourseUrl = `${getConfig().LMS_BASE_URL}/api/courseware/course/${courseMetadata.id}`;
@@ -153,7 +153,7 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
   !options.excludeFetchCourse && await executeThunk(fetchCourse(courseMetadata.id), store.dispatch);
 
   if (!options.excludeFetchSequence) {
-    await Promise.all(sequenceBlock
+    await Promise.all(sequenceBlocks
       .map(block => executeThunk(fetchSequence(block.id), store.dispatch)));
   }
 

--- a/src/shared/data/__factories__/courseBlocks.factory.js
+++ b/src/shared/data/__factories__/courseBlocks.factory.js
@@ -16,35 +16,39 @@ const getBlocks = (attr) => {
 
 Factory.define('courseBlocks')
   .option('courseId', 'course-v1:edX+DemoX+Demo_Course')
-  .option('units', ['courseId'], courseId => ([
+  .option('units', ['courseId'], courseId => [
     Factory.build(
       'block',
       { type: 'vertical' },
       { courseId },
     ),
-  ]))
-  .option('sequence', ['courseId', 'units'], (courseId, child) => Factory.build(
+  ])
+  .option('sequences', ['courseId', 'units'], (courseId, units) => [
+    Factory.build(
+      'block',
+      { type: 'sequential', children: getIds(units) },
+      { courseId },
+    ),
+  ])
+  .option('sections', ['courseId', 'sequences'], (courseId, sequences) => [
+    Factory.build(
+      'block',
+      { type: 'chapter', children: getIds(sequences) },
+      { courseId },
+    ),
+  ])
+  .option('course', ['courseId', 'sections'], (courseId, sections) => Factory.build(
     'block',
-    { type: 'sequential', children: getIds(child) },
-    { courseId },
-  ))
-  .option('section', ['courseId', 'sequence'], (courseId, child) => Factory.build(
-    'block',
-    { type: 'chapter', children: getIds(child) },
-    { courseId },
-  ))
-  .option('course', ['courseId', 'section'], (courseId, child) => Factory.build(
-    'block',
-    { type: 'course', children: getIds(child) },
+    { type: 'course', children: getIds(sections) },
     { courseId },
   ))
   .attr(
     'blocks',
-    ['course', 'section', 'sequence', 'units'],
-    (course, section, sequence, units) => ({
+    ['course', 'sections', 'sequences', 'units'],
+    (course, sections, sequences, units) => ({
       [course.id]: course,
-      ...getBlocks(section),
-      ...getBlocks(sequence),
+      ...getBlocks(sections),
+      ...getBlocks(sequences),
       ...getBlocks(units),
     }),
   )
@@ -59,19 +63,19 @@ export function buildSimpleCourseBlocks(courseId, title, options = {}) {
     { type: 'vertical' },
     { courseId },
   )];
-  const sequenceBlock = options.sequenceBlock || [Factory.build(
+  const sequenceBlocks = options.sequenceBlocks || [Factory.build(
     'block',
     { type: 'sequential', children: unitBlocks.map(block => block.id) },
     { courseId },
   )];
-  const sectionBlock = options.sectionBlock || Factory.build(
+  const sectionBlocks = options.sectionBlocks || [Factory.build(
     'block',
-    { type: 'chapter', children: sequenceBlock.map(block => block.id) },
+    { type: 'chapter', children: sequenceBlocks.map(block => block.id) },
     { courseId },
-  );
-  const courseBlock = options.courseBlocks || Factory.build(
+  )];
+  const courseBlock = options.courseBlock || Factory.build(
     'block',
-    { type: 'course', display_name: title, children: [sectionBlock.id] },
+    { type: 'course', display_name: title, children: sectionBlocks.map(block => block.id) },
     { courseId },
   );
   return {
@@ -84,14 +88,14 @@ export function buildSimpleCourseBlocks(courseId, title, options = {}) {
       },
       {
         units: unitBlocks,
-        sequence: sequenceBlock,
-        section: sectionBlock,
+        sequences: sequenceBlocks,
+        sections: sectionBlocks,
         course: courseBlock,
       },
     ),
     unitBlocks,
-    sequenceBlock,
-    sectionBlock,
+    sequenceBlocks,
+    sectionBlocks,
     courseBlock,
   };
 }
@@ -100,12 +104,12 @@ export function buildSimpleCourseBlocks(courseId, title, options = {}) {
  * Builds a course with a single chapter and sequence, but no units.
  */
 export function buildMinimalCourseBlocks(courseId, title, options = {}) {
-  const sequenceBlock = options.sequenceBlock || [Factory.build(
+  const sequenceBlocks = options.sequenceBlocks || [Factory.build(
     'block',
     { display_name: 'Title of Sequence', type: 'sequential' },
     { courseId },
   )];
-  const sectionBlock = options.sectionBlock || Factory.build(
+  const sectionBlocks = options.sectionBlocks || [Factory.build(
     'block',
     {
       type: 'chapter',
@@ -114,13 +118,13 @@ export function buildMinimalCourseBlocks(courseId, title, options = {}) {
       effort_time: 15,
       effort_activities: 2,
       resume_block: options.resumeBlock || false,
-      children: sequenceBlock.map(block => block.id),
+      children: sequenceBlocks.map(block => block.id),
     },
     { courseId },
-  );
+  )];
   const courseBlock = options.courseBlock || Factory.build(
     'block',
-    { type: 'course', display_name: title, children: [sectionBlock.id] },
+    { type: 'course', display_name: title, children: sectionBlocks.map(block => block.id) },
     { courseId },
   );
   return {
@@ -128,15 +132,15 @@ export function buildMinimalCourseBlocks(courseId, title, options = {}) {
       'courseBlocks',
       { courseId },
       {
-        sequence: sequenceBlock,
-        section: sectionBlock,
+        sequences: sequenceBlocks,
+        sections: sectionBlocks,
         course: courseBlock,
         units: [],
       },
     ),
     unitBlocks: [],
-    sequenceBlock,
-    sectionBlock,
+    sequenceBlocks,
+    sectionBlocks,
     courseBlock,
   };
 }

--- a/src/shared/data/__factories__/courseBlocks.factory.js
+++ b/src/shared/data/__factories__/courseBlocks.factory.js
@@ -144,3 +144,93 @@ export function buildMinimalCourseBlocks(courseId, title, options = {}) {
     courseBlock,
   };
 }
+
+/**
+ * Builds a course with two branches at each node. That is:
+ *
+ *                  Crs
+ *                   |
+ *        Sec--------+-------Sec
+ *         |                  |
+ *   Seq---+---Seq      Seq---+---Seq
+ *    |         |        |         |
+ * U--+--U   U--+--U  U--+--U   U--+--U
+ *                          ^
+ *
+ * Each left branch is indexed 0, and each right branch is indexed 1.
+ * So, the caret in the diagram above is pointing to `unitTree[1][0][1]`,
+ * whose parent is `sequenceTree[1][0]`, whose parent is `sectionTree[1]`.
+ */
+export function buildBinaryCourseBlocks(courseId, title) {
+  const sectionTree = [];
+  const sequenceTree = [[], []];
+  const unitTree = [[[], []], [[], []]];
+  [0, 1].forEach(sectionIndex => {
+    [0, 1].forEach(sequenceIndex => {
+      [0, 1].forEach(unitIndex => {
+        unitTree[sectionIndex][sequenceIndex][unitIndex] = Factory.build(
+          'block',
+          { type: 'vertical' },
+          { courseId },
+        );
+      });
+      sequenceTree[sectionIndex][sequenceIndex] = Factory.build(
+        'block',
+        { type: 'sequential', children: unitTree[sectionIndex][sequenceIndex].map(block => block.id) },
+        { courseId },
+      );
+    });
+    sectionTree[sectionIndex] = Factory.build(
+      'block',
+      { type: 'chapter', children: sequenceTree[sectionIndex].map(block => block.id) },
+      { courseId },
+    );
+  });
+  const courseBlock = Factory.build(
+    'block',
+    { type: 'course', display_name: title, children: sectionTree.map(block => block.id) },
+    { courseId },
+  );
+  const sectionBlocks = [
+    sectionTree[0],
+    sectionTree[1],
+  ];
+  const sequenceBlocks = [
+    sequenceTree[0][0],
+    sequenceTree[0][1],
+    sequenceTree[1][0],
+    sequenceTree[1][1],
+  ];
+  const unitBlocks = [
+    unitTree[0][0][0],
+    unitTree[0][0][1],
+    unitTree[0][1][0],
+    unitTree[0][1][1],
+    unitTree[1][0][0],
+    unitTree[1][0][1],
+    unitTree[1][1][0],
+    unitTree[1][1][1],
+  ];
+  return {
+    // Expose blocks as a combined list, lists separated by type, and as
+    // trees separated by type. The caller can decide which they want to
+    // work with.
+    courseBlocks: Factory.build(
+      'courseBlocks',
+      { courseId },
+      {
+        units: unitBlocks,
+        sequences: sequenceBlocks,
+        sections: sectionBlocks,
+        course: courseBlock,
+      },
+    ),
+    unitBlocks,
+    sequenceBlocks,
+    sectionBlocks,
+    courseBlock,
+    unitTree,
+    sequenceTree,
+    sectionTree,
+  };
+}


### PR DESCRIPTION
```
Valid courseware URLs currently include:
* /course/:courseId
* /course/:courseId/:sequenceId
* /course/:courseId/:sequenceId/:unitId

In this commit we add support for:
* /course/:courseId/:sectionId
* /course/:courseId/:sectionId/:unitId
* /course/:courseId/:unitId

All URL forms still redirect to:
  /course/:courseId/:sequenceId/:unitId

See ADR #8 for more context.
```

I recommend reviewing commit-by-commit. I did my best to break up the feature change from all the refactorings.

Blocks https://github.com/edx/edx-platform/pull/26816
Part of https://openedx.atlassian.net/browse/TNL-7796
