### PR TITLE
fix checkmark bullets to vertically align with text

### DIFF
--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
@@ -3,6 +3,7 @@
 .fa-li {
     left: -31px !important;
     padding-right: 22px;
+    top: 0;
 }
 
     @media only screen and (min-width: 992px) and (max-width: 1100px) {


### PR DESCRIPTION
The top of the checkmarks was not quite at the height of the text. This fixes that bug.