### PR TITLE
fix: LockPaywall content gating layout issue

### DIFF
--- a/src/courseware/course/NotificationIcon.jsx
+++ b/src/courseware/course/NotificationIcon.jsx
@@ -5,7 +5,6 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Icon } from '@edx/paragon';
 import { WatchOutline } from '@edx/paragon/icons';
 
-import './NotificationIcon.scss';
 import messages from './messages';
 
 function NotificationIcon({ intl, status, notificationColor }) {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -204,6 +204,7 @@ function Sequence({
             sequenceId={sequenceId}
             unitId={unitId}
             unitLoadedHandler={handleUnitLoaded}
+            notificationTrayVisible={notificationTrayVisible}
             /** [MM-P2P] Experiment */
             mmp2p={mmp2p}
           />

--- a/src/courseware/course/sequence/SequenceContent.jsx
+++ b/src/courseware/course/sequence/SequenceContent.jsx
@@ -16,6 +16,7 @@ function SequenceContent({
   sequenceId,
   unitId,
   unitLoadedHandler,
+  notificationTrayVisible,
   /** [MM-P2P] Experiment */
   mmp2p,
 }) {
@@ -61,6 +62,7 @@ function SequenceContent({
       key={unitId}
       id={unitId}
       onLoaded={unitLoadedHandler}
+      notificationTrayVisible={notificationTrayVisible}
       /** [MM-P2P] Experiment */
       mmp2p={mmp2p}
     />
@@ -73,6 +75,7 @@ SequenceContent.propTypes = {
   sequenceId: PropTypes.string.isRequired,
   unitId: PropTypes.string,
   unitLoadedHandler: PropTypes.func.isRequired,
+  notificationTrayVisible: PropTypes.bool.isRequired,
   intl: intlShape.isRequired,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -85,6 +85,7 @@ function Unit({
   onLoaded,
   id,
   intl,
+  notificationTrayVisible,
   /** [MM-P2P] Experiment */
   mmp2p,
 }) {
@@ -171,7 +172,7 @@ function Unit({
             />
           )}
         >
-          <LockPaywall courseId={courseId} />
+          <LockPaywall courseId={courseId} notificationTrayVisible={notificationTrayVisible} />
         </Suspense>
       )}
       { /** [MM-P2P] Experiment */ }
@@ -252,6 +253,7 @@ Unit.propTypes = {
   id: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
   onLoaded: PropTypes.func,
+  notificationTrayVisible: PropTypes.bool.isRequired,
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
     state: PropTypes.shape({

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
@@ -15,6 +16,7 @@ import './LockPaywall.scss';
 function LockPaywall({
   intl,
   courseId,
+  notificationTrayVisible,
 }) {
   const course = useModel('coursewareMeta', courseId);
   const {
@@ -80,7 +82,7 @@ function LockPaywall({
             {intl.formatMessage(messages['learn.lockPaywall.content'])}
           </div>
 
-          <div className="d-flex flex-row flex-wrap">
+          <div className={classNames('d-flex flex-row', { 'flex-wrap': notificationTrayVisible })}>
             <div style={{ float: 'left' }} className="mr-3 mb-2">
               <img
                 alt={intl.formatMessage(messages['learn.lockPaywall.example.alt'])}
@@ -134,7 +136,7 @@ function LockPaywall({
         </div>
 
         <div
-          className="col-md-auto p-md-0 d-md-flex align-items-md-center mr-md-3"
+          className={classNames('p-md-0 d-md-flex align-items-md-center', { 'col-md-5 mx-md-0': notificationTrayVisible, 'col-md-4 mx-md-3': !notificationTrayVisible })}
           style={{ textAlign: 'right' }}
         >
           <UpgradeButton
@@ -150,5 +152,6 @@ function LockPaywall({
 LockPaywall.propTypes = {
   intl: intlShape.isRequired,
   courseId: PropTypes.string.isRequired,
+  notificationTrayVisible: PropTypes.bool.isRequired,
 };
 export default injectIntl(LockPaywall);

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -12,7 +12,6 @@ import certificateLocked from '../../../../generic/assets/edX_locked_certificate
 import { useModel } from '../../../../generic/model-store';
 import useWindowSize, { responsiveBreakpoints } from '../../../../generic/tabs/useWindowSize';
 import { UpgradeButton } from '../../../../generic/upgrade-button';
-import './LockPaywall.scss';
 
 function LockPaywall({
   intl,

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -4,9 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import {
-  Alert, Icon,
-} from '@edx/paragon';
+import { Alert } from '@edx/paragon';
 import { Locked } from '@edx/paragon/icons';
 import messages from './messages';
 import certificateLocked from '../../../../generic/assets/edX_locked_certificate.png';
@@ -44,14 +42,6 @@ function LockPaywall({
     });
   };
 
-  const lockIcon = (
-    <Icon
-      className="float-left"
-      src={Locked}
-      aria-hidden="true"
-    />
-  );
-
   const verifiedCertLink = (
     <Alert.Link
       href="https://www.edx.org/verified-certificate"
@@ -79,12 +69,8 @@ function LockPaywall({
   );
 
   return (
-    <Alert variant="light" aria-live="off">
+    <Alert variant="light" aria-live="off" icon={Locked} className="lock-paywall-container">
       <div className="row">
-        <div className="col-auto px-0">
-          {lockIcon}
-        </div>
-
         <div className="col">
           <h4 aria-level="3">
             <span>{intl.formatMessage(messages['learn.lockPaywall.title'])}</span>

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -10,6 +10,7 @@ import { Locked } from '@edx/paragon/icons';
 import messages from './messages';
 import certificateLocked from '../../../../generic/assets/edX_locked_certificate.png';
 import { useModel } from '../../../../generic/model-store';
+import useWindowSize, { responsiveBreakpoints } from '../../../../generic/tabs/useWindowSize';
 import { UpgradeButton } from '../../../../generic/upgrade-button';
 import './LockPaywall.scss';
 
@@ -24,6 +25,8 @@ function LockPaywall({
     org,
     verifiedMode,
   } = course;
+
+  const shouldDisplayGatedContentResponsive = useWindowSize().width <= responsiveBreakpoints.medium.minWidth;
 
   if (!verifiedMode) {
     return null;
@@ -82,7 +85,7 @@ function LockPaywall({
             {intl.formatMessage(messages['learn.lockPaywall.content'])}
           </div>
 
-          <div className={classNames('d-flex flex-row', { 'flex-wrap': notificationTrayVisible })}>
+          <div className={classNames('d-flex flex-row', { 'flex-wrap': notificationTrayVisible || shouldDisplayGatedContentResponsive })}>
             <div style={{ float: 'left' }} className="mr-3 mb-2">
               <img
                 alt={intl.formatMessage(messages['learn.lockPaywall.example.alt'])}

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -25,7 +25,17 @@ function LockPaywall({
     verifiedMode,
   } = course;
 
-  const shouldDisplayGatedContentResponsive = useWindowSize().width <= responsiveBreakpoints.medium.minWidth;
+  // the following variables are set and used for resposive layout to work with
+  // whether the NotificationTray is open or not and if there's an offer with longer text
+  const shouldDisplayBulletPointsBelowCertificate = useWindowSize().width
+    <= responsiveBreakpoints.large.minWidth;
+  const shouldDisplayGatedContentOneColumn = useWindowSize().width <= responsiveBreakpoints.extraLarge.minWidth
+    && notificationTrayVisible;
+  const shouldDisplayGatedContentTwoColumns = useWindowSize().width < responsiveBreakpoints.large.minWidth
+    && notificationTrayVisible;
+  const shouldDisplayGatedContentTwoColumnsHalf = useWindowSize().width <= responsiveBreakpoints.large.minWidth
+    && !notificationTrayVisible;
+  const shouldWrapTextOnButton = useWindowSize().width > responsiveBreakpoints.extraSmall.minWidth;
 
   if (!verifiedMode) {
     return null;
@@ -84,7 +94,7 @@ function LockPaywall({
             {intl.formatMessage(messages['learn.lockPaywall.content'])}
           </div>
 
-          <div className={classNames('d-flex flex-row', { 'flex-wrap': notificationTrayVisible || shouldDisplayGatedContentResponsive })}>
+          <div className={classNames('d-flex flex-row', { 'flex-wrap': notificationTrayVisible || shouldDisplayBulletPointsBelowCertificate })}>
             <div style={{ float: 'left' }} className="mr-3 mb-2">
               <img
                 alt={intl.formatMessage(messages['learn.lockPaywall.example.alt'])}
@@ -138,13 +148,17 @@ function LockPaywall({
         </div>
 
         <div
-          className={classNames('p-md-0 d-md-flex align-items-md-center', { 'col-md-5 mx-md-0': notificationTrayVisible, 'col-md-4 mx-md-3': !notificationTrayVisible })}
-          style={{ textAlign: 'right' }}
+          className={
+            classNames('p-md-0 d-md-flex align-items-md-center text-right', {
+              'col-md-5 mx-md-0': notificationTrayVisible, 'col-md-4 mx-md-3 justify-content-center': !notificationTrayVisible && !shouldDisplayGatedContentTwoColumnsHalf, 'col-md-11 justify-content-end': shouldDisplayGatedContentOneColumn && !shouldDisplayGatedContentTwoColumns, 'col-md-6 justify-content-center': shouldDisplayGatedContentTwoColumnsHalf,
+            })
+          }
         >
           <UpgradeButton
             offer={offer}
             onClick={logClick}
             verifiedMode={verifiedMode}
+            style={{ whiteSpace: shouldWrapTextOnButton ? 'nowrap' : null }}
           />
         </div>
       </div>

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
@@ -1,3 +1,6 @@
+.lock-paywall-container svg {
+    color: #002121;
+}
 
 // Temporary CSS intervention until paragon list items will support icons (PAR-429)
 .fa-li {

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
@@ -1,8 +1,7 @@
 .lock-paywall-container svg {
-    color: #002121;
+    color: $primary-700;
 }
 
-// Temporary CSS intervention until paragon list items will support icons (PAR-429)
 .fa-li {
     left: -31px !important;
     padding-right: 22px;

--- a/src/generic/upgrade-button/UpgradeButton.jsx
+++ b/src/generic/upgrade-button/UpgradeButton.jsx
@@ -24,8 +24,6 @@ function UpgradeButton(props) {
       href={url}
       onClick={onClick}
       {...rest}
-      size="lg"
-      block
     >
       <FormattedMessage
         id="learning.upgradeButton.buttonText"

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -408,6 +408,7 @@ function UpgradeNotification({
         onClick={logClick}
         verifiedMode={verifiedMode}
         className="upgrade-notification-button"
+        block
       />
       {offerCode}
     </section>

--- a/src/index.scss
+++ b/src/index.scss
@@ -375,6 +375,7 @@
 @import 'courseware/course/NotificationTray.scss';
 @import 'courseware/course/NotificationTrigger.scss';
 @import 'courseware/course/NotificationIcon.scss';
+@import 'courseware/course/sequence/lock-paywall/LockPaywall.scss';
 @import 'shared/streak-celebration/StreakCelebrationModal.scss';
 @import 'courseware/course/content-tools/calculator/calculator.scss';
 @import 'courseware/course/content-tools/contentTools.scss';


### PR DESCRIPTION
[REV-2307](https://openedx.atlassian.net/browse/REV-2307). 

There was a change in Paragon that caused the below layout bug (prod screenshots in [this course](https://learning.edx.org/course/course-v1:BerkeleyX+CS198.1x+3T2019/block-v1:BerkeleyX+CS198.1x+3T2019+type@sequential+block@c6e867c00e404e1095bcd91f9d145440/block-v1:BerkeleyX+CS198.1x+3T2019+type@vertical+block@f62bb9067471453c87533218f632470c)):
<img width="951" alt="Screen Shot 2021-07-19 at 3 04 55 PM" src="https://user-images.githubusercontent.com/13632680/126213618-47d8235c-ff88-40b8-a768-32985eba9657.png">
<img width="954" alt="Screen Shot 2021-07-19 at 3 04 41 PM" src="https://user-images.githubusercontent.com/13632680/126213619-9ce941d6-d3a1-4517-888b-ab4f8d223041.png">

**This PR fixes this spacing issue in the gated content value prop banner:**
- Changed the size of the `UpgradeButton`.
- Used the `Alert` embedded icon i/o using an `Icon` in a separate `div`.
- Added column sizes and logic depending on whether the `NotificationTray` is open/closed and whether it's in the responsive screensize to determine if it should have 2 or 3 columns (the bullet points goes under the certificate image for 2 columns). 

**Option 1: following "expected" screenshot from the ticket with 2 columns.** 
<img width="1201" alt="Screen Shot 2021-07-19 at 3 39 03 PM" src="https://user-images.githubusercontent.com/13632680/126217307-957b4829-b6d6-49c3-bd87-9f9fd97a0ed2.png">
<img width="1200" alt="Screen Shot 2021-07-19 at 3 38 48 PM" src="https://user-images.githubusercontent.com/13632680/126217309-396814f0-0f8b-406f-83b4-3f260de632dd.png">

**Option 2: 3 columns following the [Figma doc](https://www.figma.com/file/1EaMYJ8FecwzbbSv5YIpEC/Value-Prop-Final-Designs?node-id=1067%3A89):** **--> APPROVED BY UX**
<img width="1203" alt="Screen Shot 2021-07-19 at 5 35 08 PM" src="https://user-images.githubusercontent.com/13632680/126230607-fa765261-52b5-432e-8177-1d1caab2a057.png">
<img width="1198" alt="Screen Shot 2021-07-19 at 5 34 55 PM" src="https://user-images.githubusercontent.com/13632680/126230613-9eebf08d-d18f-4c2f-b7d8-be8ea5224778.png">

**Responsive views:**
There are various screen sizes and whether the `NotificationTray` is open/closed, as well as if there's an `offer` (the `UpgradeButton` text will be longer). To account for all of these, several variables were defined and added on the last commit of this PR. 

- Extra large screen sizes (>1200px)
<img width="601" alt="Screen Shot 2021-07-21 at 9 26 31 AM" src="https://user-images.githubusercontent.com/13632680/126499801-ce3432f9-cb65-4107-a0ac-5e5a7d448a29.png">
<img width="564" alt="Screen Shot 2021-07-21 at 9 24 56 AM" src="https://user-images.githubusercontent.com/13632680/126499809-780dcc9b-6b96-4095-ab5f-95499cd6297a.png">

- Large screen sizes (>992px)
<img width="497" alt="Screen Shot 2021-07-21 at 9 36 01 AM" src="https://user-images.githubusercontent.com/13632680/126499800-67cf2f9b-9869-43e6-8f2a-5fa098fccf9d.png">
<img width="497" alt="Screen Shot 2021-07-21 at 9 35 12 AM" src="https://user-images.githubusercontent.com/13632680/126499805-45c91d03-4fb6-4c8a-8970-0aa8b3d723ad.png">

- Medium screen sizes (>768 px)
<img width="385" alt="Screen Shot 2021-07-21 at 9 36 56 AM" src="https://user-images.githubusercontent.com/13632680/126499797-e0f15676-c5a0-4baf-807c-731805bb59bc.png">

- Small screen sizes (>576 px)
<img width="288" alt="Screen Shot 2021-07-21 at 9 38 20 AM" src="https://user-images.githubusercontent.com/13632680/126499796-4a76aee7-e340-41c8-bcd9-846c1422f53d.png">

- Extra small screen sizes (>375 px) Here if there's an `offer` the text will wrap
<img width="279" alt="Screen Shot 2021-07-20 at 4 59 15 PM" src="https://user-images.githubusercontent.com/13632680/126500877-6cc476a2-68e4-4f15-92ca-3b36a4ec9029.png">
<img width="188" alt="Screen Shot 2021-07-21 at 9 39 26 AM" src="https://user-images.githubusercontent.com/13632680/126499792-10c2d986-a723-4080-a549-d475828f9f50.png">
