### PR TITLE
fix: guard against courseGoals being undefined

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -52,7 +52,7 @@ function OutlineTab({ intl }) {
     courseGoals: {
       goalOptions,
       selectedGoal,
-    },
+    } = {},
     datesBannerInfo,
     datesWidget: {
       courseDateBlocks,


### PR DESCRIPTION
No idea why this would happen honestly - it looks always defined from the backend, and api.js doesn't transorm it. But we are seeing JS errors related to it. So trying this as a first pass.

https://openedx.atlassian.net/browse/AA-848