### PR TITLE
AA-792: Progress tab UI fixes

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -119,7 +119,7 @@ function OutlineTab({ intl }) {
       >
         {goalToastHeader}
       </Toast>
-      <div className="row w-100 m-0 mb-3 justify-content-between">
+      <div className="row w-100 mx-0 my-3 justify-content-between">
         <div className="col-12 col-sm-auto p-0">
           <div role="heading" aria-level="1" className="h2">{title}</div>
         </div>

--- a/src/course-home/progress-tab/ProgressHeader.jsx
+++ b/src/course-home/progress-tab/ProgressHeader.jsx
@@ -20,7 +20,7 @@ function ProgressHeader({ intl }) {
 
   return (
     <>
-      <div className="row w-100 m-0 mb-4 justify-content-between">
+      <div className="row w-100 m-0 mt-3 mb-4 justify-content-between">
         <h1>{intl.formatMessage(messages.progressHeader)}</h1>
         {administrator && studioUrl && (
           <Button variant="outline-primary" size="sm" className="align-self-center" href={studioUrl}>

--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -37,7 +37,7 @@ function ProgressTab() {
       <ProgressHeader />
       <div className="row w-100 m-0">
         {/* Main body */}
-        <div className="col-12 col-lg-8 p-0">
+        <div className="col-12 col-md-8 p-0">
           <CourseCompletion />
           <OnMobile>
             <CertificateStatus />
@@ -50,7 +50,7 @@ function ProgressTab() {
         </div>
 
         {/* Side panel */}
-        <div className="col-12 col-lg-4 p-0 px-lg-4">
+        <div className="col-12 col-md-4 p-0 px-md-4">
           <OnDesktop>
             <CertificateStatus />
           </OnDesktop>

--- a/src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx
@@ -55,30 +55,34 @@ function CourseGradeFooter({ intl, passingGrade }) {
     }
   }
 
+  const icon = isPassing ? <Icon src={CheckCircle} className="text-success-300 d-inline-flex align-bottom" />
+    : <Icon src={WarningFilled} className="d-inline-flex align-bottom" />;
+
   return (
-    <div className={`row w-100 m-0 px-4 py-3 py-md-4 align-items-baseline rounded-bottom ${isPassing ? 'bg-success-100' : 'bg-warning-100'}`}>
-      <div className="col-auto p-0 align-self-md-center">
-        {isPassing && (
-          <Icon src={CheckCircle} className="text-success-300 mt-n1 mr-2" />
-        )}
-        {!isPassing && (
-          <Icon src={WarningFilled} className="mt-n1 mr-2" />
-        )}
+    <div className={`row w-100 m-0 px-4 py-3 py-md-4 rounded-bottom ${isPassing ? 'bg-success-100' : 'bg-warning-100'}`}>
+      <div className="col-auto p-0">
+        {icon}
       </div>
-      <div className="col-11 col-md-auto p-0">
+      <div className="col-11 pl-2 px-0">
         <OnMobile>
-          <span className="h5" style={{ verticalAlign: 'super' }}>
+          <span className="h5 align-bottom">
             {footerText}
             {hasLetterGrades && (
-              <GradeRangeTooltip iconButtonClassName="h4 ml-1" passingGrade={passingGrade} />
+              <span style={{ whiteSpace: 'nowrap' }}>
+                &nbsp;
+                <GradeRangeTooltip iconButtonClassName="h4" passingGrade={passingGrade} />
+              </span>
             )}
           </span>
         </OnMobile>
         <OnAtLeastTablet>
-          <span className="h4 m-0">
+          <span className="h4 m-0 align-bottom">
             {footerText}
             {hasLetterGrades && (
-              <GradeRangeTooltip iconButtonClassName="h3 ml-1" passingGrade={passingGrade} />
+              <span style={{ whiteSpace: 'nowrap' }}>
+                &nbsp;
+                <GradeRangeTooltip iconButtonClassName="h3" passingGrade={passingGrade} />
+              </span>
             )}
           </span>
         </OnAtLeastTablet>

--- a/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
@@ -46,7 +46,7 @@ function CurrentGradeTooltip({ intl, tooltipClassName }) {
         textAnchor={currentGrade < 50 ? 'start' : 'end'}
         x={`${currentGrade}%`}
         y="20px"
-        style={{ transform: `translateX(${currentGrade < 50 ? '' : '-'}3em)` }}
+        style={{ transform: `translateX(${currentGrade < 50 ? '' : '-'}3.4em)` }}
       >
         {intl.formatMessage(messages.currentGradeLabel)}
       </text>

--- a/src/course-home/progress-tab/grades/course-grade/GradeBar.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/GradeBar.jsx
@@ -30,7 +30,7 @@ function GradeBar({ intl, passingGrade }) {
   const lockedTooltipClassName = isLocked ? 'locked-overlay' : '';
 
   return (
-    <div className="col-12 col-sm-6 pr-sm-0 align-self-center">
+    <div className="col-12 col-sm-6 align-self-center">
       <div className="sr-only">{intl.formatMessage(messages.courseGradeBarAltText, { currentGrade, passingGrade })}</div>
       <svg width="100%" height="100px" className="grade-bar" aria-hidden="true">
         <g style={{ transform: 'translateY(2.61em)' }}>

--- a/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
@@ -31,7 +31,7 @@ function PassingGradeTooltip({ intl, passingGrade, tooltipClassName }) {
         textAnchor={passingGrade < 50 ? 'start' : 'end'}
         x={`${passingGrade}%`}
         y="90px"
-        style={{ transform: `translateX(${passingGrade < 50 ? '' : '-'}3em)` }}
+        style={{ transform: `translateX(${passingGrade < 50 ? '' : '-'}3.4em)` }}
       >
         {intl.formatMessage(messages.passingGradeLabel)}
       </text>


### PR DESCRIPTION
- Responsive page break @ `md` rather than `lg`
- Increase padding @ top of outline & progress titles
- Contain 100% grade tooltip within card
- Vertical centering for currently passing/non-passing message
- Fix grade range tooltip wrapping by itself

<img width="487" alt="Screen Shot 2021-05-10 at 2 53 32 PM" src="https://user-images.githubusercontent.com/25124041/117710006-9b65f980-b19f-11eb-989e-b31cf1803aa6.png">
<img width="679" alt="Screen Shot 2021-05-10 at 2 53 18 PM" src="https://user-images.githubusercontent.com/25124041/117710023-9f921700-b19f-11eb-88f6-70695176fbe3.png">