### PR TITLE
fix: change styling of More button to stay consistent with other navigation items.

### DIFF
--- a/src/generic/tabs/Tabs.jsx
+++ b/src/generic/tabs/Tabs.jsx
@@ -36,8 +36,8 @@ export default function Tabs({ children, className, ...attrs }) {
         ref={overflowElementRef}
         key="overflow"
       >
-        <Dropdown>
-          <Dropdown.Toggle variant="link" className="nav-link font-weight-normal">
+        <Dropdown className="h-100">
+          <Dropdown.Toggle variant="link" className="nav-link h-100">
             <FormattedMessage
               id="learn.course.tabs.navigation.overflow.menu"
               description="The title of the overflow menu for course tabs"


### PR DESCRIPTION
### [TNL-7785](https://openedx.atlassian.net/browse/TNL-7785)

#### Description
This PR fixes the `“More…”` button in navigation bar and aligns it with the preceding navigation items.

#### Before fix
<img width="462" alt="Screen Shot 2020-12-09 at 2 33 09 PM" src="https://user-images.githubusercontent.com/30112155/124821326-00fc1980-df88-11eb-870a-7e5829b91ea9.png">


#### After fix
<img width="624" alt="Screen Shot 2021-07-08 at 12 59 34 AM" src="https://user-images.githubusercontent.com/30112155/124821300-fa6da200-df87-11eb-84b6-9ff08a87b56b.png">

#### After fix (hover state)
<img width="632" alt="Screen Shot 2021-07-08 at 1 00 06 AM" src="https://user-images.githubusercontent.com/30112155/124821294-f8a3de80-df87-11eb-8e5c-5121702938fd.png">
