### PR TITLE
feat: Remove upsell banner on course home

### DIFF
--- a/src/alerts/access-expiration-alert/AccessExpirationAlert.jsx
+++ b/src/alerts/access-expiration-alert/AccessExpirationAlert.jsx
@@ -1,31 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import {
   FormattedMessage, FormattedDate, injectIntl, intlShape,
 } from '@edx/frontend-platform/i18n';
-import { Hyperlink } from '@edx/paragon';
 
 import { Alert, ALERT_TYPES } from '../../generic/user-messages';
-import messages from './messages';
-import AccessExpirationAlertMMP2P from './AccessExpirationAlertMMP2P';
 
-function AccessExpirationAlert({ intl, payload }) {
-  /** [MM-P2P] Experiment */
-  const [showMMP2P, setShowMMP2P] = useState(!!window.experiment__home_alert_bShowMMP2P);
-  if (window.experiment__home_alert_showMMP2P === undefined) {
-    window.experiment__home_alert_showMMP2P = (val) => {
-      window.experiment__home_alert_bShowMMP2P = !!val;
-      setShowMMP2P(!!val);
-    };
-  }
-
+function AccessExpirationAlert({ payload }) {
   const {
     accessExpiration,
-    courseId,
-    org,
     userTimezone,
-    analyticsPageName,
   } = payload;
   const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
 
@@ -36,8 +20,6 @@ function AccessExpirationAlert({ intl, payload }) {
   const {
     expirationDate,
     masqueradingExpiredCourse,
-    upgradeDeadline,
-    upgradeUrl,
   } = accessExpiration;
 
   if (masqueradingExpiredCourse) {
@@ -63,98 +45,7 @@ function AccessExpirationAlert({ intl, payload }) {
     );
   }
 
-  /** [MM-P2P] Experiment */
-  if (showMMP2P) {
-    return (
-      <AccessExpirationAlertMMP2P payload={payload} />
-    );
-  }
-
-  const logClick = () => {
-    sendTrackEvent('edx.bi.ecommerce.upsell_links_clicked', {
-      org_key: org,
-      courserun_key: courseId,
-      linkCategory: 'FBE_banner',
-      linkName: `${analyticsPageName}_audit_access_expires`,
-      linkType: 'link',
-      pageName: analyticsPageName,
-    });
-  };
-
-  let deadlineMessage = null;
-  if (upgradeDeadline && upgradeUrl) {
-    deadlineMessage = (
-      <>
-        <br />
-        <FormattedMessage
-          id="learning.accessExpiration.deadline"
-          defaultMessage="Upgrade by {date} to get unlimited access to the course as long as it exists on the site."
-          values={{
-            date: (
-              <FormattedDate
-                key="accessExpirationUpgradeDeadline"
-                day="numeric"
-                month="short"
-                year="numeric"
-                value={upgradeDeadline}
-                {...timezoneFormatArgs}
-              />
-            ),
-          }}
-        />
-        &nbsp;
-        <Hyperlink
-          className="font-weight-bold"
-          style={{ textDecoration: 'underline' }}
-          destination={upgradeUrl}
-          onClick={logClick}
-        >
-          {intl.formatMessage(messages.upgradeNow)}
-        </Hyperlink>
-      </>
-    );
-  }
-
-  return (
-    <Alert type={ALERT_TYPES.INFO}>
-      <span className="font-weight-bold">
-        <FormattedMessage
-          id="learning.accessExpiration.header"
-          defaultMessage="Audit Access Expires {date}"
-          values={{
-            date: (
-              <FormattedDate
-                key="accessExpirationHeaderDate"
-                day="numeric"
-                month="short"
-                year="numeric"
-                value={expirationDate}
-                {...timezoneFormatArgs}
-              />
-            ),
-          }}
-        />
-      </span>
-      <br />
-      <FormattedMessage
-        id="learning.accessExpiration.body"
-        defaultMessage="You lose all access to this course, including your progress, on {date}."
-        values={{
-          date: (
-            <FormattedDate
-              key="accessExpirationBodyDate"
-              day="numeric"
-              month="short"
-              year="numeric"
-              value={expirationDate}
-              {...timezoneFormatArgs}
-            />
-          ),
-        }}
-      />
-      {deadlineMessage}
-    </Alert>
-  );
+  return null;
 }
 
 AccessExpirationAlert.propTypes = {

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -533,59 +533,6 @@ describe('Outline Tab', () => {
         await fetchAndRender();
         await screen.findByText('This learner does not have access to this course.', { exact: false });
       });
-
-      it('shows expiration', async () => {
-        setTabData({
-          access_expiration: {
-            expiration_date: '2080-01-01T12:00:00Z',
-            masquerading_expired_course: false,
-            upgrade_deadline: null,
-            upgrade_url: null,
-          },
-        });
-        await fetchAndRender();
-        await screen.findByText('Audit Access Expires');
-      });
-
-      it('shows upgrade prompt', async () => {
-        setTabData({
-          access_expiration: {
-            expiration_date: '2080-01-01T12:00:00Z',
-            masquerading_expired_course: false,
-            upgrade_deadline: '2070-01-01T12:00:00Z',
-            upgrade_url: 'https://example.com/upgrade',
-          },
-        });
-        await fetchAndRender();
-        await screen.findByText('to get unlimited access to the course as long as it exists on the site.', { exact: false });
-      });
-
-      it('sends analytics event onClick of upgrade link', async () => {
-        setTabData({
-          access_expiration: {
-            expiration_date: '2080-01-01T12:00:00Z',
-            masquerading_expired_course: false,
-            upgrade_deadline: '2070-01-01T12:00:00Z',
-            upgrade_url: 'https://example.com/upgrade',
-          },
-        });
-        await fetchAndRender();
-
-        // Clearing after render to remove any events sent on view (ex. 'Promotion Viewed')
-        sendTrackEvent.mockClear();
-        const upgradeLink = screen.getByRole('link', { name: 'Upgrade now' });
-        fireEvent.click(upgradeLink);
-
-        expect(sendTrackEvent).toHaveBeenCalledTimes(1);
-        expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.upsell_links_clicked', {
-          org_key: 'edX',
-          courserun_key: courseId,
-          linkCategory: 'FBE_banner',
-          linkName: 'course_home_audit_access_expires',
-          linkType: 'link',
-          pageName: 'course_home',
-        });
-      });
     });
 
     describe('Course Start Alert', () => {

--- a/src/courseware/course/Course.test.jsx
+++ b/src/courseware/course/Course.test.jsx
@@ -112,60 +112,6 @@ describe('Course', () => {
     expect(sidebarOpenButton).toBeInTheDocument();
   });
 
-  it('displays offer and expiration alert', async () => {
-    const courseMetadata = Factory.build('courseMetadata', {
-      access_expiration: {
-        expiration_date: '2080-01-01T12:00:00Z',
-        masquerading_expired_course: false,
-        upgrade_deadline: null,
-        upgrade_url: null,
-      },
-      offer: {
-        code: 'EDXWELCOME',
-        expiration_date: '2070-01-01T12:00:00Z',
-        original_price: '$100',
-        discounted_price: '$85',
-        percentage: 15,
-        upgrade_url: 'https://example.com/upgrade',
-      },
-    });
-    const testStore = await initializeTestStore({ courseMetadata, excludeFetchSequence: true }, false);
-    render(<Course {...mockData} courseId={courseMetadata.id} />, { store: testStore });
-
-    await screen.findByText('EDXWELCOME');
-    await screen.findByText('Audit Access Expires');
-  });
-
-  it('sends analytics event onClick of access expiration upgrade link', async () => {
-    sendTrackEvent.mockClear();
-
-    const courseMetadata = Factory.build('courseMetadata', {
-      access_expiration: {
-        expiration_date: '2080-01-01T12:00:00Z',
-        masquerading_expired_course: false,
-        upgrade_deadline: '2070-01-01T12:00:00Z',
-        upgrade_url: 'https://example.com/upgrade',
-      },
-      user_timezone: 'UTC',
-    });
-    const testStore = await initializeTestStore({ courseMetadata, excludeFetchSequence: true }, false);
-    render(<Course {...mockData} courseId={courseMetadata.id} />, { store: testStore });
-    await screen.findByText('Audit Access Expires');
-
-    const upgradeLink = screen.getByRole('link', { name: 'Upgrade now' });
-    fireEvent.click(upgradeLink);
-
-    expect(sendTrackEvent).toHaveBeenCalledTimes(1);
-    expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.upsell_links_clicked', {
-      org_key: 'edX',
-      courserun_key: courseMetadata.id,
-      linkCategory: 'FBE_banner',
-      linkName: 'in_course_audit_access_expires',
-      linkType: 'link',
-      pageName: 'in_course',
-    });
-  });
-
   it('sends analytics event onClick of offer alert link', async () => {
     sendTrackEvent.mockClear();
 


### PR DESCRIPTION
REV-2233: The upsell banner now duplicates the sidebar banner. Removing it in favor of the new implementation on course home, but keeping the masquerade message that shows instructors when a learner lost access to the course.