### PR TITLE
update other course approved messaging

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -759,7 +759,7 @@ describe('Outline Tab', () => {
       expect(screen.queryByRole('link', { name: 'Complete Onboarding' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Review instructions and system requirements' })).toBeInTheDocument();
       expect(screen.queryByText('You must complete the onboarding process prior to taking any proctored exam.')).not.toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).not.toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).not.toBeInTheDocument();
     });
 
     it('appears for rejected', async () => {
@@ -774,7 +774,7 @@ describe('Outline Tab', () => {
       expect(screen.queryByRole('link', { name: 'Complete Onboarding' })).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Review instructions and system requirements' })).toBeInTheDocument();
       expect(screen.queryByText('You must complete the onboarding process prior to taking any proctored exam.')).toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).toBeInTheDocument();
     });
 
     it('appears for submitted', async () => {
@@ -787,7 +787,7 @@ describe('Outline Tab', () => {
       await fetchAndRender();
       await screen.findByText('This course contains proctored exams');
       expect(screen.queryByText('Your submitted profile is in review.')).toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).toBeInTheDocument();
     });
 
     it('appears for second_review_required', async () => {
@@ -800,7 +800,7 @@ describe('Outline Tab', () => {
       await fetchAndRender();
       await screen.findByText('This course contains proctored exams');
       expect(screen.queryByText('Your submitted profile is in review.')).toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).toBeInTheDocument();
     });
 
     it('appears for other_course_approved if not expiring soon', async () => {
@@ -815,8 +815,8 @@ describe('Outline Tab', () => {
       });
       await fetchAndRender();
       await screen.findByText('This course contains proctored exams');
-      expect(screen.queryByText('Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, it is highly recommended that you complete this course’s onboarding exam in order to ensure that your device still meets the requirements for proctoring.')).toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).not.toBeInTheDocument();
+      expect(screen.queryByText('You are eligible to take proctored exams in this course.')).toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).not.toBeInTheDocument();
     });
 
     it('displays expiration warning', async () => {
@@ -832,7 +832,7 @@ describe('Outline Tab', () => {
       await fetchAndRender();
       await screen.findByText('This course contains proctored exams');
       expect(screen.queryByText('Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, your onboarding status is expiring soon. Please complete onboarding again to ensure that you will be able to continue taking proctored exams.')).toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).toBeInTheDocument();
     });
 
     it('appears for no status', async () => {
@@ -847,7 +847,7 @@ describe('Outline Tab', () => {
       expect(screen.queryByRole('link', { name: 'Complete Onboarding' })).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Review instructions and system requirements' })).toBeInTheDocument();
       expect(screen.queryByText('You must complete the onboarding process prior to taking any proctored exam.')).toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).toBeInTheDocument();
     });
 
     it('does not appear for 404', async () => {
@@ -887,7 +887,7 @@ describe('Outline Tab', () => {
       expect(screen.queryByRole('link', { name: 'Complete Onboarding' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Review instructions and system requirements' })).toBeInTheDocument();
       expect(screen.queryByText('You must complete the onboarding process prior to taking any proctored exam.')).not.toBeInTheDocument();
-      expect(screen.queryByText('Onboarding profile review, including identity verification, can take 2+ business days.')).not.toBeInTheDocument();
+      expect(screen.queryByText('Onboarding profile review can take 2+ business days.')).not.toBeInTheDocument();
     });
   });
 

--- a/src/course-home/outline-tab/messages.js
+++ b/src/course-home/outline-tab/messages.js
@@ -178,9 +178,17 @@ const messages = defineMessages({
   },
   otherCourseApprovedProctoringMessage: {
     id: 'learning.proctoringPanel.message.otherCourseApproved',
-    defaultMessage: 'Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, it is highly recommended that you complete this course’s onboarding exam in order to ensure that your device still meets the requirements for proctoring.',
+    defaultMessage: 'You are eligible to take proctored exams in this course.',
+  },
+  otherCourseApprovedProctoringDetail: {
+    id: 'learning.proctoringPanel.detail.otherCourseApproved',
+    defaultMessage: 'If your device has changed, we recommend that you complete this course\'s onboarding exam in order to ensure that your setup still meets the requirements for proctoring.',
   },
   expiringSoonProctoringMessage: {
+    id: 'learning.proctoringPanel.message.expiringSoon',
+    defaultMessage: 'Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, your onboarding status is expiring soon. Please complete onboarding again to ensure that you will be able to continue taking proctored exams.',
+  },
+  expiringSoonProctoringDetail: {
     id: 'learning.proctoringPanel.message.expiringSoon',
     defaultMessage: 'Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, your onboarding status is expiring soon. Please complete onboarding again to ensure that you will be able to continue taking proctored exams.',
   },
@@ -194,11 +202,15 @@ const messages = defineMessages({
   },
   proctoringPanelGeneralTime: {
     id: 'learning.proctoringPanel.generalTime',
-    defaultMessage: 'Onboarding profile review, including identity verification, can take 2+ business days.',
+    defaultMessage: 'Onboarding profile review can take 2+ business days.',
   },
   proctoringOnboardingButton: {
     id: 'learning.proctoringPanel.onboardingButton',
     defaultMessage: 'Complete Onboarding',
+  },
+  proctoringOnboardingPracticeButton: {
+    id: 'learning.proctoringPanel.onboardingPracticeButton',
+    defaultMessage: 'View Onboarding Exam',
   },
   proctoringOnboardingButtonNotOpen: {
     id: 'learning.proctoringPanel.onboardingButtonNotOpen',

--- a/src/course-home/outline-tab/messages.js
+++ b/src/course-home/outline-tab/messages.js
@@ -188,10 +188,6 @@ const messages = defineMessages({
     id: 'learning.proctoringPanel.message.expiringSoon',
     defaultMessage: 'Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, your onboarding status is expiring soon. Please complete onboarding again to ensure that you will be able to continue taking proctored exams.',
   },
-  expiringSoonProctoringDetail: {
-    id: 'learning.proctoringPanel.message.expiringSoon',
-    defaultMessage: 'Your onboarding profile has been approved in another course, so you are eligible to take proctored exams in this course. However, your onboarding status is expiring soon. Please complete onboarding again to ensure that you will be able to continue taking proctored exams.',
-  },
   proctoringPanelGeneralInfo: {
     id: 'learning.proctoringPanel.generalInfo',
     defaultMessage: 'You must complete the onboarding process prior to taking any proctored exam. ',

--- a/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
+++ b/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
@@ -106,6 +106,9 @@ function ProctoringInfoPanel({ courseId, intl }) {
                 <p>
                   {intl.formatMessage(messages[`${readableStatus}ProctoringMessage`])}
                 </p>
+                <p>
+                  {readableStatus === readableStatuses.otherCourseApproved && intl.formatMessage(messages[`${readableStatus}ProctoringDetail`])}
+                </p>
               </>
             )}
             {![readableStatuses.verified, readableStatuses.otherCourseApproved].includes(readableStatus) && (
@@ -129,7 +132,16 @@ function ProctoringInfoPanel({ courseId, intl }) {
               <>
                 {!isNotYetReleased(releaseDate) && (
                   <Button variant="primary" block href={`${getConfig().LMS_BASE_URL}${link}`}>
-                    {intl.formatMessage(messages.proctoringOnboardingButton)}
+                    {readableStatus === readableStatuses.otherCourseApproved && (
+                      <>
+                        {intl.formatMessage(messages.proctoringOnboardingPracticeButton)}
+                      </>
+                    )}
+                    {readableStatus !== readableStatuses.otherCourseApproved && (
+                      <>
+                        {intl.formatMessage(messages.proctoringOnboardingButton)}
+                      </>
+                    )}
                   </Button>
                 )}
                 {isNotYetReleased(releaseDate) && (


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

### [MST-687](https://openedx.atlassian.net/browse/MST-687)

Messaging updates to the outline onboarding widget

1. Soften the language asking learners to try onboarding again if they are approved in another course. Also reduce the amount of text for this state.
2. Remove identity verification language because it may cause confusion with IDV

![Screen Shot 2021-03-25 at 11 55 42 AM](https://user-images.githubusercontent.com/5661461/112503166-12b30b80-8d61-11eb-9a05-4ac1b17b5126.png)
