### PR TITLE
fix: handle new 403 "redirect" responses from backend

### DIFF
--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -49,6 +49,11 @@ export function fetchTab(courseId, tab, getTabData, targetUserId) {
         logError(courseHomeCourseMetadataResult.reason);
       }
 
+      if (fetchedTabData && tabDataResult.value === null) {
+        // null tab data indicates that we have redirected elsewhere - just exit and don't visibly stop loading
+        return;
+      }
+
       if (fetchedTabData) {
         dispatch(addModel({
           modelType: tab,


### PR DESCRIPTION
To make it easier to redirect the user to an another page or an access denied error page, this PR deprecates the old custom 401 & 404 error handling, replacing them both with a generic 403 error code that contains a URL to redirect the user to.

Before this change, we weren't handling all the error cases, and when we didn't, we ended up showing a broken page to the user.

Related to https://github.com/edx/edx-platform/pull/28235