### PR TITLE
feat: Switch to default values for 12 vs 24 hour time.

### DIFF
--- a/src/course-home/outline-tab/SequenceLink.jsx
+++ b/src/course-home/outline-tab/SequenceLink.jsx
@@ -96,7 +96,6 @@ function SequenceLink({
                       day="numeric"
                       month="short"
                       year="numeric"
-                      hourCycle="h23"
                       timeZoneName="short"
                       value={due}
                       {...timezoneFormatArgs}

--- a/src/course-home/outline-tab/alerts/course-end-alert/CourseEndAlert.jsx
+++ b/src/course-home/outline-tab/alerts/course-end-alert/CourseEndAlert.jsx
@@ -37,7 +37,6 @@ function CourseEndAlert({ payload }) {
         day="numeric"
         month="short"
         year="numeric"
-        hourCycle="h23"
         timeZoneName="short"
         value={endDate}
         {...timezoneFormatArgs}

--- a/src/course-home/outline-tab/alerts/course-start-alert/CourseStartAlert.jsx
+++ b/src/course-home/outline-tab/alerts/course-start-alert/CourseStartAlert.jsx
@@ -42,7 +42,6 @@ function CourseStartAlert({ payload }) {
                 day="numeric"
                 month="short"
                 year="numeric"
-                hourCycle="h23"
                 timeZoneName="short"
                 value={startDate}
                 {...timezoneFormatArgs}


### PR DESCRIPTION
Our current version on react-intl doesn't support hourCycle
anyway and after speaking to product, we feel comfortable with
letting it default based on locale.