### PR TITLE
fix: update sequence navigation buttons to use iconBefore and iconAfter

### DIFF
--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@edx/paragon';
+import { ChevronLeft, ChevronRight } from '@edx/paragon/icons';
 import classNames from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import { useSelector } from 'react-redux';
@@ -70,17 +69,15 @@ function SequenceNavigation({
     const buttonText = (isLastUnit && exitText) ? exitText : intl.formatMessage(messages.nextButton);
     const disabled = isLastUnit && !exitActive;
     return (
-      <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled}>
+      <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled} iconAfter={ChevronRight}>
         {isValuePropCookieSet && shouldDisplaySidebarButton ? null : buttonText}
-        <FontAwesomeIcon icon={faChevronRight} className="mx-3 mr-sm-0 ml-sm-2" size="sm" />
       </Button>
     );
   };
 
   return sequenceStatus === LOADED && (
     <nav className={classNames('sequence-navigation', className)} style={{ width: isValuePropCookieSet && shouldDisplaySidebarButton ? '90%' : null }}>
-      <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit}>
-        <FontAwesomeIcon icon={faChevronLeft} className="mx-3 ml-sm-0 mr-sm-2" size="sm" />
+      <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit} iconBefore={ChevronLeft}>
         {isValuePropCookieSet && shouldDisplaySidebarButton ? null : intl.formatMessage(messages.previousButton)}
       </Button>
       {renderUnitButtons()}

--- a/src/index.scss
+++ b/src/index.scss
@@ -255,10 +255,6 @@
     @media (max-width: -1 + map-get($grid-breakpoints, 'sm')) {
       padding-top: 1rem;
       padding-bottom: 1rem;
-
-      span {
-        @include sr-only();
-      }
     }
 
     @media (min-width: map-get($grid-breakpoints, 'sm')) {


### PR DESCRIPTION
A recent Paragon update wraps the children of `<Button />` in a `<span />`

ex:
```
<Button>
  <span className="btn-icons-container">
    {children}
  </span>
</Button>
```

This clashed with the custom CSS for the sequence navigation buttons, making the content of the buttons disappear on mobile.
<img width="329" alt="Screen Shot 2021-05-03 at 5 25 56 PM" src="https://user-images.githubusercontent.com/25124041/116943299-45de9980-ac41-11eb-956a-f84a8b745651.png">

I updated the sequence navigation buttons to use the `iconBefore` and `iconAfter` utilities provided by Paragon, and this fixed subsequent styling clashes that came from the custom CSS applied to these buttons.

**Screenshots**
<img width="400" alt="Screen Shot 2021-05-03 at 6 52 50 PM" src="https://user-images.githubusercontent.com/25124041/116943092-dcf72180-ac40-11eb-9825-f225fc5d00b7.png">

Before and after:
<div>
<img width="200" alt="Screen Shot 2021-05-03 at 6 54 34 PM" src="https://user-images.githubusercontent.com/25124041/116943184-0c0d9300-ac41-11eb-963e-0926a3d51e4a.png">
<img width="200" alt="Screen Shot 2021-05-03 at 6 52 42 PM" src="https://user-images.githubusercontent.com/25124041/116943086-db2d5e00-ac40-11eb-83c1-1e116d471294.png">
</div>