### PR TITLE
fix: allow media access through unit iframe

### DIFF
--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -24,6 +24,20 @@ import { MMP2PLockPaywall } from '../../../experiments/mm-p2p';
 const LockPaywall = React.lazy(() => import('./lock-paywall'));
 
 /**
+ * Feature policy for iframe, allowing access to certain courseware-related media.
+ *
+ * We must use the wildcard (*) origin for each feature, as courseware content
+ * may be embedded in external iframes. Notably, xblock-lti-consumer is a popular
+ * block that iframes external course content.
+
+ * This policy was selected in conference with the edX Security Working Group.
+ * Changes to it should be vetted by them (security@edx.org).
+ */
+const IFRAME_FEATURE_POLICY = (
+  'microphone *; camera *; midi *; geolocation *; encrypted-media *'
+);
+
+/**
  * We discovered an error in Firefox where - upon iframe load - React would cease to call any
  * useEffect hooks until the user interacts with the page again.  This is particularly confusing
  * when navigating between sequences, as the UI partially updates leaving the user in a nebulous
@@ -155,7 +169,7 @@ function Unit({
                 : (
                   <iframe
                     title={modalOptions.title}
-                    allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
+                    allow={IFRAME_FEATURE_POLICY}
                     frameBorder="0"
                     src={modalOptions.url}
                     style={{
@@ -178,6 +192,7 @@ function Unit({
             id="unit-iframe"
             title={unit.title}
             src={iframeUrl}
+            allow={IFRAME_FEATURE_POLICY}
             allowFullScreen
             height={iframeHeight}
             scrolling="no"


### PR DESCRIPTION
## Description

Set the `allow` attribute of the unit iframe to allow
access to camera, MIDI, location, and encrpyted media.

Access to these features was implicitly allowed in older
browser versions. However, in the current versions of
at least Chromium and Firefox, iframed content must be
explicitly granted the ability to request media access.

This fixes a bug where content requiring microphone
access did not work in the Learning MFE.

## Supporting information

https://openedx.atlassian.net/browse/TNL-7675
https://openedx.atlassian.net/browse/CR-2748

edX-only: [Security ticket confirming that this change is OK to make](https://openedx.atlassian.net/browse/SEC-1223)

## Testing instructions

I have run through these using Firefox 87 on Xubuntu 20.04

### Setup
* Create a unit in Studio.
* Add a raw HTML component.
* Set the following as the content of the HTML component, and publish:
```html
<p id="mic-access-status">Mic access pending...</p>

<script type="text/javascript">
  var accessStatus = document.getElementById("mic-access-status");
  navigator.mediaDevices.getUserMedia({audio:true})
	.then(function() { accessStatus.innerText = "Got mic access"; })
	.catch(function() { accessStatus.innerText = "Failed to get mic access"; });
</script>

```

### The test

* Check out master and bring up frontend-app-learning
* As course/global staff...
  * Load the unit you prepared above in Legacy courseware.
  * (at any point, if you are prompted for mic access, click "Allow")
  * You should see "Got mic access".
  * Switch to MFE courseware.
  * You should see "Failed to get mic access".
 * Check out kdmccormick/courseware-media-access and restart the app
   * in Devstack:
     * `make frontend-app-learning-attach`
     * Ctrl-C to kill and restart
     * Ctrl-P+Ctrl-Q can be used to un-attach.
* As course/global staff...
  * Load the unit you prepared above in Legacy courseware.
  * (at any point, if you are prompted for mic access, click "Allow")
  * You should see "Got mic access".
  * Switch to MFE courseware.
  * You should see "Got mic access!".

## Deadline

Hopefully this week. This will help us mark 12 course-runs for MFE exemption removal.

## Other information

There is a similar change we may need to make to the [Feature-Policy response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy) in both Legacy and MFE courseware.

I have a [draft edx-platform PR to add them to legacy courseware](https://github.com/edx/edx-platform/pull/27304), but I haven't been able to confirm it works yet. I don't yet have a PR for adding the Feature Policy header for New courseware.

Still, the fixing the iframe permissions (as this PR does) should be enough to fix the PR for many users, and will allow us to un-exempt these courses. Then, we can proceed and decide whether to add these permissions to the Feature-Policy header in each experience.