### PR TITLE
[REV-2127] feat: ahead of value prop designs, update content lock text

### DIFF
--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
@@ -19,14 +19,6 @@ describe('Lock Paywall', () => {
     mockData.courseId = courseware.courseId;
   });
 
-  it('displays message along with lock icon', () => {
-    const { container } = render(<LockPaywall {...mockData} />);
-
-    const lockIcon = container.querySelector('svg');
-    expect(lockIcon).toHaveClass('fa-lock');
-    expect(lockIcon.parentElement).toHaveTextContent('Verified Track Access');
-  });
-
   it('displays unlock link with price', () => {
     const {
       currencySymbol,
@@ -35,7 +27,7 @@ describe('Lock Paywall', () => {
     } = store.getState().models.coursewareMeta[mockData.courseId].verifiedMode;
     render(<LockPaywall {...mockData} />);
 
-    const upgradeLink = screen.getByRole('link', { name: `Upgrade to unlock (${currencySymbol}${price})` });
+    const upgradeLink = screen.getByRole('link', { name: `Upgrade for ${currencySymbol}${price}` });
     expect(upgradeLink).toHaveAttribute('href', `${upgradeUrl}`);
   });
 
@@ -48,7 +40,7 @@ describe('Lock Paywall', () => {
     } = store.getState().models.coursewareMeta[mockData.courseId].verifiedMode;
     render(<LockPaywall {...mockData} />);
 
-    const upgradeLink = screen.getByRole('link', { name: `Upgrade to unlock (${currencySymbol}${price})` });
+    const upgradeLink = screen.getByRole('link', { name: `Upgrade for ${currencySymbol}${price}` });
     fireEvent.click(upgradeLink);
 
     expect(sendTrackEvent).toHaveBeenCalledTimes(1);

--- a/src/courseware/course/sequence/lock-paywall/messages.js
+++ b/src/courseware/course/sequence/lock-paywall/messages.js
@@ -3,23 +3,48 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 const messages = defineMessages({
   'learn.lockPaywall.title': {
     id: 'learn.lockPaywall.title',
-    defaultMessage: 'Verified Track Access',
+    defaultMessage: 'Graded assignments are locked',
     description: 'Heading for message shown to indicate that a piece of content is unavailable to audit track users.',
   },
   'learn.lockPaywall.content': {
     id: 'learn.lockPaywall.content',
-    defaultMessage: 'Graded assessments are available to Verified Track learners.',
+    defaultMessage: 'Upgrade to gain access to locked features like this one and get the most out of your course.',
     description: 'Message shown to indicate that a piece of content is unavailable to audit track users.',
   },
   'learn.lockPaywall.upgrade.link': {
     id: 'learn.lockPaywall.upgrade.link',
-    defaultMessage: 'Upgrade to unlock ({currencySymbol}{price})',
+    defaultMessage: 'Upgrade for {currencySymbol}{price}',
     description: 'A link users can click that navigates their browser to the upgrade payment page.',
   },
   'learn.lockPaywall.example.alt': {
     id: 'learn.lockPaywall.example.alt',
     defaultMessage: 'Example Certificate',
     description: 'Alternate text displayed when the example certificate image cannot be displayed.',
+  },
+  'learn.lockPaywall.list.intro': {
+    id: 'learn.lockPaywall.list.intro',
+    defaultMessage: 'When you upgrade, you:',
+    description: 'Text displayed to introduce the list of benefits from upgrading.',
+  },
+  'learn.lockPaywall.list.bullet1.linktext': {
+    id: 'learn.lockPaywall.list.bullet1.linktext',
+    defaultMessage: 'verified certificate',
+    description: 'Link text for verified certificate info page.',
+  },
+  'learn.lockPaywall.list.bullet2.boldtext': {
+    id: 'learn.lockPaywall.list.bullet2.boldtext',
+    defaultMessage: 'graded assignments',
+    description: 'Bolded text for graded assignments.',
+  },
+  'learn.lockPaywall.list.bullet3.boldtext': {
+    id: 'learn.lockPaywall.list.bullet3.boldtext',
+    defaultMessage: 'Full access',
+    description: 'Bolded text for full access.',
+  },
+  'learn.lockPaywall.list.bullet4.boldtext': {
+    id: 'learn.lockPaywall.list.bullet4.boldtext',
+    defaultMessage: 'non-profit',
+    description: 'Bolded text to highlight our non-profit status.',
   },
 });
 


### PR DESCRIPTION
Ticket REV-2127 captures the value prop designs for the gated content lock page- this work is done in [PR 394](https://github.com/edx/frontend-app-learning/pull/394). Deploying that code depends on first fixing existing bug REV-2160, so in the meantime let's deploy the new and updated messages so transifex can make sure we have our Spanish strings (and other languages) populated when the design changes are ready to deploy. 

This includes: change of text, updated use of paragon components, icons, and styling.

Note: in updating the wording for tests, I removed an old test for the previous lock/text (rather than replacing it) because of [this repo guideline](https://github.com/edx/frontend-app-learning/blob/96ef87886fdb8b00a0144f97b58567cea7bb1fae/docs/decisions/0007-testing.md#L1) to reserve tests for non-obvious behavior