### PR TITLE
feat: Deny course staff visibility of legacy courseware.

### DIFF
--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -133,6 +133,7 @@ function normalizeMetadata(metadata) {
     enrollmentMode: metadata.enrollment.mode,
     isEnrolled: metadata.enrollment.is_active,
     canLoadCourseware: camelCaseObject(metadata.can_load_courseware),
+    canViewLegacyCourseware: metadata.can_view_legacy_courseware,
     originalUserIsStaff: metadata.original_user_is_staff,
     isStaff: metadata.is_staff,
     license: metadata.license,

--- a/src/instructor-toolbar/InstructorToolbar.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.jsx
@@ -53,9 +53,14 @@ export default function InstructorToolbar(props) {
   const {
     courseId,
     unitId,
+    canViewLegacyCourseware,
   } = props;
   const urlInsights = getInsightsUrl(courseId);
   const urlLegacy = useSelector((state) => {
+    if (!canViewLegacyCourseware) {
+      return undefined;
+    }
+
     if (!unitId) {
       return undefined;
     }
@@ -113,9 +118,11 @@ export default function InstructorToolbar(props) {
 InstructorToolbar.propTypes = {
   courseId: PropTypes.string,
   unitId: PropTypes.string,
+  canViewLegacyCourseware: PropTypes.bool,
 };
 
 InstructorToolbar.defaultProps = {
   courseId: undefined,
   unitId: undefined,
+  canViewLegacyCourseware: undefined,
 };

--- a/src/instructor-toolbar/InstructorToolbar.test.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.test.jsx
@@ -25,6 +25,7 @@ describe('Instructor Toolbar', () => {
     mockData = {
       courseId: courseware.courseId,
       unitId: Object.values(models.units)[0].id,
+      canViewLegacyCourseware: true,
     };
 
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
@@ -53,7 +54,7 @@ describe('Instructor Toolbar', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('Unable to get masquerade options');
   });
 
-  it('displays links to view course in different services', () => {
+  it('displays links to view course in available services', () => {
     const config = { ...originalConfig };
     config.INSIGHTS_BASE_URL = 'http://localhost:18100';
     getConfig.mockImplementation(() => config);
@@ -61,6 +62,32 @@ describe('Instructor Toolbar', () => {
 
     const linksContainer = screen.getByText('View course in:').parentElement;
     ['Legacy experience', 'Studio', 'Insights'].forEach(service => {
+      expect(getByText(linksContainer, service).getAttribute('href')).toMatch(/http.*/);
+    });
+  });
+
+  it('displays links to view course in available services - false legacy courseware flag', () => {
+    const config = { ...originalConfig };
+    config.INSIGHTS_BASE_URL = 'http://localhost:18100';
+    getConfig.mockImplementation(() => config);
+    mockData.canViewLegacyCourseware = false;
+    render(<InstructorToolbar {...mockData} />);
+
+    const linksContainer = screen.getByText('View course in:').parentElement;
+    ['Studio', 'Insights'].forEach(service => {
+      expect(getByText(linksContainer, service).getAttribute('href')).toMatch(/http.*/);
+    });
+  });
+
+  it('displays links to view course in available services - empty unit', () => {
+    const config = { ...originalConfig };
+    config.INSIGHTS_BASE_URL = 'http://localhost:18100';
+    getConfig.mockImplementation(() => config);
+    mockData.unitId = undefined;
+    render(<InstructorToolbar {...mockData} />);
+
+    const linksContainer = screen.getByText('View course in:').parentElement;
+    ['Studio', 'Insights'].forEach(service => {
       expect(getByText(linksContainer, service).getAttribute('href')).toMatch(/http.*/);
     });
   });

--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -26,6 +26,7 @@ function LoadedTabPage({
     tabs,
     title,
     celebrations,
+    canViewLegacyCourseware,
   } = useModel(metadataModel, courseId);
 
   // Logistration and enrollment alerts are only really used for the outline tab, but loaded here to put them above
@@ -51,6 +52,7 @@ function LoadedTabPage({
         <InstructorToolbar
           courseId={courseId}
           unitId={unitId}
+          canViewLegacyCourseware={canViewLegacyCourseware}
         />
       )}
       {streakLengthToCelebrate && (


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-8203

Currently, course staff can always view their courses
in the Legacy courseware experience.

With this change, course staff will *not* be able
to view their courses if the New (MFE) courseware
experience has been enabled for them.

This does not affect global staff, and it does not
affect courses that are still running in the Legacy
experience.

Adds a new parameter returned by the course metadata API
used by the courseware MFE to determine if the button to
show legacy experience should be displayed or not.

Companion PR: https://github.com/edx/edx-platform/pull/27469