### PR TITLE
fix: Autoscroll on page when using jump_to_id

### DIFF
--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -99,6 +99,13 @@ function Unit({
 
   const dispatch = useDispatch();
 
+  const checkForHash = () => {
+    const { hash } = window.location;
+    if (hash) {
+      const unitIframe = document.getElementById('unit-iframe');
+      unitIframe.contentWindow.postMessage({ hashName: hash }, `${getConfig().LMS_BASE_URL}`);
+    }
+  };
   // Do not remove this hook.  See function description.
   useLoadBearingHook(id);
 
@@ -215,6 +222,7 @@ function Unit({
             scrolling="no"
             referrerPolicy="origin"
             onLoad={() => {
+              checkForHash();
               window.onmessage = function handleResetDates(e) {
                 if (e.data.event_name) {
                   dispatch(processEvent(e.data, fetchCourse));

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -221,8 +221,7 @@ function Unit({
             scrolling="no"
             referrerPolicy="origin"
             onLoad={() => {
-              const unitIframe = document.getElementById('unit-iframe');
-              checkForHash(unitIframe);
+              checkForHash(document.getElementById('unit-iframe'));
               window.onmessage = function handleResetDates(e) {
                 if (e.data.event_name) {
                   dispatch(processEvent(e.data, fetchCourse));

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -70,9 +70,10 @@ function useLoadBearingHook(id) {
   }, [id]);
 }
 
-export function checkForHash(frame) {
+export function sendHash(frame) {
   const { hash } = window.location;
   if (hash) {
+    // The hash will be sent to LMS so that the location of the hash can be found.
     frame.contentWindow.postMessage({ hashName: hash }, `${getConfig().LMS_BASE_URL}`);
   }
 }
@@ -111,7 +112,7 @@ function Unit({
   // We use this ref so that we can hold a reference to the currently active event listener.
   const messageEventListenerRef = useRef(null);
   useEffect(() => {
-    checkForHash(document.getElementById('unit-iframe'));
+    sendHash(document.getElementById('unit-iframe'));
     function receiveMessage(event) {
       const { type, payload } = event.data;
       if (type === 'plugin.resize') {

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -111,6 +111,7 @@ function Unit({
   // We use this ref so that we can hold a reference to the currently active event listener.
   const messageEventListenerRef = useRef(null);
   useEffect(() => {
+    checkForHash(document.getElementById('unit-iframe'));
     function receiveMessage(event) {
       const { type, payload } = event.data;
       if (type === 'plugin.resize') {
@@ -212,7 +213,6 @@ function Unit({
       { !mmp2p.meta.blockContent && !userNeedsIntegritySignature && (
         <div className="unit-iframe-wrapper">
           <iframe
-            data-testid="iframe-unit"
             id="unit-iframe"
             title={unit.title}
             src={iframeUrl}
@@ -222,7 +222,6 @@ function Unit({
             scrolling="no"
             referrerPolicy="origin"
             onLoad={() => {
-              checkForHash(document.getElementById('unit-iframe'));
               window.onmessage = function handleResetDates(e) {
                 if (e.data.event_name) {
                   dispatch(processEvent(e.data, fetchCourse));

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -70,10 +70,11 @@ function useLoadBearingHook(id) {
   }, [id]);
 }
 
-export function sendHash(frame) {
+export function sendUrlHashToFrame(frame) {
   const { hash } = window.location;
   if (hash) {
-    // The hash will be sent to LMS so that the location of the hash can be found.
+    // The url hash will be sent to LMS-served iframe in order to find the location of the
+    // hash within the iframe.
     frame.contentWindow.postMessage({ hashName: hash }, `${getConfig().LMS_BASE_URL}`);
   }
 }
@@ -112,7 +113,7 @@ function Unit({
   // We use this ref so that we can hold a reference to the currently active event listener.
   const messageEventListenerRef = useRef(null);
   useEffect(() => {
-    sendHash(document.getElementById('unit-iframe'));
+    sendUrlHashToFrame(document.getElementById('unit-iframe'));
     function receiveMessage(event) {
       const { type, payload } = event.data;
       if (type === 'plugin.resize') {
@@ -128,7 +129,7 @@ function Unit({
         setModalOptions(payload);
       } else if (event.data.offset) {
         // We listen for this message from LMS to know when the page needs to
-        // be scroll to another location on the page.
+        // be scrolled to another location on the page.
         window.scrollTo(0, event.data.offset);
       }
     }

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -212,6 +212,7 @@ function Unit({
       { !mmp2p.meta.blockContent && !userNeedsIntegritySignature && (
         <div className="unit-iframe-wrapper">
           <iframe
+            data-testid="iframe-unit"
             id="unit-iframe"
             title={unit.title}
             src={iframeUrl}

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -70,6 +70,13 @@ function useLoadBearingHook(id) {
   }, [id]);
 }
 
+export function checkForHash(frame) {
+  const { hash } = window.location;
+  if (hash) {
+    frame.contentWindow.postMessage({ hashName: hash }, `${getConfig().LMS_BASE_URL}`);
+  }
+}
+
 function Unit({
   courseId,
   format,
@@ -98,14 +105,6 @@ function Unit({
   } = course;
 
   const dispatch = useDispatch();
-
-  const checkForHash = () => {
-    const { hash } = window.location;
-    if (hash) {
-      const unitIframe = document.getElementById('unit-iframe');
-      unitIframe.contentWindow.postMessage({ hashName: hash }, `${getConfig().LMS_BASE_URL}`);
-    }
-  };
   // Do not remove this hook.  See function description.
   useLoadBearingHook(id);
 
@@ -222,7 +221,8 @@ function Unit({
             scrolling="no"
             referrerPolicy="origin"
             onLoad={() => {
-              checkForHash();
+              const unitIframe = document.getElementById('unit-iframe');
+              checkForHash(unitIframe);
               window.onmessage = function handleResetDates(e) {
                 if (e.data.event_name) {
                   dispatch(processEvent(e.data, fetchCourse));

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -3,7 +3,7 @@ import { Factory } from 'rosie';
 import {
   initializeTestStore, loadUnit, messageEvent, render, screen, waitFor,
 } from '../../../setupTest';
-import Unit, { checkForHash } from './Unit';
+import Unit, { sendHash } from './Unit';
 
 describe('Unit', () => {
   let mockData;
@@ -126,7 +126,7 @@ describe('Unit', () => {
   it('scrolls to correct place onLoad', () => {
     document.body.innerHTML = "<iframe id='unit-iframe' />";
 
-    const mockHashCheck = jest.fn(frameVar => checkForHash(frameVar));
+    const mockHashCheck = jest.fn(frameVar => sendHash(frameVar));
     const frame = document.getElementById('unit-iframe');
     const originalWindow = { ...window };
     const windowSpy = jest.spyOn(global, 'window', 'get');
@@ -148,7 +148,7 @@ describe('Unit', () => {
   });
 
   it('calls useEffect and checkForHash', () => {
-    const mockHashCheck = jest.fn(() => checkForHash());
+    const mockHashCheck = jest.fn(() => sendHash());
     const effectSpy = jest.spyOn(React, 'useEffect');
     effectSpy.mockImplementation(() => mockHashCheck());
     render(<Unit {...mockData} />);

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -79,20 +79,6 @@ describe('Unit', () => {
     expect(screen.getByTitle(unit.display_name)).toHaveAttribute('height', String(messageEvent.payload.height));
   });
 
-  it('calls iframe attribute onLoad', async () => {
-    const mockHashCheck = jest.fn(frameVar => checkForHash(frameVar));
-    render(<Unit {...mockData} />);
-    const frame = screen.getByTestId('iframe-unit');
-
-    expect(frame).toBeInTheDocument();
-
-    frame.onLoad = jest.fn(() => mockHashCheck);
-    const loadSpy = jest.spyOn(frame, 'onLoad');
-    frame.onLoad();
-
-    expect(loadSpy).toHaveBeenCalled();
-  });
-
   it('calls onLoaded after receiving MessageEvent', async () => {
     const onLoaded = jest.fn();
     render(<Unit {...mockData} {...{ onLoaded }} />);
@@ -157,5 +143,16 @@ describe('Unit', () => {
 
     expect(mockHashCheck).toHaveBeenCalled();
     expect(messageSpy).toHaveBeenCalled();
+
+    windowSpy.mockRestore();
+  });
+
+  it('calls useEffect and checkForHash', () => {
+    const mockHashCheck = jest.fn(() => checkForHash());
+    const effectSpy = jest.spyOn(React, 'useEffect');
+    effectSpy.mockImplementation(() => mockHashCheck());
+    render(<Unit {...mockData} />);
+    expect(React.useEffect).toHaveBeenCalled();
+    expect(mockHashCheck).toHaveBeenCalled();
   });
 });

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -79,6 +79,20 @@ describe('Unit', () => {
     expect(screen.getByTitle(unit.display_name)).toHaveAttribute('height', String(messageEvent.payload.height));
   });
 
+  it('calls iframe attribute onLoad', async () => {
+    const mockHashCheck = jest.fn(frameVar => checkForHash(frameVar));
+    render(<Unit {...mockData} />);
+    const frame = screen.getByTestId('iframe-unit');
+
+    expect(frame).toBeInTheDocument();
+
+    frame.onLoad = jest.fn(() => mockHashCheck);
+    const loadSpy = jest.spyOn(frame, 'onLoad');
+    frame.onLoad();
+
+    expect(loadSpy).toHaveBeenCalled();
+  });
+
   it('calls onLoaded after receiving MessageEvent', async () => {
     const onLoaded = jest.fn();
     render(<Unit {...mockData} {...{ onLoaded }} />);

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -3,7 +3,7 @@ import { Factory } from 'rosie';
 import {
   initializeTestStore, loadUnit, messageEvent, render, screen, waitFor,
 } from '../../../setupTest';
-import Unit, { sendHash } from './Unit';
+import Unit, { sendUrlHashToFrame } from './Unit';
 
 describe('Unit', () => {
   let mockData;
@@ -126,7 +126,7 @@ describe('Unit', () => {
   it('scrolls to correct place onLoad', () => {
     document.body.innerHTML = "<iframe id='unit-iframe' />";
 
-    const mockHashCheck = jest.fn(frameVar => sendHash(frameVar));
+    const mockHashCheck = jest.fn(frameVar => sendUrlHashToFrame(frameVar));
     const frame = document.getElementById('unit-iframe');
     const originalWindow = { ...window };
     const windowSpy = jest.spyOn(global, 'window', 'get');
@@ -148,7 +148,7 @@ describe('Unit', () => {
   });
 
   it('calls useEffect and checkForHash', () => {
-    const mockHashCheck = jest.fn(() => sendHash());
+    const mockHashCheck = jest.fn(() => sendUrlHashToFrame());
     const effectSpy = jest.spyOn(React, 'useEffect');
     effectSpy.mockImplementation(() => mockHashCheck());
     render(<Unit {...mockData} />);

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -126,7 +126,7 @@ describe('Unit', () => {
   it('scrolls to correct place onLoad', () => {
     document.body.innerHTML = "<iframe id='unit-iframe' />";
 
-    const mockHashCheck = jest.fn(checkForHash());
+    const mockHashCheck = jest.fn(frameVar => checkForHash(frameVar));
     const frame = document.getElementById('unit-iframe');
     const originalWindow = { ...window };
     const windowSpy = jest.spyOn(global, 'window', 'get');
@@ -137,8 +137,11 @@ describe('Unit', () => {
         hash: '#test',
       },
     }));
+    const messageSpy = jest.spyOn(frame.contentWindow, 'postMessage');
+    messageSpy.mockImplementation(() => ({ hashName: originalWindow.location.hash }));
     mockHashCheck(frame);
 
     expect(mockHashCheck).toHaveBeenCalled();
+    expect(messageSpy).toHaveBeenCalled();
   });
 });

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Factory } from 'rosie';
 import {
-  initializeTestStore, loadUnit, messageEvent, render, screen, waitFor,
+  initializeTestStore, loadUnit, loadScroll, messageEvent, scrollEvent, render, screen, waitFor,
 } from '../../../setupTest';
 import Unit from './Unit';
 
@@ -124,5 +124,17 @@ describe('Unit', () => {
       () => expect(screen.getByTitle(unit.display_name)).toHaveAttribute('height', String(testMessageWithUnhandledType.payload.height)),
       { timeout: 100 },
     )).rejects.toThrowError(/Expected the element to have attribute/);
+  });
+
+  it('scrolls to correct place onLoad', () => {
+    const onLoaded = jest.fn();
+    const message = { hashName: '#test' };
+    window.postMessage = jest.fn();
+
+    render(<Unit {...mockData} {...{ onLoaded }} />);
+    loadScroll(message);
+
+    expect(window.postMessage).toHaveBeenCalled();
+    expect(window.postMessage).toHaveBeenCalledWith(scrollEvent, '*');
   });
 });

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -118,16 +118,6 @@ export function loadUnit(message = messageEvent) {
   window.postMessage(message, '*');
 }
 
-export const scrollEvent = {
-  offset: 1500,
-};
-
-export function loadScroll(message) {
-  if (message.hashName[0] === '#') {
-    window.postMessage(scrollEvent, '*');
-  }
-}
-
 // Helper function to log unhandled API requests to the console while running tests.
 export function logUnhandledRequests(axiosMock) {
   axiosMock.onAny().reply((config) => {

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -118,6 +118,16 @@ export function loadUnit(message = messageEvent) {
   window.postMessage(message, '*');
 }
 
+export const scrollEvent = {
+  offset: 1500,
+};
+
+export function loadScroll(message) {
+  if (message.hashName[0] === '#') {
+    window.postMessage(scrollEvent, '*');
+  }
+}
+
 // Helper function to log unhandled API requests to the console while running tests.
 export function logUnhandledRequests(axiosMock) {
   axiosMock.onAny().reply((config) => {


### PR DESCRIPTION
This PR changes the default function of HTML anchor tags that focus on another element on a different page in the course. Previously the anchor tags that were set to scroll on a different page would open up the page but remain at the top of the page. As a result, users would have to manually scroll to the correct part of the page if that information is known or they will read the entire page. Now when the anchor tag is used to focus on a different page, the link of the new page is checked for a hash and sends the location of the hash to the parent page to scroll to the correct location. This change will impact the Learner in the New Experience view.

This PR is connected to [PR-27952](https://github.com/edx/edx-platform/pull/27952) in the edx-platform repo.