### PR TITLE
fix: gated content banner discount display

### DIFF
--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -155,7 +155,6 @@ function LockPaywall({
             offer={offer}
             onClick={logClick}
             verifiedMode={verifiedMode}
-            className="lock_paywall_upgrade_link"
           />
         </div>
       </div>

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -5,12 +5,13 @@ import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
-  Alert, Button, Icon,
+  Alert, Icon,
 } from '@edx/paragon';
 import { Locked } from '@edx/paragon/icons';
 import messages from './messages';
 import certificateLocked from '../../../../generic/assets/edX_locked_certificate.png';
 import { useModel } from '../../../../generic/model-store';
+import { UpgradeButton } from '../../../../generic/upgrade-button';
 import './LockPaywall.scss';
 
 function LockPaywall({
@@ -19,6 +20,7 @@ function LockPaywall({
 }) {
   const course = useModel('coursewareMeta', courseId);
   const {
+    offer,
     org,
     verifiedMode,
   } = course;
@@ -26,11 +28,6 @@ function LockPaywall({
   if (!verifiedMode) {
     return null;
   }
-  const {
-    currencySymbol,
-    price,
-    upgradeUrl,
-  } = verifiedMode;
 
   const eventProperties = {
     org_key: org,
@@ -154,17 +151,12 @@ function LockPaywall({
           className="col-md-auto p-md-0 d-md-flex align-items-md-center mr-md-3"
           style={{ textAlign: 'right' }}
         >
-          <Button
-            className="lock_paywall_upgrade_link"
-            href={upgradeUrl}
+          <UpgradeButton
+            offer={offer}
             onClick={logClick}
-            role="link"
-          >
-            {intl.formatMessage(messages['learn.lockPaywall.upgrade.link'], {
-              currencySymbol,
-              price,
-            })}
-          </Button>
+            verifiedMode={verifiedMode}
+            className="lock_paywall_upgrade_link"
+          />
         </div>
       </div>
     </Alert>

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -72,7 +72,7 @@ function LockPaywall({
       {intl.formatMessage(messages['learn.lockPaywall.list.bullet3.boldtext'])}
     </span>
   );
-  const nonProfit = (
+  const nonProfitMission = (
     <span className="font-weight-bold">
       {intl.formatMessage(messages['learn.lockPaywall.list.bullet4.boldtext'])}
     </span>
@@ -138,8 +138,8 @@ function LockPaywall({
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
                   <FormattedMessage
                     id="gatedContent.paragraph.bulletFour"
-                    defaultMessage="Support our {nonProfit} mission at edX"
-                    values={{ nonProfit }}
+                    defaultMessage="Support our {nonProfitMission} at edX"
+                    values={{ nonProfitMission }}
                   />
                 </li>
               </ul>

--- a/src/courseware/course/sequence/lock-paywall/messages.js
+++ b/src/courseware/course/sequence/lock-paywall/messages.js
@@ -38,7 +38,7 @@ const messages = defineMessages({
   },
   'learn.lockPaywall.list.bullet4.boldtext': {
     id: 'learn.lockPaywall.list.bullet4.boldtext',
-    defaultMessage: 'non-profit',
+    defaultMessage: 'non-profit mission',
     description: 'Bolded text to highlight our non-profit status.',
   },
 });

--- a/src/courseware/course/sequence/lock-paywall/messages.js
+++ b/src/courseware/course/sequence/lock-paywall/messages.js
@@ -11,11 +11,6 @@ const messages = defineMessages({
     defaultMessage: 'Upgrade to gain access to locked features like this one and get the most out of your course.',
     description: 'Message shown to indicate that a piece of content is unavailable to audit track users.',
   },
-  'learn.lockPaywall.upgrade.link': {
-    id: 'learn.lockPaywall.upgrade.link',
-    defaultMessage: 'Upgrade for {currencySymbol}{price}',
-    description: 'A link users can click that navigates their browser to the upgrade payment page.',
-  },
   'learn.lockPaywall.example.alt': {
     id: 'learn.lockPaywall.example.alt',
     defaultMessage: 'Example Certificate',


### PR DESCRIPTION
[REV-2232](https://openedx.atlassian.net/browse/REV-2232).

Bug fix for enabling the display of a discount in the upgrade button in the gated content banner. 
This is part of the Value Prop work.

![Screen Shot 2021-05-28 at 12 35 26 PM](https://user-images.githubusercontent.com/13632680/120015921-f0807880-bfb1-11eb-8b5e-00a3568b9941.png)
Thanks @dianekaplan for checking out this locally and for the screenshot :)

**Note on Codecov:**
The -0.01% decrease in Codecov looks like it's a fraction issue (covered lines ÷ total lines) rather than a "no coverage" for the added lines issue. I've discussed it with Purchase Squad, and will go ahead and ignore the failing Codecov report.