### PR TITLE
fix: handle course access errors in Course Home side of things too

### DIFF
--- a/src/course-home/data/__factories__/courseHomeMetadata.factory.js
+++ b/src/course-home/data/__factories__/courseHomeMetadata.factory.js
@@ -10,4 +10,13 @@ Factory.define('courseHomeMetadata')
     is_self_paced: false,
     is_enrolled: false,
     can_load_courseware: false,
+    course_access: {
+      additional_context_user_message: null,
+      developer_message: null,
+      error_code: null,
+      has_access: true,
+      user_fragment: null,
+      user_message: null,
+    },
+    start: '2013-02-05T05:00:00Z',
   });

--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -23,6 +23,14 @@ Object {
     "courseHomeMeta": Object {
       "course-v1:edX+DemoX+Demo_Course_1": Object {
         "canLoadCourseware": false,
+        "courseAccess": Object {
+          "additionalContextUserMessage": null,
+          "developerMessage": null,
+          "errorCode": null,
+          "hasAccess": true,
+          "userFragment": null,
+          "userMessage": null,
+        },
         "id": "course-v1:edX+DemoX+Demo_Course_1",
         "isEnrolled": false,
         "isSelfPaced": false,
@@ -30,6 +38,7 @@ Object {
         "number": "DemoX",
         "org": "edX",
         "originalUserIsStaff": false,
+        "start": "2013-02-05T05:00:00Z",
         "tabs": Array [
           Object {
             "slug": "outline",
@@ -320,6 +329,14 @@ Object {
     "courseHomeMeta": Object {
       "course-v1:edX+DemoX+Demo_Course_1": Object {
         "canLoadCourseware": false,
+        "courseAccess": Object {
+          "additionalContextUserMessage": null,
+          "developerMessage": null,
+          "errorCode": null,
+          "hasAccess": true,
+          "userFragment": null,
+          "userMessage": null,
+        },
         "id": "course-v1:edX+DemoX+Demo_Course_1",
         "isEnrolled": false,
         "isSelfPaced": false,
@@ -327,6 +344,7 @@ Object {
         "number": "DemoX",
         "org": "edX",
         "originalUserIsStaff": false,
+        "start": "2013-02-05T05:00:00Z",
         "tabs": Array [
           Object {
             "slug": "outline",
@@ -500,6 +518,14 @@ Object {
     "courseHomeMeta": Object {
       "course-v1:edX+DemoX+Demo_Course_1": Object {
         "canLoadCourseware": false,
+        "courseAccess": Object {
+          "additionalContextUserMessage": null,
+          "developerMessage": null,
+          "errorCode": null,
+          "hasAccess": true,
+          "userFragment": null,
+          "userMessage": null,
+        },
         "id": "course-v1:edX+DemoX+Demo_Course_1",
         "isEnrolled": false,
         "isSelfPaced": false,
@@ -507,6 +533,7 @@ Object {
         "number": "DemoX",
         "org": "edX",
         "originalUserIsStaff": false,
+        "start": "2013-02-05T05:00:00Z",
         "tabs": Array [
           Object {
             "slug": "outline",

--- a/src/course-home/data/slice.js
+++ b/src/course-home/data/slice.js
@@ -4,6 +4,7 @@ import { createSlice } from '@reduxjs/toolkit';
 export const LOADING = 'loading';
 export const LOADED = 'loaded';
 export const FAILED = 'failed';
+export const DENIED = 'denied';
 
 const slice = createSlice({
   name: 'course-home',
@@ -16,6 +17,14 @@ const slice = createSlice({
     toastHeader: '',
   },
   reducers: {
+    fetchTabDenied: (state, { payload }) => {
+      state.courseId = payload.courseId;
+      state.courseStatus = DENIED;
+    },
+    fetchTabFailure: (state, { payload }) => {
+      state.courseId = payload.courseId;
+      state.courseStatus = FAILED;
+    },
     fetchTabRequest: (state, { payload }) => {
       state.courseId = payload.courseId;
       state.courseStatus = LOADING;
@@ -24,10 +33,6 @@ const slice = createSlice({
       state.courseId = payload.courseId;
       state.targetUserId = payload.targetUserId;
       state.courseStatus = LOADED;
-    },
-    fetchTabFailure: (state, { payload }) => {
-      state.courseId = payload.courseId;
-      state.courseStatus = FAILED;
     },
     setCallToActionToast: (state, { payload }) => {
       const {
@@ -46,9 +51,10 @@ const slice = createSlice({
 });
 
 export const {
+  fetchTabDenied,
+  fetchTabFailure,
   fetchTabRequest,
   fetchTabSuccess,
-  fetchTabFailure,
   setCallToActionToast,
   setGradesFeatureStatus,
 } = slice.actions;

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -17,6 +17,7 @@ import {
 } from '../../generic/model-store';
 
 import {
+  fetchTabDenied,
   fetchTabFailure,
   fetchTabRequest,
   fetchTabSuccess,
@@ -61,7 +62,9 @@ export function fetchTab(courseId, tab, getTabData, targetUserId) {
         logError(tabDataResult.reason);
       }
 
-      if (fetchedCourseHomeCourseMetadata && fetchedTabData) {
+      if (fetchedCourseHomeCourseMetadata && !courseHomeCourseMetadataResult.value.courseAccess.hasAccess) {
+        dispatch(fetchTabDenied({ courseId }));
+      } else if (fetchedCourseHomeCourseMetadata && fetchedTabData) {
         dispatch(fetchTabSuccess({ courseId, targetUserId }));
       } else {
         dispatch(fetchTabFailure({ courseId }));

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { history } from '@edx/frontend-platform';
-import { getLocale } from '@edx/frontend-platform/i18n';
-import { Redirect } from 'react-router';
 import { createSelector } from '@reduxjs/toolkit';
 import { defaultMemoize as memoize } from 'reselect';
 
@@ -245,42 +243,6 @@ class CoursewareContainer extends Component {
     }
   }
 
-  renderDenied() {
-    const {
-      course,
-      courseId,
-      match: {
-        params: {
-          unitId: routeUnitId,
-        },
-      },
-    } = this.props;
-    let url = `/redirect/course-home/${courseId}`;
-    switch (course.canLoadCourseware.errorCode) {
-      case 'audit_expired':
-        url = `/redirect/dashboard?access_response_error=${course.canLoadCourseware.additionalContextUserMessage}`;
-        break;
-      case 'course_not_started':
-        // eslint-disable-next-line no-case-declarations
-        const startDate = (new Intl.DateTimeFormat(getLocale())).format(new Date(course.start));
-        url = `/redirect/dashboard?notlive=${startDate}`;
-        break;
-      case 'survey_required': // TODO: Redirect to the course survey
-      case 'unfulfilled_milestones':
-        url = '/redirect/dashboard';
-        break;
-      case 'microfrontend_disabled':
-        url = `/redirect/courseware/${courseId}/unit/${routeUnitId}`;
-        break;
-      case 'authentication_required':
-      case 'enrollment_required':
-      default:
-    }
-    return (
-      <Redirect to={url} />
-    );
-  }
-
   render() {
     const {
       courseStatus,
@@ -292,10 +254,6 @@ class CoursewareContainer extends Component {
         },
       },
     } = this.props;
-
-    if (courseStatus === 'denied') {
-      return this.renderDenied();
-    }
 
     return (
       <TabPage
@@ -338,10 +296,9 @@ const sectionShape = PropTypes.shape({
 });
 
 const courseShape = PropTypes.shape({
-  canLoadCourseware: PropTypes.shape({
-    errorCode: PropTypes.string,
-    additionalContextUserMessage: PropTypes.string,
-  }).isRequired,
+  celebrations: PropTypes.shape({
+    firstSection: PropTypes.bool,
+  }),
 });
 
 CoursewareContainer.propTypes = {

--- a/src/courseware/CoursewareRedirectLandingPage.jsx
+++ b/src/courseware/CoursewareRedirectLandingPage.jsx
@@ -32,6 +32,12 @@ export default () => {
           }}
         />
         <PageRoute
+          path={`${path}/survey/:courseId`}
+          render={({ match }) => {
+            global.location.assign(`${getConfig().LMS_BASE_URL}/courses/${match.params.courseId}/survey`);
+          }}
+        />
+        <PageRoute
           path={`${path}/dashboard`}
           render={({ location }) => {
             global.location.assign(`${getConfig().LMS_BASE_URL}/dashboard${location.search}`);

--- a/src/courseware/data/__factories__/courseMetadata.factory.js
+++ b/src/courseware/data/__factories__/courseMetadata.factory.js
@@ -34,7 +34,7 @@ Factory.define('courseMetadata')
     },
     show_calculator: false,
     license: 'all-rights-reserved',
-    can_load_courseware: {
+    course_access: {
       has_access: true,
       user_fragment: null,
       developer_message: null,

--- a/src/courseware/data/__factories__/sequenceMetadata.factory.js
+++ b/src/courseware/data/__factories__/sequenceMetadata.factory.js
@@ -68,7 +68,7 @@ Factory.define('sequenceMetadata')
  */
 export default function buildSimpleCourseAndSequenceMetadata(options = {}) {
   const courseMetadata = options.courseMetadata || Factory.build('courseMetadata', {
-    can_load_courseware: {
+    course_access: {
       has_access: false,
     },
   });

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -160,7 +160,7 @@ function normalizeMetadata(metadata) {
     start: data.start,
     enrollmentMode: data.enrollment.mode,
     isEnrolled: data.enrollment.is_active,
-    canLoadCourseware: camelCaseObject(data.can_load_courseware),
+    courseAccess: camelCaseObject(data.course_access),
     canViewLegacyCourseware: data.can_view_legacy_courseware,
     originalUserIsStaff: data.original_user_is_staff,
     isStaff: data.is_staff,

--- a/src/courseware/data/redux.test.js
+++ b/src/courseware/data/redux.test.js
@@ -68,7 +68,7 @@ describe('Data layer integration tests', () => {
 
     it('Should fetch, normalize, and save metadata, but with denied status', async () => {
       const forbiddenCourseMetadata = Factory.build('courseMetadata', {
-        can_load_courseware: {
+        course_access: {
           has_access: false,
         },
       });
@@ -89,7 +89,7 @@ describe('Data layer integration tests', () => {
       expect(state.courseware.courseStatus).toEqual('denied');
 
       // check that at least one key camel cased, thus course data normalized
-      expect(state.models.coursewareMeta[forbiddenCourseMetadata.id].canLoadCourseware).not.toBeUndefined();
+      expect(state.models.coursewareMeta[forbiddenCourseMetadata.id].courseAccess).not.toBeUndefined();
     });
 
     it('Should fetch, normalize, and save metadata', async () => {
@@ -107,7 +107,7 @@ describe('Data layer integration tests', () => {
       expect(state.courseware.sequenceId).toEqual(null);
 
       // check that at least one key camel cased, thus course data normalized
-      expect(state.models.coursewareMeta[courseId].canLoadCourseware).not.toBeUndefined();
+      expect(state.models.coursewareMeta[courseId].courseAccess).not.toBeUndefined();
     });
 
     it('Should fetch, normalize, and save metadata; filtering has no effect', async () => {
@@ -127,7 +127,7 @@ describe('Data layer integration tests', () => {
       expect(state.courseware.sequenceId).toEqual(null);
 
       // check that at least one key camel cased, thus course data normalized
-      expect(state.models.coursewareMeta[courseId].canLoadCourseware).not.toBeUndefined();
+      expect(state.models.coursewareMeta[courseId].courseAccess).not.toBeUndefined();
       expect(state.models.sequences.length === 1);
       Object.values(state.models.sections).forEach(section => expect(section.sequenceIds.length === 1));
     });
@@ -149,7 +149,7 @@ describe('Data layer integration tests', () => {
       expect(state.courseware.sequenceId).toEqual(null);
 
       // check that at least one key camel cased, thus course data normalized
-      expect(state.models.coursewareMeta[courseId].canLoadCourseware).not.toBeUndefined();
+      expect(state.models.coursewareMeta[courseId].courseAccess).not.toBeUndefined();
       expect(state.models.sequences === null);
       Object.values(state.models.sections).forEach(section => expect(section.sequenceIds.length === 0));
     });

--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -117,7 +117,7 @@ export function fetchCourse(courseId) {
       }
 
       if (fetchedMetadata) {
-        if (courseMetadataResult.value.canLoadCourseware.hasAccess && fetchedBlocks) {
+        if (courseMetadataResult.value.courseAccess.hasAccess && fetchedBlocks) {
           // User has access
           dispatch(fetchCourseSuccess({ courseId }));
           return;

--- a/src/shared/access-denied-redirect/AccessDeniedRedirect.jsx
+++ b/src/shared/access-denied-redirect/AccessDeniedRedirect.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getLocale } from '@edx/frontend-platform/i18n';
+import { Redirect } from 'react-router';
+import { useModel } from '../../generic/model-store';
+
+// This component inspects an access denied error and redirects to a /redirect/... path, which then renders a nice
+// little message while the browser loads the next page.
+// This is basically a frontend version of check_course_access_with_redirect in the backend.
+
+function AccessDeniedRedirect(props) {
+  const {
+    courseId,
+    metadataModel,
+    unitId,
+  } = props;
+
+  const {
+    courseAccess,
+    start,
+  } = useModel(metadataModel, courseId);
+
+  let url = `/redirect/course-home/${courseId}`;
+  switch (courseAccess.errorCode) {
+    case 'audit_expired':
+      url = `/redirect/dashboard?access_response_error=${courseAccess.additionalContextUserMessage}`;
+      break;
+    case 'course_not_started':
+      // eslint-disable-next-line no-case-declarations
+      const startDate = (new Intl.DateTimeFormat(getLocale())).format(new Date(start));
+      url = `/redirect/dashboard?notlive=${startDate}`;
+      break;
+    case 'survey_required':
+      url = `/redirect/survey/${courseId}`;
+      break;
+    case 'unfulfilled_milestones':
+      url = '/redirect/dashboard';
+      break;
+    case 'microfrontend_disabled':
+      // This code path is only used by the courseware right now. The course home tabs each have their own check for
+      // this in the tab-specific API calls. In those cases, the API will return an http status code if the MFE version
+      // of those tabs are disabled, rather than an access error like this. We could try to unify these approaches, but
+      // hopefully the legacy code isn't around long enough for that to be worth it.
+      if (unitId) {
+        url = `/redirect/courseware/${courseId}/unit/${unitId}`;
+      }
+      break;
+    case 'authentication_required':
+    case 'enrollment_required':
+    default:
+  }
+  return (
+    <Redirect to={url} />
+  );
+}
+
+AccessDeniedRedirect.defaultProps = {
+  unitId: null,
+};
+
+AccessDeniedRedirect.propTypes = {
+  courseId: PropTypes.string.isRequired,
+  metadataModel: PropTypes.string.isRequired,
+  unitId: PropTypes.string,
+};
+
+export default AccessDeniedRedirect;

--- a/src/shared/access-denied-redirect/index.js
+++ b/src/shared/access-denied-redirect/index.js
@@ -1,0 +1,3 @@
+import AccessDeniedRedirect from './AccessDeniedRedirect';
+
+export default AccessDeniedRedirect;

--- a/src/tab-page/TabPage.jsx
+++ b/src/tab-page/TabPage.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { Toast } from '@edx/paragon';
 import { Header } from '../course-header';
+import AccessDeniedRedirect from '../shared/access-denied-redirect';
 import PageLoading from '../generic/PageLoading';
 
 import genericMessages from '../generic/messages';
@@ -14,7 +15,10 @@ import { setCallToActionToast } from '../course-home/data/slice';
 
 function TabPage({
   intl,
+  courseId,
   courseStatus,
+  metadataModel,
+  unitId,
   ...passthroughProps
 }) {
   const {
@@ -49,8 +53,18 @@ function TabPage({
         >
           {toastHeader}
         </Toast>
-        <LoadedTabPage {...passthroughProps} />
+        <LoadedTabPage courseId={courseId} metadataModel={metadataModel} unitId={unitId} {...passthroughProps} />
       </>
+    );
+  }
+
+  if (courseStatus === 'denied') {
+    return (
+      <AccessDeniedRedirect
+        courseId={courseId}
+        metadataModel={metadataModel}
+        unitId={unitId}
+      />
     );
   }
 
@@ -65,9 +79,16 @@ function TabPage({
   );
 }
 
+TabPage.defaultProps = {
+  unitId: null,
+};
+
 TabPage.propTypes = {
   intl: intlShape.isRequired,
+  courseId: PropTypes.string.isRequired,
   courseStatus: PropTypes.string.isRequired,
+  metadataModel: PropTypes.string.isRequired,
+  unitId: PropTypes.string,
 };
 
 export default injectIntl(TabPage);


### PR DESCRIPTION
The courseware was properly reading the access errors and redirecting the user as appropriate (like to the dashboard or whatever).

This requires a backend change to push the error along.