### PR TITLE
Fix height issue in safari

### DIFF
--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -174,7 +174,7 @@ function Unit({
                     src={modalOptions.url}
                     style={{
                       width: '100%',
-                      height: '100%',
+                      height: '100vh',
                     }}
                   />
                 )}


### PR DESCRIPTION
This PR fixes LTI modal height for the safari browser. `height:100%` doesn't seem to work there. 

This fix is specific to the Safari browser. 
In the new learning experience, the LTI modal contained inside `iframe` does not respect  `height:100%`. To fix that I have changed it to have a 100 percent view height using `height: 100vh`. 

[TNL-7410](https://openedx.atlassian.net/browse/TNL-7410)

Before fix:
<img width="1320" alt="Screen Shot 2021-05-05 at 10 53 58 PM" src="https://user-images.githubusercontent.com/4252738/117186942-d14c5c00-adf4-11eb-8912-19663552489e.png">

After Fix:
<img width="1312" alt="Screen Shot 2021-05-05 at 10 53 45 PM" src="https://user-images.githubusercontent.com/4252738/117186965-d7423d00-adf4-11eb-9648-7434e3f0b6b3.png">
