### PR TITLE
fix: AA-738: Switch our use of FormattedTime to use hourCycle

### DIFF
--- a/src/course-home/outline-tab/SequenceLink.jsx
+++ b/src/course-home/outline-tab/SequenceLink.jsx
@@ -96,7 +96,7 @@ function SequenceLink({
                       day="numeric"
                       month="short"
                       year="numeric"
-                      hour12={false}
+                      hourCycle="h23"
                       timeZoneName="short"
                       value={due}
                       {...timezoneFormatArgs}

--- a/src/course-home/outline-tab/alerts/course-end-alert/CourseEndAlert.jsx
+++ b/src/course-home/outline-tab/alerts/course-end-alert/CourseEndAlert.jsx
@@ -37,7 +37,7 @@ function CourseEndAlert({ payload }) {
         day="numeric"
         month="short"
         year="numeric"
-        hour12={false}
+        hourCycle="h23"
         timeZoneName="short"
         value={endDate}
         {...timezoneFormatArgs}

--- a/src/course-home/outline-tab/alerts/course-start-alert/CourseStartAlert.jsx
+++ b/src/course-home/outline-tab/alerts/course-start-alert/CourseStartAlert.jsx
@@ -42,7 +42,7 @@ function CourseStartAlert({ payload }) {
                 day="numeric"
                 month="short"
                 year="numeric"
-                hour12={false}
+                hourCycle="h23"
                 timeZoneName="short"
                 value={startDate}
                 {...timezoneFormatArgs}


### PR DESCRIPTION
We had a bug reported where learners were seeing a due date like
March 24, 24:59 instead of March 25, 00:59. This is a bug that only
shows up in Chrome. The hour12 flag overrides the hourCycle flag so
we are just going to swap the two. h23 means a 24 hour format ranging
from 0-23 (there also exists a h24 option which goes from 1-24).

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
for any additional details on the options.