### PR TITLE
refactor!: clean up unused references to lms_web_url

### DIFF
--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -56,13 +56,12 @@ export function normalizeOutlineBlocks(courseId, blocks) {
           effortTime: block.effort_time,
           icon: block.icon,
           id: block.id,
-          // Fall back to `lms_web_url` until `legacy_web_url` is added to API (TNL-7796).
-          legacyWebUrl: block.legacy_web_url || block.lms_web_url,
-          // The presence of an LMS URL for the sequence indicates that we want this
+          legacyWebUrl: block.legacy_web_url,
+          // The presence of an legacy URL for the sequence indicates that we want this
           // sequence to be a clickable link in the outline (even though, if the new
           // courseware experience is active, we will ignore `legacyWebUrl` and build a
           // link to the MFE ourselves).
-          showLink: !!(block.legacy_web_url || block.lms_web_url),
+          showLink: !!block.legacy_web_url,
           title: block.display_name,
         };
         break;

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -38,8 +38,7 @@ export function normalizeBlocks(courseId, blocks) {
           effortTime: block.effort_time,
           id: block.id,
           title: block.display_name,
-          // Fall back to `lms_web_url` until `legacy_web_url` is added to API (TNL-7796).
-          legacyWebUrl: block.legacy_web_url || block.lms_web_url,
+          legacyWebUrl: block.legacy_web_url,
           unitIds: block.children || [],
         };
         break;
@@ -48,8 +47,7 @@ export function normalizeBlocks(courseId, blocks) {
           graded: block.graded,
           id: block.id,
           title: block.display_name,
-          // Fall back to `lms_web_url` until `legacy_web_url` is added to API (TNL-7796).
-          legacyWebUrl: block.legacy_web_url || block.lms_web_url,
+          legacyWebUrl: block.legacy_web_url,
         };
         break;
       default:

--- a/src/shared/data/__factories__/block.factory.js
+++ b/src/shared/data/__factories__/block.factory.js
@@ -47,17 +47,6 @@ Factory.define('block')
     },
   )
   .attr(
-    'lms_web_url',
-    ['legacy_web_url', 'host', 'courseId', 'id'],
-    (url, host, courseId, id) => {
-      if (url) {
-        return url;
-      }
-
-      return `${host}/courses/${courseId}/jump_to/${id}`;
-    },
-  )
-  .attr(
     'legacy_web_url',
     ['legacy_web_url', 'host', 'courseId', 'id'],
     (url, host, courseId, id) => {


### PR DESCRIPTION
## Description

Before edx-platform version [19ba691](https://github.com/edx/edx-platform/tree/19ba691e33b7fba73d730ee9af0e040fb28208e6),
only `lms_web_url` was exposed from the course
blocks API. Now that the API also exposes
`legacy_web_url`, we can stop falling back
to `lms_web_url` when `legacy_web_url` is
absent.

## Other/Supporting Information

This is a follow-up from https://github.com/edx/frontend-app-learning/pull/404

I will not merge this until https://github.com/edx/edx-platform/pull/26816 has been deployed for long enough that it is not likely to be rolled back, since that edx-platform PR is a prerequisite to this clean-up.

Part of TNL-7796

