### PR TITLE
fix: remove currency symbol to avoid double currency symbol with some upgrade buttons

### DIFF
--- a/src/course-home/outline-tab/widgets/UpgradeCard.test.jsx
+++ b/src/course-home/outline-tab/widgets/UpgradeCard.test.jsx
@@ -134,8 +134,8 @@ describe('Upgrade Card', () => {
         expirationDate: discountExpirationDate.toString(),
         percentage: 15,
         code: 'Welcome15',
-        discountedPrice: '126.65',
-        originalPrice: '149',
+        discountedPrice: '$126.65',
+        originalPrice: '$149',
         upgradeUrl: 'www.exampleUpgradeUrl.com',
       },
     });
@@ -163,8 +163,8 @@ describe('Upgrade Card', () => {
         expirationDate: discountExpirationDate.toString(),
         percentage: 15,
         code: 'Welcome15',
-        discountedPrice: '126.65',
-        originalPrice: '149',
+        discountedPrice: '$126.65',
+        originalPrice: '$149',
         upgradeUrl: 'www.exampleUpgradeUrl.com',
       },
     });
@@ -192,8 +192,8 @@ describe('Upgrade Card', () => {
         expirationDate: discountExpirationDate.toString(),
         percentage: 15,
         code: 'Welcome15',
-        discountedPrice: '126.65',
-        originalPrice: '149',
+        discountedPrice: '$126.65',
+        originalPrice: '$149',
         upgradeUrl: 'www.exampleUpgradeUrl.com',
       },
     });
@@ -221,8 +221,8 @@ describe('Upgrade Card', () => {
         expirationDate: discountExpirationDate.toString(),
         percentage: 15,
         code: 'Welcome15',
-        discountedPrice: '126.65',
-        originalPrice: '149',
+        discountedPrice: '$126.65',
+        originalPrice: '$149',
         upgradeUrl: 'www.exampleUpgradeUrl.com',
       },
     });

--- a/src/generic/upgrade-button/FormattedPricing.jsx
+++ b/src/generic/upgrade-button/FormattedPricing.jsx
@@ -53,7 +53,7 @@ function FormattedPricing(props) {
         {intl.formatMessage(messages.srPrices, { discountedPrice, originalPrice })}
       </span>
       <span aria-hidden="true">
-        <span>{currencySymbol}{discountedPrice}</span> (<del>{currencySymbol}{originalPrice}</del>)
+        <span>{discountedPrice}</span> (<del>{originalPrice}</del>)
       </span>
     </>
   );

--- a/src/shared/streak-celebration/StreakCelebrationModal.jsx
+++ b/src/shared/streak-celebration/StreakCelebrationModal.jsx
@@ -90,8 +90,8 @@ function StreakModal({
     };
 
     offer = {
-      discountedPrice: (mode.price * 0.85).toFixed(2).toString(),
-      originalPrice: mode.price.toString(),
+      discountedPrice: `${verifiedMode.currencySymbol}${(mode.price * 0.85).toFixed(2).toString()}`,
+      originalPrice: `${verifiedMode.currencySymbol}${mode.price.toString()}`,
       upgradeUrl: mode.upgradeUrl,
     };
   }


### PR DESCRIPTION
i was adding a currency symbol but discounted_price and original_price both come with the currency symbol already