### PR TITLE
fix checkmark bullets to line up with text

### DIFF
--- a/src/course-home/outline-tab/widgets/UpgradeCard.scss
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.scss
@@ -30,6 +30,7 @@
 
 .upgrade-card-li{
   left: -2.125rem;
+  top: 0;
 }
 
 .upgrade-card-text{


### PR DESCRIPTION
The top of the checkmarks was not quite at the height of the text. This fixes that bug.