### PR TITLE
[AA-713] fix: remove extra x in first section celebration modal

### DIFF
--- a/src/courseware/course/celebration/CelebrationModal.scss
+++ b/src/courseware/course/celebration/CelebrationModal.scss
@@ -11,10 +11,6 @@
       position: absolute;
       right: 1rem;
     }
-
-    button::after {
-      content: "⨉";
-    }
   }
 
   .modal-body {


### PR DESCRIPTION
x icon that was added to paragon as part of the streak celebration modal is redundant with the x added to only the first section celebration modal

fixing this bug:
<img width="468" alt="Screen Shot 2021-03-22 at 8 39 25 AM" src="https://user-images.githubusercontent.com/5958221/111990929-1d17a000-8aea-11eb-988b-9b3583636139.png">
