### PR TITLE
chore: update special exams library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1383,9 +1383,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.0.0.tgz",
-      "integrity": "sha512-tVF38zD1+madCvxFb0HT3WEfGIPyQaaMr64y7bA/JMkPR34o8Zz6PibhNymmQESElNWZtavLdYxX5wCRIIhTxA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.7.1.tgz",
+      "integrity": "sha512-noR1BBBlk9p33nMJ4zhOPK7aOmeAgWnb7GsSWB/JeipnOea/5gsu8UWeuZW6ClUA2/NR7jUwGi5j1HzU05sjKQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.5",
     "@edx/frontend-enterprise": "4.2.3",
-    "@edx/frontend-lib-special-exams": "1.0.0",
+    "@edx/frontend-lib-special-exams": "1.7.1",
     "@edx/frontend-platform": "1.11.0",
     "@edx/paragon": "14.8.0",
     "@fortawesome/fontawesome-svg-core": "1.2.34",


### PR DESCRIPTION
update to most recent version of the special exams library. Includes several bugfixes for timed exams and limited support for proctored/onboarding. These features are still disabled by default in production.