### PR TITLE
MMP2P G2 Fix React Hooks error

### DIFF
--- a/src/experiments/mm-p2p/index.jsx
+++ b/src/experiments/mm-p2p/index.jsx
@@ -108,9 +108,9 @@ const initHomeMMP2P = (courseId) => {
   const setMMP2POptions = createWindowStateSetter(_setMMP2POptions, MMP2PKeys.state);
   const setMMP2PAccess = createWindowStateSetter(_setMMP2PAccess, MMP2PKeys.access);
 
-  const loadAccess = () => {
-    const { accessExpiration, verifiedMode } = useModel('coursewareMeta', courseId);
+  const { accessExpiration, verifiedMode } = useModel('outline', courseId);
 
+  const loadAccess = () => {
     if (accessExpiration !== null && accessExpiration !== undefined) {
       setMMP2PAccess({
         isAudit: true,


### PR DESCRIPTION
Moved `useModel` call out of function to avoid react error.

I also changed the model to `outline` from `coursewareMeta`... I don't know if I'm missing something locally, but for me, on the course home page, the `coursewareMeta` model wasn't being loaded, and the endpoint that provides it wasn't being requested. The `courseHomeMeta` was requested and loaded, but it doesn't include `accessExpiration` (https://github.com/edx/edx-platform/blob/526982c5484c52d9868d74e0244ea136ba7afc00/lms/djangoapps/course_home_api/course_metadata/v1/serializers.py#L32)


Testing instructions:

Setup:
 - Choose your test course. We'll need a verified_mode and an access_expiration from the LMS.
 - verified_mode:
            - Navigate to the LMS admin, and go to the Course Modes page. For your course, add a verified mode with some price and an upgrade and verification deadline in the future, and add an audit mode. 
 - access expiration:
             - This one requires config from discovery which to be honest I didn't want to have to figure out, so I just short circuited it. 
             - in lms/djangoapps/course_home_api/outline/v1/views.py, line 241 should be setting `access_expiration` to the result of a function call. replace that with setting it to:
             ```
                 access_expiration = {
                        'expiration_date': "2021-08-24T15:00:00Z",
                        'masquerading_expired_course': False,
                        'upgrade_deadline': "2021-07-13T23:59:00Z",
                        'upgrade_url': "https://ecommerce.edx.org/basket/add/?sku=9D7A892",
                 }
           ```
           - similarly, in openedx/core/djangoapps/courseware_api/views.py, (around line 146), change the return value of `access_expiration` to 
           ```
             return {
                 'expiration_date': "2021-08-24T15:00:00Z",
                 'masquerading_expired_course': False,
                 'upgrade_deadline': "2021-07-13T23:59:00Z",
                 'upgrade_url': "https://ecommerce.edx.org/basket/add/?sku=9D7A892",
             }
             ```

note: if anyone knows how to actually set up discovery for access expiration, please point me to the docs.

 - Now, on master, navigate to your course, and in the console type
 -`window.experiment__mmp2p_home_enable('Sep 25 2021 23:59 UTC');` (or some other date in the future)
 - you should get a React hooks error, and you shouldn't see the new sidecard thing.
 - now, check out this branch, wait until the app reloads, and then in the console, type the same thing again. There should be no error, and you should see the sidecard.
  
@edx/masters-devs-gta 