### PR TITLE
fix: adjust syntax of a translation, so transifex will accept it

### DIFF
--- a/src/shared/effort-estimate/messages.js
+++ b/src/shared/effort-estimate/messages.js
@@ -7,7 +7,7 @@ const messages = defineMessages({
   },
   minutesAbbreviated: {
     id: 'learning.effortEstimation.minutesAbbreviated',
-    defaultMessage: '{minuteCount, plural, other {# min}}',
+    defaultMessage: '{minuteCount, plural, one {# min} other {# min}}',
     description: 'Number of minutes in a casual, shorthand manner: 5 min',
   },
   minutesFull: {


### PR DESCRIPTION
Transifex will complain like so: `Exception: Invalid plural types for string: learning\.effortEstimation\.minutesAbbreviated. Language supports: ['one', 'other'], but found: ['other'] instead.`