### PR TITLE
fix: display Unit titles as <h1> (TNL-8387)

### DIFF
--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -135,7 +135,7 @@ function Unit({
 
   return (
     <div className="unit">
-      <h2 className="mb-0 h3">{unit.title}</h2>
+      <h1 className="mb-0 h3">{unit.title}</h1>
       <BookmarkButton
         unitId={unit.id}
         isBookmarked={unit.bookmarked}


### PR DESCRIPTION
```
Unit titles were being written to the page as <h2> because the old
courseware experience reserved <h1> for wrapping the header logo link.
We've since determined that this is not a best practice, and the new
courseware MFE in this repo no longer uses a <h1> for that purpose, but
the Unit title was never promoted from <h2> to <h1> until this commit.

Course teams have traditionally been permitted to use <h3>-<h6> in their
content. Making this change does mean that there will now be a gap with
some content, where we skip from <h1> to <h3>. For the short term, we
are NOT recommending course teams use <h2>, until we have a better
chance to evaluate whether that heading should remain reserved for
platform-level use.
```
