### PR TITLE
add edxwelcome code info to unhappy path

### DIFF
--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -327,20 +327,6 @@ function UpgradeNotification({
     const accessExpirationDate = new Date(accessExpiration.expirationDate);
     const hoursToAccessExpiration = Math.floor((accessExpirationDate - correctedTime) / 1000 / 60 / 60);
 
-    if (offer) { // if there's a first purchase discount, message the code at the bottom
-      offerCode = (
-        <div className="text-center discount-info">
-          <FormattedMessage
-            id="learning.generic.upgradeNotification.code"
-            defaultMessage="Use code {code} at checkout"
-            values={{
-              code: (<span className="font-weight-bold">{offer.code}</span>),
-            }}
-          />
-        </div>
-      );
-    }
-
     if (hoursToAccessExpiration >= (7 * 24)) {
       if (offer) { // countdown to the first purchase discount if there is one
         const hoursToDiscountExpiration = Math.floor((new Date(offer.expirationDate) - correctedTime) / 1000 / 60 / 60);
@@ -392,6 +378,20 @@ function UpgradeNotification({
       />
     );
     upsellMessage = (<UpsellNoFBECardContent />);
+  }
+
+  if (offer) { // if there's a first purchase discount, message the code at the bottom
+    offerCode = (
+      <div className="text-center discount-info">
+        <FormattedMessage
+          id="learning.generic.upgradeNotification.code"
+          defaultMessage="Use code {code} at checkout"
+          values={{
+            code: (<span className="font-weight-bold">{offer.code}</span>),
+          }}
+        />
+      </div>
+    );
   }
 
   return (

--- a/src/generic/upgrade-notification/UpgradeNotification.test.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.test.jsx
@@ -54,6 +54,26 @@ describe('Upgrade Notification', () => {
     expect(screen.getByRole('link', { name: 'Upgrade for $149' })).toBeInTheDocument();
   });
 
+  it('renders non-FBE with a discount properly', async () => {
+    const discountExpirationDate = new Date(dateNow);
+    discountExpirationDate.setDate(discountExpirationDate.getDate() + 6);
+    buildAndRender({
+      offer: {
+        expirationDate: discountExpirationDate.toString(),
+        percentage: 15,
+        code: 'Welcome15',
+        discountedPrice: '$126.65',
+        originalPrice: '$149',
+        upgradeUrl: 'www.exampleUpgradeUrl.com',
+      },
+    });
+    expect(screen.getByRole('heading', { name: 'Pursue a verified certificate' })).toBeInTheDocument();
+    expect(screen.getByText(/Earn a.*?of completion to showcase on your resume/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resume');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Upgrade for/).textContent).toMatch('$126.65 ($149)');
+    expect(screen.getByText(/Use code.*?at checkout/s).textContent).toMatch('Use code Welcome15 at checkout');
+  });
+
   it('renders FBE expiration within an hour properly', async () => {
     const expirationDate = new Date(dateNow);
     expirationDate.setMinutes(expirationDate.getMinutes() + 45);


### PR DESCRIPTION
This pr is to solve an issue where if courses/users are not eligible for full FBE (content gating and course duration limits), the upsell messaging did not include a coupon code for the first purchase discount.
Here is the old state: 
![image](https://user-images.githubusercontent.com/32077611/126500241-be6c4ad4-9035-4969-92c0-0fcc5856cd06.png)

Here is the new state:
<img width="373" alt="Screen Shot 2021-07-21 at 10 05 34 AM" src="https://user-images.githubusercontent.com/32077611/126502253-30178be4-6b6a-42dd-9650-0b3799791b4b.png">
