### PR TITLE
fix: remove sequences we shouldn't see by using learning_sequences

### DIFF
--- a/src/courseware/CoursewareContainer.test.jsx
+++ b/src/courseware/CoursewareContainer.test.jsx
@@ -121,6 +121,9 @@ describe('CoursewareContainer', () => {
     const courseBlocksUrlRegExp = new RegExp(`${getConfig().LMS_BASE_URL}/api/courses/v2/blocks/*`);
     axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);
 
+    const learningSequencesUrlRegExp = new RegExp(`${getConfig().LMS_BASE_URL}/api/learning_sequences/v1/course_outline/*`);
+    axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
+
     const courseMetadataUrl = appendBrowserTimezoneToUrl(`${getConfig().LMS_BASE_URL}/api/courseware/course/${courseId}`);
     axiosMock.onGet(courseMetadataUrl).reply(200, courseMetadata);
 

--- a/src/courseware/course/course-exit/CourseExit.test.jsx
+++ b/src/courseware/course/course-exit/CourseExit.test.jsx
@@ -33,6 +33,8 @@ describe('Course Exit Pages', () => {
   const courseBlocksUrlRegExp = new RegExp(`${getConfig().LMS_BASE_URL}/api/courses/v2/blocks/*`);
   const discoveryRecommendationsUrl = new RegExp(`${getConfig().DISCOVERY_API_BASE_URL}/api/v1/course_recommendations/*`);
   const enrollmentsUrl = new RegExp(`${getConfig().LMS_BASE_URL}/api/enrollment/v1/enrollment*`);
+  const learningSequencesUrlRegExp = new RegExp(`${getConfig().LMS_BASE_URL}/api/learning_sequences/v1/course_outline/*`);
+
   function setMetadata(attributes) {
     const courseMetadata = { ...defaultMetadata, ...attributes };
     axiosMock.onGet(courseMetadataUrl).reply(200, courseMetadata);
@@ -51,6 +53,8 @@ describe('Course Exit Pages', () => {
     axiosMock.onGet(discoveryRecommendationsUrl).reply(200,
       Factory.build('courseRecommendations', {}, { numRecs: 2 }));
     axiosMock.onGet(enrollmentsUrl).reply(200, []);
+    axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
+
     logUnhandledRequests(axiosMock);
   });
 
@@ -366,6 +370,7 @@ describe('Course Exit Pages', () => {
       const courseBlocks = buildSimpleCourseBlocks(defaultMetadata.id, defaultMetadata.name,
         { hasScheduledContent: true });
       axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);
+      axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
 
       await fetchAndRender(<CourseInProgress />);
       expect(screen.getByText('More content is coming soon!')).toBeInTheDocument();

--- a/src/courseware/data/__factories__/learningSequencesOutline.factory.js
+++ b/src/courseware/data/__factories__/learningSequencesOutline.factory.js
@@ -1,0 +1,37 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+
+Factory.define('learningSequencesOutline')
+  .option('courseId', (courseId) => {
+    if (courseId) {
+      return courseId;
+    }
+    throw new Error('courseId must be specified for learningSequencesOutline factory.');
+  })
+  .attrs({
+    outline: {
+      sequences: {
+      },
+    },
+  });
+
+export function buildEmptyOutline(courseId) {
+  return Factory.build(
+    'learningSequencesOutline',
+    {},
+    { courseId },
+  );
+}
+
+export function buildSimpleOutline(courseId, sequenceBlocks) {
+  return Factory.build(
+    'learningSequencesOutline',
+    {
+      outline: {
+        sequences: Object.fromEntries(
+          sequenceBlocks.map(({ id }) => [id, {}]),
+        ),
+      },
+    },
+    { courseId },
+  );
+}

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -152,9 +152,11 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
   forbiddenCourseUrl = appendBrowserTimezoneToUrl(forbiddenCourseUrl);
 
   const courseBlocksUrlRegExp = new RegExp(`${getConfig().LMS_BASE_URL}/api/courses/v2/blocks/*`);
+  const learningSequencesUrlRegExp = new RegExp(`${getConfig().LMS_BASE_URL}/api/learning_sequences/v1/course_outline/*`);
 
   axiosMock.onGet(forbiddenCourseUrl).reply(200, courseMetadata);
   axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);
+  axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
   sequenceMetadata.forEach(metadata => {
     const sequenceMetadataUrl = `${getConfig().LMS_BASE_URL}/api/courseware/sequence/${metadata.item_id}`;
     axiosMock.onGet(sequenceMetadataUrl).reply(200, metadata);


### PR DESCRIPTION
Removes sequences we shouldn't see by using the Learning Sequences API (TNL-8377).

It works by adding a call to the Learning Sequences API and (if that endpoint is enabled, i.e. returns 200 for this user+course), uses the results of that endpoint to remove sequences from the Course Blocks API call. Learning Sequences knows how to do things like bubble up the content group settings of units to sequences for the case where all units have the same restrictions and the user would see an empty sequence.

Depends on https://github.com/edx/frontend-app-learning/pull/488#:~:text=edx/edx-platform%2327955