### PR TITLE
fix: remove focus state for Navigation tab items.

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -67,9 +67,6 @@
     &:hover {
       background-color: $light-400;
     }
-    &:focus {
-      border: 2px solid $dark-500;
-    }
   }
 
   .nav a {


### PR DESCRIPTION
### [TNL-7969](https://openedx.atlassian.net/browse/TNL-7969)

### Description
Styling fix for Navigation tab items for the focus state.

Stay consistent with Tabs from paragon  https://paragon-edx.netlify.app/components/tabs/ 

