### PR TITLE
fix: i18n translations for UpgradeCard

### DIFF
--- a/src/course-home/outline-tab/widgets/UpgradeCard.jsx
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.jsx
@@ -11,6 +11,20 @@ import { Hyperlink } from '@edx/paragon';
 import { UpgradeButton } from '../../../generic/upgrade-button';
 
 function UpsellNoFBECardContent() {
+  const verifiedCertLink = (
+    <Hyperlink
+      destination={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
+      className="font-weight-bold"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <FormattedMessage
+        id="learning.outline.widgets.upgradeCard.verifiedCertLink"
+        defaultMessage="verified certificate"
+      />
+    </Hyperlink>
+  );
+
   return (
     <ul className="fa-ul upgrade-card-ul pt-0">
       <li>
@@ -18,20 +32,7 @@ function UpsellNoFBECardContent() {
         <FormattedMessage
           id="learning.outline.widgets.upgradeCard.verifiedCertMessage"
           defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resume"
-          values={{
-            verifiedCertLink: (
-              <Hyperlink
-                destination={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
-                className="font-weight-bold"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <FormattedMessage
-                  id="learning.outline.widgets.upgradeCard.verifiedCertLink"
-                  defaultMessage="verified certificate"
-                />
-              </Hyperlink>),
-          }}
+          values={{ verifiedCertLink }}
         />
       </li>
       <li>

--- a/src/course-home/outline-tab/widgets/UpgradeCard.jsx
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.jsx
@@ -15,7 +15,7 @@ function UpsellNoFBECardContent() {
       <li>
         <span className="fa-li upgrade-card-li"><FontAwesomeIcon icon={faCheck} /></span>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.verifiedCertLink"
+          id="learning.outline.widgets.upgradeCard.verifiedCertMessage"
           defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resume"
           values={{
             verifiedCertLink: (
@@ -27,7 +27,7 @@ function UpsellNoFBECardContent() {
       <li>
         <span className="fa-li upgrade-card-li"><FontAwesomeIcon icon={faCheck} /></span>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.nonProfitMission"
+          id="learning.outline.widgets.upgradeCard.nonProfitMission"
           defaultMessage="Support our {nonProfitMission} at edX"
           values={{
             nonProfitMission: (
@@ -46,7 +46,7 @@ function UpsellFBEFarAwayCardContent() {
       <li>
         <span className="fa-li upgrade-card-li"><FontAwesomeIcon icon={faCheck} /></span>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.verifiedCertLink"
+          id="learning.outline.widgets.upgradeCard.verifiedCertMessage"
           defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resume"
           values={{
             verifiedCertLink: (
@@ -58,7 +58,7 @@ function UpsellFBEFarAwayCardContent() {
       <li>
         <span className="fa-li upgrade-card-li"><FontAwesomeIcon icon={faCheck} /></span>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.unlock-graded"
+          id="learning.outline.widgets.upgradeCard.unlockGraded"
           defaultMessage="Unlock your access to all course activities, including {gradedAssignments}"
           values={{
             gradedAssignments: (
@@ -70,7 +70,7 @@ function UpsellFBEFarAwayCardContent() {
       <li>
         <span className="fa-li upgrade-card-li"><FontAwesomeIcon icon={faCheck} /></span>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.fullAccess"
+          id="learning.outline.widgets.upgradeCard.fullAccess"
           defaultMessage="{fullAccess} to course content and materials, even after the course ends"
           values={{
             fullAccess: (
@@ -82,7 +82,7 @@ function UpsellFBEFarAwayCardContent() {
       <li>
         <span className="fa-li upgrade-card-li"><FontAwesomeIcon icon={faCheck} /></span>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.nonProfitMission"
+          id="learning.outline.widgets.upgradeCard.nonProfitMission"
           defaultMessage="Support our {nonProfitMission} at edX"
           values={{
             nonProfitMission: (
@@ -100,7 +100,7 @@ function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) 
     <div className="upgrade-card-text">
       <p>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.expirationAccessLoss"
+          id="learning.outline.widgets.upgradeCard.expirationAccessLoss"
           defaultMessage="You will lose all access to this course, {includingAnyProgress}, on {date}."
           values={{
             includingAnyProgress: (<span className="font-weight-bold">including any progress</span>),
@@ -118,7 +118,7 @@ function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) 
       </p>
       <p>
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.expirationVerifiedCert"
+          id="learning.outline.widgets.upgradeCard.expirationVerifiedCert"
           defaultMessage="Upgrading your course enables you to pursue a verified certificate and unlocks numerous features. Learn more about the {benefitsOfUpgrading}."
           values={{
             benefitsOfUpgrading: (<a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href="https://support.edx.org/hc/en-us/articles/360013426573-What-are-the-differences-between-audit-free-and-verified-paid-courses-">benefits of upgrading</a>),
@@ -146,7 +146,7 @@ function ExpirationCountdown({ hoursToExpiration }) {
   if (hoursToExpiration >= 24) {
     expirationText = (
       <FormattedMessage
-        id="learning.outline.alert.upgradecard.expiration.days"
+        id="learning.outline.widgets.upgradeCard.expirationDays"
         defaultMessage={`{dayCount, number} {dayCount, plural, 
           one {day}
           other {days}} left`}
@@ -158,7 +158,7 @@ function ExpirationCountdown({ hoursToExpiration }) {
   } else if (hoursToExpiration >= 1) {
     expirationText = (
       <FormattedMessage
-        id="learning.outline.alert.upgradecard.expiration.hours"
+        id="learning.outline.widgets.upgradeCard.expirationHours"
         defaultMessage={`{hourCount, number} {hourCount, plural,
           one {hour}
           other {hours}} left`}
@@ -170,7 +170,7 @@ function ExpirationCountdown({ hoursToExpiration }) {
   } else {
     expirationText = (
       <FormattedMessage
-        id="learning.outline.alert.upgradecard.expiration.minutes"
+        id="learning.outline.widgets.upgradeCard.expirationMinutes"
         defaultMessage="Less than 1 hour left"
       />
     );
@@ -186,7 +186,7 @@ function AccessExpirationDateBanner({ accessExpirationDate, timezoneFormatArgs }
   return (
     <div className="upsell-warning-light">
       <FormattedMessage
-        id="learning.outline.alert.upgradecard.expirationr"
+        id="learning.outline.widgets.upgradeCard.expiration"
         defaultMessage="Course access will expire {date}"
         values={{
           date: (
@@ -286,7 +286,7 @@ function UpgradeCard({
       offerCode = (
         <div className="text-center discount-info">
           <FormattedMessage
-            id="learning.outline.alert.upgradecard.code"
+            id="learning.outline.widgets.upgradeCard.code"
             defaultMessage="Use code {code} at checkout"
             values={{
               code: (<span className="font-weight-bold">{offer.code}</span>),
@@ -301,7 +301,7 @@ function UpgradeCard({
         const hoursToDiscountExpiration = Math.floor((new Date(offer.expirationDate) - correctedTime) / 1000 / 60 / 60);
         upgradeCardHeaderText = (
           <FormattedMessage
-            id="learning.outline.alert.upgradecard.firstTimeLearnerDiscount"
+            id="learning.outline.widgets.upgradeCard.firstTimeLearnerDiscount"
             defaultMessage="{percentage}% First-Time Learner Discount"
             values={{
               percentage: (offer.percentage),
@@ -312,7 +312,7 @@ function UpgradeCard({
       } else {
         upgradeCardHeaderText = (
           <FormattedMessage
-            id="learning.outline.alert.upgradecard.accessExpiration"
+            id="learning.outline.widgets.upgradeCard.accessExpiration"
             defaultMessage="Upgrade your course today"
           />
         );
@@ -327,7 +327,7 @@ function UpgradeCard({
     } else { // more urgent messaging if there's less than 7 days left to access expiration
       upgradeCardHeaderText = (
         <FormattedMessage
-          id="learning.outline.alert.upgradecard.accessExpirationUrgent"
+          id="learning.outline.widgets.upgradeCard.accessExpirationUrgent"
           defaultMessage="Course Access Expiration"
         />
       );
@@ -342,7 +342,7 @@ function UpgradeCard({
   } else { // FBE is turned off
     upgradeCardHeaderText = (
       <FormattedMessage
-        id="learning.outline.alert.upgradecard.pursueAverifiedCertificate"
+        id="learning.outline.widgets.upgradeCard.pursueAverifiedCertificate"
         defaultMessage="Pursue a verified certificate"
       />
     );

--- a/src/course-home/outline-tab/widgets/UpgradeCard.jsx
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.jsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { sendTrackEvent, sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { FormattedDate, FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
+import { Hyperlink } from '@edx/paragon';
 
 import { UpgradeButton } from '../../../generic/upgrade-button';
 
@@ -19,8 +20,17 @@ function UpsellNoFBECardContent() {
           defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resume"
           values={{
             verifiedCertLink: (
-              <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>verified certificate</a>
-            ),
+              <Hyperlink
+                destination={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
+                className="font-weight-bold"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <FormattedMessage
+                  id="learning.outline.widgets.upgradeCard.verifiedCertLink"
+                  defaultMessage="verified certificate"
+                />
+              </Hyperlink>),
           }}
         />
       </li>
@@ -41,6 +51,47 @@ function UpsellNoFBECardContent() {
 }
 
 function UpsellFBEFarAwayCardContent() {
+  const verifiedCertLink = (
+    <Hyperlink
+      destination={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
+      className="font-weight-bold"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <FormattedMessage
+        id="learning.outline.widgets.upgradeCard.verifiedCertLink"
+        defaultMessage="verified certificate"
+      />
+    </Hyperlink>
+  );
+
+  const gradedAssignments = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="learning.outline.widgets.upgradeCard.gradedAssignments"
+        defaultMessage="graded assignments"
+      />
+    </span>
+  );
+
+  const fullAccess = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="learning.upgradeCard.verifiedCertLink"
+        defaultMessage="Full access"
+      />
+    </span>
+  );
+
+  const nonProfitMission = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="learning.upgradeCard.nonProfitMission"
+        defaultMessage="non-profit mission"
+      />
+    </span>
+  );
+
   return (
     <ul className="fa-ul upgrade-card-ul">
       <li>
@@ -48,11 +99,7 @@ function UpsellFBEFarAwayCardContent() {
         <FormattedMessage
           id="learning.outline.widgets.upgradeCard.verifiedCertMessage"
           defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resume"
-          values={{
-            verifiedCertLink: (
-              <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>verified certificate</a>
-            ),
-          }}
+          values={{ verifiedCertLink }}
         />
       </li>
       <li>
@@ -60,11 +107,7 @@ function UpsellFBEFarAwayCardContent() {
         <FormattedMessage
           id="learning.outline.widgets.upgradeCard.unlockGraded"
           defaultMessage="Unlock your access to all course activities, including {gradedAssignments}"
-          values={{
-            gradedAssignments: (
-              <span className="font-weight-bold">graded assignments</span>
-            ),
-          }}
+          values={{ gradedAssignments }}
         />
       </li>
       <li>
@@ -72,11 +115,7 @@ function UpsellFBEFarAwayCardContent() {
         <FormattedMessage
           id="learning.outline.widgets.upgradeCard.fullAccess"
           defaultMessage="{fullAccess} to course content and materials, even after the course ends"
-          values={{
-            fullAccess: (
-              <span className="font-weight-bold">Full access</span>
-            ),
-          }}
+          values={{ fullAccess }}
         />
       </li>
       <li>
@@ -84,11 +123,7 @@ function UpsellFBEFarAwayCardContent() {
         <FormattedMessage
           id="learning.outline.widgets.upgradeCard.nonProfitMission"
           defaultMessage="Support our {nonProfitMission} at edX"
-          values={{
-            nonProfitMission: (
-              <span className="font-weight-bold">non-profit mission</span>
-            ),
-          }}
+          values={{ nonProfitMission }}
         />
       </li>
     </ul>
@@ -96,6 +131,39 @@ function UpsellFBEFarAwayCardContent() {
 }
 
 function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) {
+  const includingAnyProgress = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="learning.upgradeCard.expirationAccessLoss.progress"
+        defaultMessage="including any progress"
+      />
+    </span>
+  );
+
+  const date = (
+    <FormattedDate
+      key="accessDate"
+      day="numeric"
+      month="long"
+      value={new Date(accessExpirationDate)}
+      {...timezoneFormatArgs}
+    />
+  );
+
+  const benefitsOfUpgrading = (
+    <Hyperlink
+      destination="https://support.edx.org/hc/en-us/articles/360013426573-What-are-the-differences-between-audit-free-and-verified-paid-courses-"
+      className="font-weight-bold"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <FormattedMessage
+        id="learning.outline.widgets.upgradeCard.expirationVerifiedCert.benefits"
+        defaultMessage="benefits of upgrading"
+      />
+    </Hyperlink>
+  );
+
   return (
     <div className="upgrade-card-text">
       <p>
@@ -103,16 +171,8 @@ function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) 
           id="learning.outline.widgets.upgradeCard.expirationAccessLoss"
           defaultMessage="You will lose all access to this course, {includingAnyProgress}, on {date}."
           values={{
-            includingAnyProgress: (<span className="font-weight-bold">including any progress</span>),
-            date: (
-              <FormattedDate
-                key="accessDate"
-                day="numeric"
-                month="long"
-                value={new Date(accessExpirationDate)}
-                {...timezoneFormatArgs}
-              />
-            ),
+            includingAnyProgress,
+            date,
           }}
         />
       </p>
@@ -120,9 +180,7 @@ function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) 
         <FormattedMessage
           id="learning.outline.widgets.upgradeCard.expirationVerifiedCert"
           defaultMessage="Upgrading your course enables you to pursue a verified certificate and unlocks numerous features. Learn more about the {benefitsOfUpgrading}."
-          values={{
-            benefitsOfUpgrading: (<a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href="https://support.edx.org/hc/en-us/articles/360013426573-What-are-the-differences-between-audit-free-and-verified-paid-courses-">benefits of upgrading</a>),
-          }}
+          values={{ benefitsOfUpgrading }}
         />
       </p>
     </div>

--- a/src/course-home/outline-tab/widgets/UpgradeCard.jsx
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.jsx
@@ -6,23 +6,17 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { sendTrackEvent, sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { FormattedDate, FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
-import { Hyperlink } from '@edx/paragon';
 
 import { UpgradeButton } from '../../../generic/upgrade-button';
 
 function UpsellNoFBECardContent() {
   const verifiedCertLink = (
-    <Hyperlink
-      destination={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
-      className="font-weight-bold"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
       <FormattedMessage
         id="learning.outline.widgets.upgradeCard.verifiedCertLink"
         defaultMessage="verified certificate"
       />
-    </Hyperlink>
+    </a>
   );
 
   return (
@@ -53,17 +47,12 @@ function UpsellNoFBECardContent() {
 
 function UpsellFBEFarAwayCardContent() {
   const verifiedCertLink = (
-    <Hyperlink
-      destination={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
-      className="font-weight-bold"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
+    <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
       <FormattedMessage
         id="learning.outline.widgets.upgradeCard.verifiedCertLink"
         defaultMessage="verified certificate"
       />
-    </Hyperlink>
+    </a>
   );
 
   const gradedAssignments = (
@@ -152,17 +141,12 @@ function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) 
   );
 
   const benefitsOfUpgrading = (
-    <Hyperlink
-      destination="https://support.edx.org/hc/en-us/articles/360013426573-What-are-the-differences-between-audit-free-and-verified-paid-courses-"
-      className="font-weight-bold"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
+    <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href="https://support.edx.org/hc/en-us/articles/360013426573-What-are-the-differences-between-audit-free-and-verified-paid-courses-">
       <FormattedMessage
         id="learning.outline.widgets.upgradeCard.expirationVerifiedCert.benefits"
         defaultMessage="benefits of upgrading"
       />
-    </Hyperlink>
+    </a>
   );
 
   return (

--- a/src/course-home/outline-tab/widgets/UpgradeCard.scss
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.scss
@@ -4,7 +4,6 @@
 
 .upgrade-card-header{
   margin: 1.25rem;
-
 }
 
 .upsell-warning{


### PR DESCRIPTION
[REV-2224](https://openedx.atlassian.net/browse/REV-2224).

Translations with missing formatted strings for https://github.com/edx/frontend-app-learning/pull/377

**Pls note:**
`<Hyperlink>` component from Paragon is not used here because it looks like it has a bug, it adds an extra space at the end of the link. So keeping it as `<a>` tag with styling instead. 
<img width="862" alt="Screen Shot 2021-05-11 at 12 16 38 PM" src="https://user-images.githubusercontent.com/13632680/117853348-4f29c080-b256-11eb-8498-e40e2b3f1260.png">
