### PR TITLE
REV-2253: remove first purchase discount banner from course home

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -22,7 +22,6 @@ import useAccessExpirationAlert from '../../alerts/access-expiration-alert';
 import useCertificateAvailableAlert from './alerts/certificate-available-alert';
 import useCourseEndAlert from './alerts/course-end-alert';
 import useCourseStartAlert from './alerts/course-start-alert';
-import useOfferAlert from '../../alerts/offer-alert';
 import usePrivateCourseAlert from './alerts/private-course-alert';
 import { useModel } from '../../generic/model-store';
 import WelcomeMessage from './widgets/WelcomeMessage';
@@ -86,7 +85,6 @@ function OutlineTab({ intl }) {
   };
 
   // Below the course title alerts (appearing in the order listed here)
-  const offerAlert = useOfferAlert(courseId, offer, org, userTimezone, 'outline-course-alerts', 'course_home');
   const accessExpirationAlert = useAccessExpirationAlert(accessExpiration, courseId, org, userTimezone, 'outline-course-alerts', 'course_home');
   const courseStartAlert = useCourseStartAlert(courseId);
   const courseEndAlert = useCourseEndAlert(courseId);
@@ -153,7 +151,6 @@ function OutlineTab({ intl }) {
                 ...certificateAvailableAlert,
                 ...courseEndAlert,
                 ...courseStartAlert,
-                ...offerAlert,
               }}
             />
             )}

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -689,53 +689,6 @@ describe('Outline Tab', () => {
         await screen.findByText('Your grade and certificate will be ready soon!');
       });
     });
-
-    describe('Offer Alert', () => {
-      it('sends analytics event onClick of upgrade link', async () => {
-        setTabData({
-          offer: {
-            code: 'EDXWELCOME',
-            expiration_date: '2070-01-01T12:00:00Z',
-            original_price: '$100',
-            discounted_price: '$85',
-            percentage: 15,
-            upgrade_url: 'https://example.com/upgrade',
-          },
-        });
-        await fetchAndRender();
-
-        expect(screen.getByRole('link', { name: 'Upgrade now' })).toBeInTheDocument();
-      });
-
-      it('sends analytics event onClick of upgrade link', async () => {
-        setTabData({
-          offer: {
-            code: 'EDXWELCOME',
-            expiration_date: '2070-01-01T12:00:00Z',
-            original_price: '$100',
-            discounted_price: '$85',
-            percentage: 15,
-            upgrade_url: 'https://example.com/upgrade',
-          },
-        });
-        await fetchAndRender();
-
-        // Clearing after render to remove any events sent on view (ex. 'Promotion Viewed')
-        sendTrackEvent.mockClear();
-        const upgradeLink = screen.getByRole('link', { name: 'Upgrade now' });
-        fireEvent.click(upgradeLink);
-
-        expect(sendTrackEvent).toHaveBeenCalledTimes(1);
-        expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.upsell_links_clicked', {
-          org_key: 'edX',
-          courserun_key: courseId,
-          linkCategory: 'welcome',
-          linkName: 'course_home_welcome',
-          linkType: 'link',
-          pageName: 'course_home',
-        });
-      });
-    });
   });
 
   describe('Proctoring Info Panel', () => {


### PR DESCRIPTION
## Description
The Value Prop redesign streamlines our messaging so we won't need so many different upsell links. Here we remove the first purchase discount from the learning MFE (aka EDXWELCOME banner aka course_home_welcome upsell link**).

Earlier PR [here](https://github.com/edx/edx-platform/pull/27603) removed it from the old courseware, here we take it off the course home page in the learning MFE (and leave it in place in courseware). Note: offer still is accessible to the expiration box (strikethrough price shows discount). 


## Supporting information
Relevant Jira ticket: https://openedx.atlassian.net/browse/REV-2253

## Deadline
None- this upsell link is redundant now that the new expiration box is live (5/6), so removing it will cut down on clutter

## Note:
The offerAlert code looks very generic, but the only thing it can contain right now is the first purchase discount: 
- the learning MFE's getOutlineTabData calls the edx-platform API at /api/course_home/v1/outline/${courseId}
- in edx-platform, that endpoint gets to the course_home_api's OutlineTabView class, whose get method grabs data from the generate_offer_data method, which only can return the first purchase discount or nothing: https://github.com/edx/edx-platform/blob/c3a22eb6e55c0a59dab093f9357b7027274b313d/openedx/features/discounts/utils.py#L74

Before: 
![Screen Shot 2021-05-28 at 9 24 15 AM](https://user-images.githubusercontent.com/5384216/119991044-0a609200-bf97-11eb-90c4-d9640c6ff4bd.png)

After: 
![Screen Shot 2021-05-28 at 9 20 52 AM](https://user-images.githubusercontent.com/5384216/119991017-016fc080-bf97-11eb-8da6-03a1a5f141be.png)
