### PR TITLE
fix: update border color for approved in another course status

### DIFF
--- a/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
+++ b/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
@@ -58,9 +58,9 @@ function ProctoringInfoPanel({ courseId, username, intl }) {
 
   function getBorderClass() {
     let borderClass = '';
-    if (readableStatus === readableStatuses.submitted) {
+    if ([readableStatuses.submitted, readableStatuses.expiringSoon].includes(readableStatus)) {
       borderClass = 'proctoring-onboarding-submitted';
-    } else if (readableStatus === readableStatuses.verified) {
+    } else if ([readableStatuses.verified, readableStatuses.otherCourseApproved].includes(readableStatus)) {
       borderClass = 'proctoring-onboarding-success';
     }
     return borderClass;


### PR DESCRIPTION
## [MST-755](https://openedx.atlassian.net/browse/MST-755)

The border color for `other_course_approved` and `expiring_soon` were not updated here to reflect the same changes that were made to the legacy outline view. 

`other_course_approved` should now have the same border color as `verified`, and `expiring_soon` should have the same color as `submitted`. 