### PR TITLE
fix: center content by fixing the container-fluid class

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -7,6 +7,7 @@
 
 // TODO: Fix .container-fluid for mobile in paragon
 .container-fluid {
+  max-width: 1140px + 2 * $grid-gutter-width;
   @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
     padding-left: $grid-gutter-width/2;
     padding-right: $grid-gutter-width/2;


### PR DESCRIPTION
### [TNL-8232](https://openedx.atlassian.net/browse/TNL-8232)

#### Description 

Fix `container-fluid` class to center content by adjusting `max-width` property

#### @edx/brand-openedx
<img width="1437" alt="Screen Shot 2021-04-22 at 8 20 56 PM" src="https://user-images.githubusercontent.com/30112155/115743710-570ae900-a3ab-11eb-95cc-72d6455d205d.png">

#### @edx/brand-edx.org
<img width="1438" alt="Screen Shot 2021-04-22 at 8 17 31 PM" src="https://user-images.githubusercontent.com/30112155/115743696-55412580-a3ab-11eb-8360-1a96b62a53a3.png">

FYI -- The PR https://github.com/edx/brand-edx.org/pull/30 removed max-width from brand-edx.org in its version 2.0.0 -- once we bump to ^2.0.0 prod also needs this change. 