### PR TITLE
[AA-805] fix: ensure clicking the bookmarks button doesn't break the unitHasLoaded property

### DIFF
--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -117,11 +117,16 @@ function Sequence({
   const handleUnitLoaded = () => {
     setUnitHasLoaded(true);
   };
+
+  // We want hide the unit navigation if we're in the middle of navigating to another unit
+  // but not if other things about the unit change, like the bookmark status.
+  // The array property of this useEffect ensures that we only hide the unit navigation
+  // while navigating to another unit.
   useEffect(() => {
     if (unit) {
       setUnitHasLoaded(false);
     }
-  }, [unit]);
+  }, [(unit || {}).id]);
 
   if (sequenceStatus === 'loading') {
     if (!sequenceId) {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/AA-805

Currently [unitHasLoaded](https://github.com/edx/frontend-app-learning/pull/481/files#diff-19c40869566f3bb029d00d9c4f53277b366fc5f4cf9c1c2d243329b4625f69ceL200) is being used to hide the unit navigation when it is false

We don't want to show the unit navigation while switching between units within a sequence, so the existing code sets unitHasLoaded to false whenever the unit changes.
However, this has the unintended effect of hiding the unit navigation when other things about the unit change like the bookmark state.

As a solution, we make the useEffect hook array properties more narrow by only triggering on the unit.id instead of anything about the unit.