### PR TITLE
fix: Autoscroll moves element to center of page

### DIFF
--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -130,7 +130,8 @@ function Unit({
       } else if (event.data.offset) {
         // We listen for this message from LMS to know when the page needs to
         // be scrolled to another location on the page.
-        window.scrollTo(0, event.data.offset);
+        const diffToTopOfPage = window.innerHeight / 2;
+        window.scrollTo(0, event.data.offset + diffToTopOfPage);
       }
     }
     // If we currently have an event listener, remove it.

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -130,8 +130,7 @@ function Unit({
       } else if (event.data.offset) {
         // We listen for this message from LMS to know when the page needs to
         // be scrolled to another location on the page.
-        const diffToTopOfPage = window.innerHeight / 2;
-        window.scrollTo(0, event.data.offset + diffToTopOfPage);
+        window.scrollTo(0, event.data.offset + document.getElementById('unit-iframe').offsetTop);
       }
     }
     // If we currently have an event listener, remove it.


### PR DESCRIPTION
Jira issue: [TNL-8312](https://openedx.atlassian.net/browse/TNL-8312)

This PR fixes the anchor tag's position on the page when autoscrolling is used. Previously, the scroll would move the element to the center of the page. Now the scroll moves the element to the top of the page. The only case where the element will not be at the top of the page is when the element is too close to the bottom of the page and there is not enough page remaining to force the element to the top.