### PR TITLE
fix: temporarily disable course-home denied redirects

### DIFF
--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -17,7 +17,7 @@ import {
 } from '../../generic/model-store';
 
 import {
-  fetchTabDenied,
+  // fetchTabDenied,
   fetchTabFailure,
   fetchTabRequest,
   fetchTabSuccess,
@@ -62,9 +62,11 @@ export function fetchTab(courseId, tab, getTabData, targetUserId) {
         logError(tabDataResult.reason);
       }
 
-      if (fetchedCourseHomeCourseMetadata && !courseHomeCourseMetadataResult.value.courseAccess.hasAccess) {
+      // Disable the access-denied path for now - it caused a regression
+      /* if (fetchedCourseHomeCourseMetadata && !courseHomeCourseMetadataResult.value.courseAccess.hasAccess) {
         dispatch(fetchTabDenied({ courseId }));
-      } else if (fetchedCourseHomeCourseMetadata && fetchedTabData) {
+      } else */
+      if (fetchedCourseHomeCourseMetadata && fetchedTabData) {
         dispatch(fetchTabSuccess({ courseId, targetUserId }));
       } else {
         dispatch(fetchTabFailure({ courseId }));

--- a/src/course-home/dates-tab/DatesTab.test.jsx
+++ b/src/course-home/dates-tab/DatesTab.test.jsx
@@ -299,7 +299,7 @@ describe('DatesTab', () => {
     });
   });
 
-  describe('when receiving an access denied error', () => {
+  describe.skip('when receiving an access denied error', () => {
     // These tests could go into any particular tab, as they all go through the same flow. But dates tab works.
 
     async function renderDenied(errorCode) {


### PR DESCRIPTION
They caused a regression when not logged in or enrolled. Will hopefully re-enable after developing a fix.