### PR TITLE
fix: update Navigation tab items styling to match design.

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -70,6 +70,22 @@
 }
 .course-tabs-navigation {
   border-bottom: solid 1px #EAEAEA;
+
+  .nav a, .nav button {
+    &:hover {
+      background-color: $light-400;
+    }
+    &:focus {
+      border: 2px solid $dark-500;
+    }
+  }
+
+  .nav a {
+    &:not(.active):hover {
+      background-color: $light-400;
+      border-bottom: none;
+    }
+  }
 }
 
 .nav-underline-tabs {


### PR DESCRIPTION
### [TNL-7969](https://openedx.atlassian.net/browse/TNL-7969)

### Description
Styling fix for Navigation tab items for the hover state.

#### Hover for inactive tab
<img width="634" alt="Screen Shot 2021-07-14 at 1 03 35 AM" src="https://user-images.githubusercontent.com/30112155/125517481-e9a6be0c-1392-40ae-a63d-18a0f2f64240.png">

#### Hover for active tab
<img width="620" alt="Screen Shot 2021-07-14 at 1 03 51 AM" src="https://user-images.githubusercontent.com/30112155/125517490-17d648ff-2f79-4faf-965f-9d95a43cec73.png">

#### Focus state
<img width="583" alt="Screen Shot 2021-07-27 at 1 19 41 AM" src="https://user-images.githubusercontent.com/30112155/127053987-58dc050f-87c8-42db-a8f9-abe96867a630.png">
