### PR TITLE
REV-2304: add upsell events for progress tab upsell links

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -281,7 +281,7 @@ describe('Progress Tab', () => {
       expect(screen.getAllByRole('link', 'Unlock now')).toHaveLength(3);
     });
 
-    it('sends event on click of upgrade button in locked content header (CourseGradeHeader)', async () => {
+    it('sends events on click of upgrade button in locked content header (CourseGradeHeader)', async () => {
       sendTrackEvent.mockClear();
       setTabData({
         completion_summary: {
@@ -325,11 +325,19 @@ describe('Progress Tab', () => {
       const upgradeButton = screen.getAllByRole('link', 'Unlock now')[0];
       fireEvent.click(upgradeButton);
 
-      expect(sendTrackEvent).toHaveBeenCalledTimes(1);
+      expect(sendTrackEvent).toHaveBeenCalledTimes(2);
       expect(sendTrackEvent).toHaveBeenCalledWith('edx.ui.lms.course_progress.grades_upgrade.clicked', {
         org_key: 'edX',
         courserun_key: courseId,
         is_staff: false,
+      });
+      expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.upsell_links_clicked', {
+        org_key: 'edX',
+        courserun_key: courseId,
+        linkCategory: '(none)',
+        linkName: 'progress_locked',
+        linkType: 'button',
+        pageName: 'progress',
       });
     });
 
@@ -1093,12 +1101,20 @@ describe('Progress Tab', () => {
         const upgradeLink = screen.getByRole('link', { name: 'Upgrade now' });
         fireEvent.click(upgradeLink);
 
-        expect(sendTrackEvent).toHaveBeenCalledTimes(2);
+        expect(sendTrackEvent).toHaveBeenCalledTimes(3);
         expect(sendTrackEvent).toHaveBeenNthCalledWith(2, 'edx.ui.lms.course_progress.certificate_status.clicked', {
           org_key: 'edX',
           courserun_key: courseId,
           is_staff: false,
           certificate_status_variant: 'audit_passing',
+        });
+        expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.upsell_links_clicked', {
+          org_key: 'edX',
+          courserun_key: courseId,
+          linkCategory: '(none)',
+          linkName: 'progress_certificate',
+          linkType: 'button',
+          pageName: 'progress',
         });
       });
 

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -46,6 +46,12 @@ function CertificateStatus({ intl }) {
     isEnrolled,
     userHasPassingGrade,
   );
+
+  const eventProperties = {
+    org_key: org,
+    courserun_key: courseId,
+  };
+
   const dispatch = useDispatch();
   const { administrator } = getAuthenticatedUser();
 
@@ -198,6 +204,15 @@ function CertificateStatus({ intl }) {
       is_staff: administrator,
       certificate_status_variant: certEventName,
     });
+    if (certCase === 'upgrade') {
+      sendTrackEvent('edx.bi.ecommerce.upsell_links_clicked', {
+        ...eventProperties,
+        linkCategory: '(none)',
+        linkName: 'progress_certificate',
+        linkType: 'button',
+        pageName: 'progress',
+      });
+    }
   };
 
   return (

--- a/src/course-home/progress-tab/grades/course-grade/CourseGradeHeader.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CourseGradeHeader.jsx
@@ -22,12 +22,24 @@ function CourseGradeHeader({ intl }) {
     gradesFeatureIsFullyLocked,
   } = useModel('progress', courseId);
 
+  const eventProperties = {
+    org_key: org,
+    courserun_key: courseId,
+  };
+
   const { administrator } = getAuthenticatedUser();
   const logUpgradeButtonClick = () => {
     sendTrackEvent('edx.ui.lms.course_progress.grades_upgrade.clicked', {
       org_key: org,
       courserun_key: courseId,
       is_staff: administrator,
+    });
+    sendTrackEvent('edx.bi.ecommerce.upsell_links_clicked', {
+      ...eventProperties,
+      linkCategory: '(none)',
+      linkName: 'progress_locked',
+      linkType: 'button',
+      pageName: 'progress',
     });
   };
   let previewText;


### PR DESCRIPTION
The new learning MFE version of the progress tab has two new upsell links: 
1) “Upgrade now” link in ‘Preview of a locked feature’ banner (currently sends: edx.ui.lms.course_progress.grades_upgrade.clicked)
2) “Upgrade now” link in ‘Earn a certificate’ square (currently sends edx.ui.lms.course_progress.certificate_status.clicked with a certificate_status_variant of audit_passing)

When a learner clicks either of those links, we want them to also send our typical "upsell click" event: edx.bi.ecommerce.upsell_links_clicked

![image](https://user-images.githubusercontent.com/5384216/124982782-1cf1d080-e005-11eb-8604-9f473fa6e802.png)