### PR TITLE
differentiate upsell link eventing between in_course and course_home

### DIFF
--- a/src/course-home/data/__factories__/upgradeNotificationData.factory.js
+++ b/src/course-home/data/__factories__/upgradeNotificationData.factory.js
@@ -8,6 +8,7 @@ Factory.define('upgradeNotificationData')
   .option('accessExpiration', null)
   .option('contentTypeGatingEnabled', false)
   .attr('courseId', 'course-v1:edX+DemoX+Demo_Course')
+  .attr('upsellPageName', 'test')
   .attr('verifiedMode', ['host'], (host) => ({
     access_expiration_date: '2050-01-01T12:00:00',
     currency: 'USD',

--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -224,11 +224,12 @@ function OutlineTab({ intl }) {
                   verifiedMode={verifiedMode}
                   accessExpiration={accessExpiration}
                   contentTypeGatingEnabled={datesBannerInfo.contentTypeGatingEnabled}
+                  upsellPageName="course_home"
                   userTimezone={userTimezone}
+                  shouldDisplayBorder
                   timeOffsetMillis={timeOffsetMillis}
                   courseId={courseId}
                   org={org}
-                  shouldDisplayBorder
                 />
               )}
             <CourseDates

--- a/src/courseware/course/NotificationTray.jsx
+++ b/src/courseware/course/NotificationTray.jsx
@@ -58,11 +58,12 @@ function NotificationTray({
             verifiedMode={verifiedMode}
             accessExpiration={accessExpiration}
             contentTypeGatingEnabled={contentTypeGatingEnabled}
+            upsellPageName="in_course"
             userTimezone={userTimezone}
+            shouldDisplayBorder={false}
             timeOffsetMillis={timeOffsetMillis}
             courseId={courseId}
             org={org}
-            shouldDisplayBorder={false}
           />
         ) : <p className="notification-tray-content">{intl.formatMessage(messages.noNotificationsMessage)}</p>}
       </div>

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -265,10 +265,11 @@ function UpgradeNotification({
   courseId,
   offer,
   org,
+  shouldDisplayBorder,
   timeOffsetMillis,
+  upsellPageName,
   userTimezone,
   verifiedMode,
-  shouldDisplayBorder,
 }) {
   const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
   const correctedTime = new Date(Date.now() + timeOffsetMillis);
@@ -305,9 +306,9 @@ function UpgradeNotification({
     sendTrackEvent('edx.bi.ecommerce.upsell_links_clicked', {
       ...eventProperties,
       linkCategory: 'green_upgrade',
-      linkName: 'course_home_green',
+      linkName: `${upsellPageName}_green`,
       linkType: 'button',
-      pageName: 'course_home',
+      pageName: upsellPageName,
     });
   };
 
@@ -427,24 +428,25 @@ UpgradeNotification.propTypes = {
     percentage: PropTypes.number,
     code: PropTypes.string,
   }),
+  shouldDisplayBorder: PropTypes.bool,
   timeOffsetMillis: PropTypes.number,
+  upsellPageName: PropTypes.string.isRequired,
   userTimezone: PropTypes.string,
   verifiedMode: PropTypes.shape({
     currencySymbol: PropTypes.string.isRequired,
     price: PropTypes.number.isRequired,
     upgradeUrl: PropTypes.string.isRequired,
   }),
-  shouldDisplayBorder: PropTypes.bool,
 };
 
 UpgradeNotification.defaultProps = {
   accessExpiration: null,
   contentTypeGatingEnabled: false,
   offer: null,
+  shouldDisplayBorder: null,
   timeOffsetMillis: 0,
   userTimezone: null,
   verifiedMode: null,
-  shouldDisplayBorder: null,
 };
 
 export default injectIntl(UpgradeNotification);


### PR DESCRIPTION
The Upgrade Notification component appears on two pages in the course: course home and inside of the notification tray inside the course. This component contains an upgrade link. Prior to this change, it was sending the same LinkName in upsell_link_clicked segment tracking events. This made it impossible to know where the user was upgrading from. This pr attempts to remedy that.

I also changed the order of the props in the UpgradeNotification component so that they would be in alphabetical order.