### PR TITLE
REV-2305: cleanup tracking code for obsolete upsell link

### DIFF
--- a/src/course-home/data/__factories__/outlineTabData.factory.js
+++ b/src/course-home/data/__factories__/outlineTabData.factory.js
@@ -48,11 +48,6 @@ Factory.define('outlineTabData')
         title: 'Bookmarks',
         url: 'https://example.com/bookmarks',
       },
-      {
-        analytics_id: 'edx.tool.verified_upgrade',
-        title: 'Upgrade to Verified',
-        url: 'https://example.com/upgrade',
-      },
     ],
     dates_banner_info: {
       content_type_gating_enabled: false,

--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -442,11 +442,6 @@ Object {
             "title": "Bookmarks",
             "url": "https://example.com/bookmarks",
           },
-          Object {
-            "analyticsId": "edx.tool.verified_upgrade",
-            "title": "Upgrade to Verified",
-            "url": "https://example.com/upgrade",
-          },
         ],
         "datesBannerInfo": Object {
           "contentTypeGatingEnabled": false,

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -437,35 +437,6 @@ describe('Outline Tab', () => {
       await fetchAndRender();
       expect(screen.queryByRole('heading', { name: 'Course Tools' })).not.toBeInTheDocument();
     });
-
-    it('analytics sent when upgrade link clicked', async () => {
-      await fetchAndRender();
-      expect(screen.getByRole('heading', { name: 'Course Tools' })).toBeInTheDocument();
-      sendTrackEvent.mockClear();
-      sendTrackingLogEvent.mockClear();
-
-      const upgradeLink = screen.getByRole('link', { name: 'Upgrade to Verified' });
-      fireEvent.click(upgradeLink);
-
-      expect(sendTrackEvent).toHaveBeenCalledTimes(1);
-      expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.upsell_links_clicked', {
-        org_key: 'edX',
-        courserun_key: courseId,
-        linkCategory: '(none)',
-        linkName: 'course_home_course_tools',
-        linkType: 'link',
-        pageName: 'course_home',
-      });
-
-      expect(sendTrackingLogEvent).toHaveBeenCalledTimes(1);
-      expect(sendTrackingLogEvent).toHaveBeenCalledWith('edx.course.tool.accessed', {
-        org_key: 'edX',
-        courserun_key: courseId,
-        course_id: courseId,
-        is_staff: false,
-        tool_name: 'edx.tool.verified_upgrade',
-      });
-    });
   });
 
   describe('Alert List', () => {

--- a/src/course-home/outline-tab/widgets/CourseTools.jsx
+++ b/src/course-home/outline-tab/widgets/CourseTools.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { sendTrackEvent, sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
+import { sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -36,16 +36,6 @@ function CourseTools({ courseId, intl }) {
       is_staff: administrator,
       tool_name: analyticsId,
     });
-
-    if (analyticsId === 'edx.tool.verified_upgrade') {
-      sendTrackEvent('edx.bi.ecommerce.upsell_links_clicked', {
-        ...eventProperties,
-        linkCategory: '(none)',
-        linkName: 'course_home_course_tools',
-        linkType: 'link',
-        pageName: 'course_home',
-      });
-    }
   };
 
   const renderIcon = (iconClasses) => {


### PR DESCRIPTION
The upsell link appearing in the Course Tools menu (aka 'course_home_course_tools') was removed from edx-platform in REV-2131, but its tracking code is still present in frontend-app-learning. This PR removes the related code from this repo. 