### PR TITLE
small changes to the way the price is displayed on the course home page to pave the way for the expiration box

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -899,7 +899,7 @@ describe('Outline Tab', () => {
 
     it('displays link to upgrade', async () => {
       await fetchAndRender();
-      expect(screen.getByRole('link', { name: 'Upgrade ($149)' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Upgrade for $149' })).toBeInTheDocument();
     });
 
     it('viewing upgrade card sends analytics', async () => {
@@ -930,7 +930,7 @@ describe('Outline Tab', () => {
       // Clearing after render to remove any events sent on view (ex. 'Promotion Viewed')
       sendTrackEvent.mockClear();
       sendTrackingLogEvent.mockClear();
-      const upgradeButton = screen.getByRole('link', { name: 'Upgrade ($149)' });
+      const upgradeButton = screen.getByRole('link', { name: 'Upgrade for $149' });
 
       fireEvent.click(upgradeButton);
 

--- a/src/generic/course-sock/CourseSock.test.jsx
+++ b/src/generic/course-sock/CourseSock.test.jsx
@@ -36,7 +36,7 @@ describe('Course Sock', () => {
 
     expect(screen.getByText('edX Verified Certificate')).toBeInTheDocument();
     const { currencySymbol, price } = mockData.verifiedMode;
-    expect(screen.getByText(`Upgrade (${currencySymbol}${price})`)).toBeInTheDocument();
+    expect(screen.getByText(`Upgrade for ${currencySymbol}${price}`)).toBeInTheDocument();
 
     fireEvent.click(upsellButton);
     expect(screen.queryByText('edX Verified Certificate')).not.toBeInTheDocument();

--- a/src/generic/upgrade-button/FormattedPricing.jsx
+++ b/src/generic/upgrade-button/FormattedPricing.jsx
@@ -49,7 +49,7 @@ function FormattedPricing(props) {
         {intl.formatMessage(messages.srPrices, { discountedPrice, originalPrice })}
       </span>
       <span aria-hidden="true">
-        <span>{discountedPrice}</span> <del>{originalPrice}</del>
+        <span>{discountedPrice}</span> (<del>{originalPrice}</del>)
       </span>
     </>
   );

--- a/src/generic/upgrade-button/UpgradeButton.jsx
+++ b/src/generic/upgrade-button/UpgradeButton.jsx
@@ -26,7 +26,7 @@ function UpgradeButton(props) {
     >
       <FormattedMessage
         id="learning.upgradeButton.buttonText"
-        defaultMessage="Upgrade ({pricing})"
+        defaultMessage="Upgrade for {pricing}"
         values={{
           pricing: (
             <FormattedPricing


### PR DESCRIPTION
I've got a (relatively) big, huge, gigantic change in another pr (https://github.com/edx/frontend-app-learning/pull/377) that will change the certificate messaging on the home page to an expiration box. This is a couple of wording tweaks that can go out first.