### PR TITLE
[fix] Add href to dates link on coming soon alert

### DIFF
--- a/src/course-home/outline-tab/alerts/scheduled-content-alert/ScheduledCotentAlert.jsx
+++ b/src/course-home/outline-tab/alerts/scheduled-content-alert/ScheduledCotentAlert.jsx
@@ -25,11 +25,12 @@ function ScheduledContentAlert({ payload }) {
         </div>
         <div className="flex-grow-0 pt-3 pt-lg-0">
           {datesTabLink && (
-            <Button>
+            <Button
+              href={datesTabLink}
+            >
               <FormattedMessage
                 id="learning.outline.alert.scheduled-content.button"
                 defaultMessage="View Course Schedule"
-                href={datesTabLink}
               />
             </Button>
           )}


### PR DESCRIPTION
A small PR to move an `href` from the message to the `Button` component to properly render the anchor tag.