### PR TITLE
REV-2297: red dot functionality

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -15,6 +15,7 @@ import NotificationTrigger from './NotificationTrigger';
 
 import { useModel } from '../../generic/model-store';
 import useWindowSize, { responsiveBreakpoints } from '../../generic/tabs/useWindowSize';
+import { getLocalStorage, setLocalStorage } from '../../data/localStorage';
 
 /** [MM-P2P] Experiment */
 import { initCoursewareMMP2P, MMP2PBlockModal } from '../../experiments/mm-p2p';
@@ -60,6 +61,22 @@ function Course({
     if (notificationTrayVisible) { setNotificationTray(false); } else { setNotificationTray(true); }
   };
 
+  if (!getLocalStorage('notificationStatus')) {
+    setLocalStorage('notificationStatus', 'active'); // Show red dot on notificationTrigger until seen
+  }
+
+  if (!getLocalStorage('currentState')) {
+    setLocalStorage('currentState', 'initialize');
+  }
+
+  const [notificationStatus, setNotificationStatus] = useState(getLocalStorage('notificationStatus'));
+  const [currentState, setCurrentState] = useState(getLocalStorage('currentState'));
+
+  const onNotificationSeen = () => {
+    setNotificationStatus('inactive');
+    setLocalStorage('notificationStatus', 'inactive');
+  };
+
   /** [MM-P2P] Experiment */
   const MMP2P = initCoursewareMMP2P(courseId, sequenceId, unitId);
 
@@ -81,6 +98,9 @@ function Course({
           <NotificationTrigger
             toggleNotificationTray={toggleNotificationTray}
             isNotificationTrayVisible={isNotificationTrayVisible}
+            notificationStatus={notificationStatus}
+            setNotificationStatus={setNotificationStatus}
+            currentState={currentState}
           />
         ) : null}
       </div>
@@ -96,6 +116,11 @@ function Course({
         toggleNotificationTray={toggleNotificationTray}
         isNotificationTrayVisible={isNotificationTrayVisible}
         notificationTrayVisible={notificationTrayVisible}
+        notificationStatus={notificationStatus}
+        setNotificationStatus={setNotificationStatus}
+        onNotificationSeen={onNotificationSeen}
+        currentState={currentState}
+        setCurrentState={setCurrentState}
         //* * [MM-P2P] Experiment */
         mmp2p={MMP2P}
       />

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -65,12 +65,12 @@ function Course({
     setLocalStorage('notificationStatus', 'active'); // Show red dot on notificationTrigger until seen
   }
 
-  if (!getLocalStorage('currentState')) {
-    setLocalStorage('currentState', 'initialize');
+  if (!getLocalStorage('upgradeNotificationCurrentState')) {
+    setLocalStorage('upgradeNotificationCurrentState', 'initialize');
   }
 
   const [notificationStatus, setNotificationStatus] = useState(getLocalStorage('notificationStatus'));
-  const [currentState, setCurrentState] = useState(getLocalStorage('currentState'));
+  const [upgradeNotificationCurrentState, setupgradeNotificationCurrentState] = useState(getLocalStorage('upgradeNotificationCurrentState'));
 
   const onNotificationSeen = () => {
     setNotificationStatus('inactive');
@@ -100,7 +100,7 @@ function Course({
             isNotificationTrayVisible={isNotificationTrayVisible}
             notificationStatus={notificationStatus}
             setNotificationStatus={setNotificationStatus}
-            currentState={currentState}
+            upgradeNotificationCurrentState={upgradeNotificationCurrentState}
           />
         ) : null}
       </div>
@@ -119,8 +119,8 @@ function Course({
         notificationStatus={notificationStatus}
         setNotificationStatus={setNotificationStatus}
         onNotificationSeen={onNotificationSeen}
-        currentState={currentState}
-        setCurrentState={setCurrentState}
+        upgradeNotificationCurrentState={upgradeNotificationCurrentState}
+        setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
         //* * [MM-P2P] Experiment */
         mmp2p={MMP2P}
       />

--- a/src/courseware/course/NotificationTray.jsx
+++ b/src/courseware/course/NotificationTray.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -12,7 +12,7 @@ import useWindowSize, { responsiveBreakpoints } from '../../generic/tabs/useWind
 import UpgradeNotification from '../../generic/upgrade-notification/UpgradeNotification';
 
 function NotificationTray({
-  intl, toggleNotificationTray,
+  intl, toggleNotificationTray, onNotificationSeen, currentState, setCurrentState,
 }) {
   const {
     courseId,
@@ -31,6 +31,9 @@ function NotificationTray({
   } = course;
 
   const shouldDisplayFullScreen = useWindowSize().width < responsiveBreakpoints.large.minWidth;
+
+  // After three seconds, update notificationSeen (to hide red dot)
+  useEffect(() => { setTimeout(onNotificationSeen, 3000); }, []);
 
   return (
     <section className={classNames('notification-tray-container ml-0 ml-lg-4', { 'no-notification': !verifiedMode && !shouldDisplayFullScreen })} aria-label={intl.formatMessage(messages.notificationTray)}>
@@ -64,6 +67,8 @@ function NotificationTray({
             timeOffsetMillis={timeOffsetMillis}
             courseId={courseId}
             org={org}
+            currentState={currentState}
+            setCurrentState={setCurrentState}
           />
         ) : <p className="notification-tray-content">{intl.formatMessage(messages.noNotificationsMessage)}</p>}
       </div>
@@ -74,10 +79,14 @@ function NotificationTray({
 NotificationTray.propTypes = {
   intl: intlShape.isRequired,
   toggleNotificationTray: PropTypes.func,
+  onNotificationSeen: PropTypes.func,
+  currentState: PropTypes.string.isRequired,
+  setCurrentState: PropTypes.func.isRequired,
 };
 
 NotificationTray.defaultProps = {
   toggleNotificationTray: null,
+  onNotificationSeen: null,
 };
 
 export default injectIntl(NotificationTray);

--- a/src/courseware/course/NotificationTray.jsx
+++ b/src/courseware/course/NotificationTray.jsx
@@ -12,7 +12,7 @@ import useWindowSize, { responsiveBreakpoints } from '../../generic/tabs/useWind
 import UpgradeNotification from '../../generic/upgrade-notification/UpgradeNotification';
 
 function NotificationTray({
-  intl, toggleNotificationTray, onNotificationSeen, currentState, setCurrentState,
+  intl, toggleNotificationTray, onNotificationSeen, upgradeNotificationCurrentState, setupgradeNotificationCurrentState,
 }) {
   const {
     courseId,
@@ -67,8 +67,8 @@ function NotificationTray({
             timeOffsetMillis={timeOffsetMillis}
             courseId={courseId}
             org={org}
-            currentState={currentState}
-            setCurrentState={setCurrentState}
+            upgradeNotificationCurrentState={upgradeNotificationCurrentState}
+            setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
           />
         ) : <p className="notification-tray-content">{intl.formatMessage(messages.noNotificationsMessage)}</p>}
       </div>
@@ -80,8 +80,8 @@ NotificationTray.propTypes = {
   intl: intlShape.isRequired,
   toggleNotificationTray: PropTypes.func,
   onNotificationSeen: PropTypes.func,
-  currentState: PropTypes.string.isRequired,
-  setCurrentState: PropTypes.func.isRequired,
+  upgradeNotificationCurrentState: PropTypes.string.isRequired,
+  setupgradeNotificationCurrentState: PropTypes.func.isRequired,
 };
 
 NotificationTray.defaultProps = {

--- a/src/courseware/course/NotificationTrigger.jsx
+++ b/src/courseware/course/NotificationTrigger.jsx
@@ -9,22 +9,22 @@ import messages from './messages';
 
 function NotificationTrigger({
   intl, toggleNotificationTray, isNotificationTrayVisible, notificationStatus, setNotificationStatus,
-  currentState,
+  upgradeNotificationCurrentState,
 }) {
   /* Re-show a red dot beside the notification trigger for each of the 7 UpgradeNotification stages
-   The currentState prop will be available after UpgradeNotification mounts. Once available,
+   The upgradeNotificationCurrentState prop will be available after UpgradeNotification mounts. Once available,
   compare with the last state they've seen, and if it's different then set dot back to red */
-  function updateLastSeen() {
-    if (currentState) {
-      if (getLocalStorage('lastSeen') !== currentState) {
+  function UpdateUpgradeNotificationLastSeen() {
+    if (upgradeNotificationCurrentState) {
+      if (getLocalStorage('upgradeNotificationLastSeen') !== upgradeNotificationCurrentState) {
         setNotificationStatus('active');
         setLocalStorage('notificationStatus', 'active');
-        setLocalStorage('lastSeen', currentState);
+        setLocalStorage('upgradeNotificationLastSeen', upgradeNotificationCurrentState);
       }
     }
   }
 
-  useEffect(() => { updateLastSeen(); });
+  useEffect(() => { UpdateUpgradeNotificationLastSeen(); });
 
   return (
     <button
@@ -44,7 +44,7 @@ NotificationTrigger.propTypes = {
   notificationStatus: PropTypes.string.isRequired,
   setNotificationStatus: PropTypes.func.isRequired,
   isNotificationTrayVisible: PropTypes.func.isRequired,
-  currentState: PropTypes.string.isRequired,
+  upgradeNotificationCurrentState: PropTypes.string.isRequired,
 };
 
 export default injectIntl(NotificationTrigger);

--- a/src/courseware/course/NotificationTrigger.jsx
+++ b/src/courseware/course/NotificationTrigger.jsx
@@ -1,12 +1,31 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { getLocalStorage, setLocalStorage } from '../../data/localStorage';
 
 import NotificationIcon from './NotificationIcon';
 import messages from './messages';
 
-function NotificationTrigger({ intl, toggleNotificationTray, isNotificationTrayVisible }) {
+function NotificationTrigger({
+  intl, toggleNotificationTray, isNotificationTrayVisible, notificationStatus, setNotificationStatus,
+  currentState,
+}) {
+  /* Re-show a red dot beside the notification trigger for each of the 7 UpgradeNotification stages
+   The currentState prop will be available after UpgradeNotification mounts. Once available,
+  compare with the last state they've seen, and if it's different then set dot back to red */
+  function updateLastSeen() {
+    if (currentState) {
+      if (getLocalStorage('lastSeen') !== currentState) {
+        setNotificationStatus('active');
+        setLocalStorage('notificationStatus', 'active');
+        setLocalStorage('lastSeen', currentState);
+      }
+    }
+  }
+
+  useEffect(() => { updateLastSeen(); });
+
   return (
     <button
       className={classNames('notification-trigger-btn', { 'trigger-active': isNotificationTrayVisible() })}
@@ -14,8 +33,7 @@ function NotificationTrigger({ intl, toggleNotificationTray, isNotificationTrayV
       onClick={() => { toggleNotificationTray(); }}
       aria-label={intl.formatMessage(messages.openNotificationTrigger)}
     >
-      {/* REV-2297 TODO: add logic for status "active" if red dot should display */}
-      <NotificationIcon status="inactive" notificationColor="bg-danger-500" />
+      <NotificationIcon status={notificationStatus} notificationColor="bg-danger-500" />
     </button>
   );
 }
@@ -23,7 +41,10 @@ function NotificationTrigger({ intl, toggleNotificationTray, isNotificationTrayV
 NotificationTrigger.propTypes = {
   intl: intlShape.isRequired,
   toggleNotificationTray: PropTypes.func.isRequired,
+  notificationStatus: PropTypes.string.isRequired,
+  setNotificationStatus: PropTypes.func.isRequired,
   isNotificationTrayVisible: PropTypes.func.isRequired,
+  currentState: PropTypes.string.isRequired,
 };
 
 export default injectIntl(NotificationTrigger);

--- a/src/courseware/course/NotificationTrigger.test.jsx
+++ b/src/courseware/course/NotificationTrigger.test.jsx
@@ -39,7 +39,7 @@ describe('Notification Trigger', () => {
     };
   });
 
-  it('renders notification trigger with icon when notificationStatus is active', async () => {
+  it('renders notification trigger icon with red dot when notificationStatus is active', async () => {
     const { container } = render(<NotificationTrigger {...mockDataBaseline} />);
     expect(container).toBeInTheDocument();
     const buttonIcon = container.querySelectorAll('svg');
@@ -47,7 +47,7 @@ describe('Notification Trigger', () => {
     expect(screen.getByTestId('notification-dot')).toBeInTheDocument();
   });
 
-  it('renders notification trigger WITHOUT icon 3 seconds later', async () => {
+  it('renders notification trigger icon WITHOUT red dot 3 seconds later', async () => {
     const { container } = render(<NotificationTrigger {...mockDataBaseline} />);
     expect(container).toBeInTheDocument();
     jest.useFakeTimers();
@@ -57,7 +57,7 @@ describe('Notification Trigger', () => {
     jest.runAllTimers();
   });
 
-  it('renders notification trigger WITHOUT icon within the same phase', async () => {
+  it('renders notification trigger icon WITHOUT red dot within the same phase', async () => {
     const { container } = render(<NotificationTrigger {...mockDataSameState} />);
     expect(container).toBeInTheDocument();
     const buttonIcon = container.querySelectorAll('svg');
@@ -79,12 +79,12 @@ describe('Notification Trigger', () => {
     expect(toggleNotificationTray).toHaveBeenCalledTimes(1);
   });
 
+  // rendering NotificationTrigger has the effect of calling UpdateUpgradeNotificationLastSeen()
+  // Verify that local storage was updated accordingly
   it('we make the right updates when rendering a new phase (before -> after)', async () => {
     const { container } = render(<NotificationTrigger {...mockDataDifferentState} />);
     expect(container).toBeInTheDocument();
 
-    // rendering NotificationTrigger has the effect of calling UpdateUpgradeNotificationLastSeen()
-    // Verify that local storage was updated accordingly
     expect(getLocalStorage('notificationStatus')).toBe('active');
     expect(getLocalStorage('upgradeNotificationLastSeen')).toBe('after');
   });

--- a/src/courseware/course/NotificationTrigger.test.jsx
+++ b/src/courseware/course/NotificationTrigger.test.jsx
@@ -19,23 +19,23 @@ describe('Notification Trigger', () => {
       isNotificationTrayVisible: () => {},
       notificationStatus: 'active',
       setNotificationStatus: () => {},
-      currentState: 'FPDdaysLeft',
+      upgradeNotificationCurrentState: 'FPDdaysLeft',
     };
     mockDataSameState = {
       toggleNotificationTray: () => {},
       isNotificationTrayVisible: () => {},
       notificationStatus: 'inactive',
       setNotificationStatus: () => {},
-      currentState: 'sameState',
-      lastSeen: 'sameState',
+      upgradeNotificationCurrentState: 'sameState',
+      upgradeNotificationLastSeen: 'sameState',
     };
     mockDataDifferentState = {
       toggleNotificationTray: () => {},
       isNotificationTrayVisible: () => {},
       notificationStatus: 'inactive',
       setNotificationStatus: () => {},
-      currentState: 'after',
-      lastSeen: 'before',
+      upgradeNotificationCurrentState: 'after',
+      upgradeNotificationLastSeen: 'before',
     };
   });
 
@@ -83,9 +83,9 @@ describe('Notification Trigger', () => {
     const { container } = render(<NotificationTrigger {...mockDataDifferentState} />);
     expect(container).toBeInTheDocument();
 
-    // rendering NotificationTrigger has the effect of calling updateLastSeen()
+    // rendering NotificationTrigger has the effect of calling UpdateUpgradeNotificationLastSeen()
     // Verify that local storage was updated accordingly
     expect(getLocalStorage('notificationStatus')).toBe('active');
-    expect(getLocalStorage('lastSeen')).toBe('after');
+    expect(getLocalStorage('upgradeNotificationLastSeen')).toBe('after');
   });
 });

--- a/src/courseware/course/NotificationTrigger.test.jsx
+++ b/src/courseware/course/NotificationTrigger.test.jsx
@@ -7,40 +7,24 @@ import NotificationTrigger from './NotificationTrigger';
 import { getLocalStorage } from '../../data/localStorage';
 
 describe('Notification Trigger', () => {
-  let mockDataBaseline;
-  let mockDataSameState;
-  let mockDataDifferentState;
+  let mockData;
+  // let mockDataSameState;
+  // let mockDataDifferentState;
   const courseMetadata = Factory.build('courseMetadata');
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await initializeTestStore({ courseMetadata, excludeFetchCourse: true, excludeFetchSequence: true });
-    mockDataBaseline = {
+    mockData = {
       toggleNotificationTray: () => {},
       isNotificationTrayVisible: () => {},
       notificationStatus: 'active',
       setNotificationStatus: () => {},
       upgradeNotificationCurrentState: 'FPDdaysLeft',
     };
-    mockDataSameState = {
-      toggleNotificationTray: () => {},
-      isNotificationTrayVisible: () => {},
-      notificationStatus: 'inactive',
-      setNotificationStatus: () => {},
-      upgradeNotificationCurrentState: 'sameState',
-      upgradeNotificationLastSeen: 'sameState',
-    };
-    mockDataDifferentState = {
-      toggleNotificationTray: () => {},
-      isNotificationTrayVisible: () => {},
-      notificationStatus: 'inactive',
-      setNotificationStatus: () => {},
-      upgradeNotificationCurrentState: 'after',
-      upgradeNotificationLastSeen: 'before',
-    };
   });
 
   it('renders notification trigger icon with red dot when notificationStatus is active', async () => {
-    const { container } = render(<NotificationTrigger {...mockDataBaseline} />);
+    const { container } = render(<NotificationTrigger {...mockData} />);
     expect(container).toBeInTheDocument();
     const buttonIcon = container.querySelectorAll('svg');
     expect(buttonIcon).toHaveLength(1);
@@ -48,7 +32,7 @@ describe('Notification Trigger', () => {
   });
 
   it('renders notification trigger icon WITHOUT red dot 3 seconds later', async () => {
-    const { container } = render(<NotificationTrigger {...mockDataBaseline} />);
+    const { container } = render(<NotificationTrigger {...mockData} />);
     expect(container).toBeInTheDocument();
     jest.useFakeTimers();
     setTimeout(() => {
@@ -58,7 +42,9 @@ describe('Notification Trigger', () => {
   });
 
   it('renders notification trigger icon WITHOUT red dot within the same phase', async () => {
-    const { container } = render(<NotificationTrigger {...mockDataSameState} />);
+    const { container } = render(
+      <NotificationTrigger {...mockData} upgradeNotificationCurrentState="sameState" upgradeNotificationLastSeen="sameState" />,
+    );
     expect(container).toBeInTheDocument();
     const buttonIcon = container.querySelectorAll('svg');
     expect(buttonIcon).toHaveLength(1);
@@ -68,7 +54,7 @@ describe('Notification Trigger', () => {
   it('handles onClick event toggling the notification tray', async () => {
     const toggleNotificationTray = jest.fn();
     const testData = {
-      ...mockDataBaseline,
+      ...mockData,
       toggleNotificationTray,
     };
     render(<NotificationTrigger {...testData} />);
@@ -82,7 +68,9 @@ describe('Notification Trigger', () => {
   // rendering NotificationTrigger has the effect of calling UpdateUpgradeNotificationLastSeen()
   // Verify that local storage was updated accordingly
   it('we make the right updates when rendering a new phase (before -> after)', async () => {
-    const { container } = render(<NotificationTrigger {...mockDataDifferentState} />);
+    const { container } = render(
+      <NotificationTrigger {...mockData} upgradeNotificationLastSeen="before" upgradeNotificationCurrentState="after" />,
+    );
     expect(container).toBeInTheDocument();
 
     expect(getLocalStorage('notificationStatus')).toBe('active');

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -40,6 +40,11 @@ function Sequence({
   toggleNotificationTray,
   notificationTrayVisible,
   isNotificationTrayVisible,
+  notificationStatus,
+  setNotificationStatus,
+  onNotificationSeen,
+  currentState,
+  setCurrentState,
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
@@ -194,6 +199,9 @@ function Sequence({
           <NotificationTrigger
             toggleNotificationTray={toggleNotificationTray}
             isNotificationTrayVisible={isNotificationTrayVisible}
+            notificationStatus={notificationStatus}
+            setNotificationStatus={setNotificationStatus}
+            currentState={currentState}
           />
         ) : null}
 
@@ -229,6 +237,10 @@ function Sequence({
         <NotificationTray
           toggleNotificationTray={toggleNotificationTray}
           notificationTrayVisible={notificationTrayVisible}
+          notificationStatus={notificationStatus}
+          onNotificationSeen={onNotificationSeen}
+          currentState={currentState}
+          setCurrentState={setCurrentState}
         />
       ) : null }
 
@@ -271,6 +283,11 @@ Sequence.propTypes = {
   toggleNotificationTray: PropTypes.func,
   notificationTrayVisible: PropTypes.bool,
   isNotificationTrayVisible: PropTypes.func,
+  notificationStatus: PropTypes.string.isRequired,
+  setNotificationStatus: PropTypes.func.isRequired,
+  onNotificationSeen: PropTypes.func,
+  currentState: PropTypes.string.isRequired,
+  setCurrentState: PropTypes.func.isRequired,
 
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({
@@ -292,6 +309,7 @@ Sequence.defaultProps = {
   toggleNotificationTray: null,
   notificationTrayVisible: null,
   isNotificationTrayVisible: null,
+  onNotificationSeen: null,
 
   /** [MM-P2P] Experiment */
   mmp2p: {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -43,8 +43,8 @@ function Sequence({
   notificationStatus,
   setNotificationStatus,
   onNotificationSeen,
-  currentState,
-  setCurrentState,
+  upgradeNotificationCurrentState,
+  setupgradeNotificationCurrentState,
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
@@ -201,7 +201,7 @@ function Sequence({
             isNotificationTrayVisible={isNotificationTrayVisible}
             notificationStatus={notificationStatus}
             setNotificationStatus={setNotificationStatus}
-            currentState={currentState}
+            upgradeNotificationCurrentState={upgradeNotificationCurrentState}
           />
         ) : null}
 
@@ -239,8 +239,8 @@ function Sequence({
           notificationTrayVisible={notificationTrayVisible}
           notificationStatus={notificationStatus}
           onNotificationSeen={onNotificationSeen}
-          currentState={currentState}
-          setCurrentState={setCurrentState}
+          upgradeNotificationCurrentState={upgradeNotificationCurrentState}
+          setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
         />
       ) : null }
 
@@ -286,8 +286,8 @@ Sequence.propTypes = {
   notificationStatus: PropTypes.string.isRequired,
   setNotificationStatus: PropTypes.func.isRequired,
   onNotificationSeen: PropTypes.func,
-  currentState: PropTypes.string.isRequired,
-  setCurrentState: PropTypes.func.isRequired,
+  upgradeNotificationCurrentState: PropTypes.string.isRequired,
+  setupgradeNotificationCurrentState: PropTypes.func.isRequired,
 
   /** [MM-P2P] Experiment */
   mmp2p: PropTypes.shape({

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { sendTrackEvent, sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { FormattedDate, FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
+import { setLocalStorage } from '../../data/localStorage';
 
 import { UpgradeButton } from '../upgrade-button';
 
@@ -184,10 +185,20 @@ UpsellFBESoonCardContent.defaultProps = {
   timezoneFormatArgs: {},
 };
 
-function ExpirationCountdown({ hoursToExpiration }) {
+function ExpirationCountdown({ hoursToExpiration, setCurrentState, type }) {
   let expirationText;
-
   if (hoursToExpiration >= 24) {
+    // setCurrentState is available in NotificationTray (not course home)
+    if (setCurrentState) {
+      if (type === 'access') {
+        setCurrentState('accessDaysLeft');
+        setLocalStorage('currentState', 'accessDaysLeft');
+      }
+      if (type === 'offer') {
+        setCurrentState('FPDdaysLeft');
+        setLocalStorage('currentState', 'FPDdaysLeft');
+      }
+    }
     expirationText = (
       <FormattedMessage
         id="learning.generic.upgradeNotification.expirationDays"
@@ -200,6 +211,17 @@ function ExpirationCountdown({ hoursToExpiration }) {
       />
     );
   } else if (hoursToExpiration >= 1) {
+    // setCurrentState is available in NotificationTray (not course home)
+    if (setCurrentState) {
+      if (type === 'access') {
+        setCurrentState('accessHoursLeft');
+        setLocalStorage('currentState', 'accessHoursLeft');
+      }
+      if (type === 'offer') {
+        setCurrentState('FPDHoursLeft');
+        setLocalStorage('currentState', 'FPDHoursLeft');
+      }
+    }
     expirationText = (
       <FormattedMessage
         id="learning.generic.upgradeNotification.expirationHours"
@@ -212,6 +234,17 @@ function ExpirationCountdown({ hoursToExpiration }) {
       />
     );
   } else {
+    // setCurrentState is available in NotificationTray (not course home)
+    if (setCurrentState) {
+      if (type === 'access') {
+        setCurrentState('accessLastHour');
+        setLocalStorage('currentState', 'accessLastHour');
+      }
+      if (type === 'offer') {
+        setCurrentState('FPDLastHour');
+        setLocalStorage('currentState', 'FPDLastHour');
+      }
+    }
     expirationText = (
       <FormattedMessage
         id="learning.generic.upgradeNotification.expirationMinutes"
@@ -224,9 +257,19 @@ function ExpirationCountdown({ hoursToExpiration }) {
 
 ExpirationCountdown.propTypes = {
   hoursToExpiration: PropTypes.number.isRequired,
+  setCurrentState: PropTypes.func,
+  type: PropTypes.string,
+};
+ExpirationCountdown.defaultProps = {
+  setCurrentState: null,
+  type: null,
 };
 
-function AccessExpirationDateBanner({ accessExpirationDate, timezoneFormatArgs }) {
+function AccessExpirationDateBanner({ accessExpirationDate, timezoneFormatArgs, setCurrentState }) {
+  if (setCurrentState) {
+    setCurrentState('accessDateView');
+    setLocalStorage('currentState', 'accessDateView');
+  }
   return (
     <div className="upsell-warning-light">
       <FormattedMessage
@@ -253,10 +296,12 @@ AccessExpirationDateBanner.propTypes = {
   timezoneFormatArgs: PropTypes.shape({
     timeZone: PropTypes.string,
   }),
+  setCurrentState: PropTypes.func,
 };
 
 AccessExpirationDateBanner.defaultProps = {
   timezoneFormatArgs: {},
+  setCurrentState: null,
 };
 
 function UpgradeNotification({
@@ -265,6 +310,7 @@ function UpgradeNotification({
   courseId,
   offer,
   org,
+  setCurrentState,
   shouldDisplayBorder,
   timeOffsetMillis,
   upsellPageName,
@@ -340,7 +386,13 @@ function UpgradeNotification({
             }}
           />
         );
-        expirationBanner = <ExpirationCountdown hoursToExpiration={hoursToDiscountExpiration} />;
+        expirationBanner = (
+          <ExpirationCountdown
+            hoursToExpiration={hoursToDiscountExpiration}
+            setCurrentState={setCurrentState}
+            type="offer"
+          />
+        );
       } else {
         upgradeNotificationHeaderText = (
           <FormattedMessage
@@ -352,6 +404,7 @@ function UpgradeNotification({
           <AccessExpirationDateBanner
             accessExpirationDate={accessExpirationDate}
             timezoneFormatArgs={timezoneFormatArgs}
+            setCurrentState={setCurrentState}
           />
         );
       }
@@ -363,7 +416,13 @@ function UpgradeNotification({
           defaultMessage="Course Access Expiration"
         />
       );
-      expirationBanner = <ExpirationCountdown hoursToExpiration={hoursToAccessExpiration} />;
+      expirationBanner = (
+        <ExpirationCountdown
+          hoursToExpiration={hoursToAccessExpiration}
+          setCurrentState={setCurrentState}
+          type="access"
+        />
+      );
       upsellMessage = (
         <UpsellFBESoonCardContent
           accessExpirationDate={accessExpirationDate}
@@ -429,6 +488,7 @@ UpgradeNotification.propTypes = {
     code: PropTypes.string,
   }),
   shouldDisplayBorder: PropTypes.bool,
+  setCurrentState: PropTypes.func,
   timeOffsetMillis: PropTypes.number,
   upsellPageName: PropTypes.string.isRequired,
   userTimezone: PropTypes.string,
@@ -443,6 +503,7 @@ UpgradeNotification.defaultProps = {
   accessExpiration: null,
   contentTypeGatingEnabled: false,
   offer: null,
+  setCurrentState: null,
   shouldDisplayBorder: null,
   timeOffsetMillis: 0,
   userTimezone: null,

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -185,18 +185,18 @@ UpsellFBESoonCardContent.defaultProps = {
   timezoneFormatArgs: {},
 };
 
-function ExpirationCountdown({ hoursToExpiration, setCurrentState, type }) {
+function ExpirationCountdown({ hoursToExpiration, setupgradeNotificationCurrentState, type }) {
   let expirationText;
   if (hoursToExpiration >= 24) {
-    // setCurrentState is available in NotificationTray (not course home)
-    if (setCurrentState) {
+    // setupgradeNotificationCurrentState is available in NotificationTray (not course home)
+    if (setupgradeNotificationCurrentState) {
       if (type === 'access') {
-        setCurrentState('accessDaysLeft');
-        setLocalStorage('currentState', 'accessDaysLeft');
+        setupgradeNotificationCurrentState('accessDaysLeft');
+        setLocalStorage('upgradeNotificationCurrentState', 'accessDaysLeft');
       }
       if (type === 'offer') {
-        setCurrentState('FPDdaysLeft');
-        setLocalStorage('currentState', 'FPDdaysLeft');
+        setupgradeNotificationCurrentState('FPDdaysLeft');
+        setLocalStorage('upgradeNotificationCurrentState', 'FPDdaysLeft');
       }
     }
     expirationText = (
@@ -211,15 +211,15 @@ function ExpirationCountdown({ hoursToExpiration, setCurrentState, type }) {
       />
     );
   } else if (hoursToExpiration >= 1) {
-    // setCurrentState is available in NotificationTray (not course home)
-    if (setCurrentState) {
+    // setupgradeNotificationCurrentState is available in NotificationTray (not course home)
+    if (setupgradeNotificationCurrentState) {
       if (type === 'access') {
-        setCurrentState('accessHoursLeft');
-        setLocalStorage('currentState', 'accessHoursLeft');
+        setupgradeNotificationCurrentState('accessHoursLeft');
+        setLocalStorage('upgradeNotificationCurrentState', 'accessHoursLeft');
       }
       if (type === 'offer') {
-        setCurrentState('FPDHoursLeft');
-        setLocalStorage('currentState', 'FPDHoursLeft');
+        setupgradeNotificationCurrentState('FPDHoursLeft');
+        setLocalStorage('upgradeNotificationCurrentState', 'FPDHoursLeft');
       }
     }
     expirationText = (
@@ -234,15 +234,15 @@ function ExpirationCountdown({ hoursToExpiration, setCurrentState, type }) {
       />
     );
   } else {
-    // setCurrentState is available in NotificationTray (not course home)
-    if (setCurrentState) {
+    // setupgradeNotificationCurrentState is available in NotificationTray (not course home)
+    if (setupgradeNotificationCurrentState) {
       if (type === 'access') {
-        setCurrentState('accessLastHour');
-        setLocalStorage('currentState', 'accessLastHour');
+        setupgradeNotificationCurrentState('accessLastHour');
+        setLocalStorage('upgradeNotificationCurrentState', 'accessLastHour');
       }
       if (type === 'offer') {
-        setCurrentState('FPDLastHour');
-        setLocalStorage('currentState', 'FPDLastHour');
+        setupgradeNotificationCurrentState('FPDLastHour');
+        setLocalStorage('upgradeNotificationCurrentState', 'FPDLastHour');
       }
     }
     expirationText = (
@@ -257,18 +257,18 @@ function ExpirationCountdown({ hoursToExpiration, setCurrentState, type }) {
 
 ExpirationCountdown.propTypes = {
   hoursToExpiration: PropTypes.number.isRequired,
-  setCurrentState: PropTypes.func,
+  setupgradeNotificationCurrentState: PropTypes.func,
   type: PropTypes.string,
 };
 ExpirationCountdown.defaultProps = {
-  setCurrentState: null,
+  setupgradeNotificationCurrentState: null,
   type: null,
 };
 
-function AccessExpirationDateBanner({ accessExpirationDate, timezoneFormatArgs, setCurrentState }) {
-  if (setCurrentState) {
-    setCurrentState('accessDateView');
-    setLocalStorage('currentState', 'accessDateView');
+function AccessExpirationDateBanner({ accessExpirationDate, timezoneFormatArgs, setupgradeNotificationCurrentState }) {
+  if (setupgradeNotificationCurrentState) {
+    setupgradeNotificationCurrentState('accessDateView');
+    setLocalStorage('upgradeNotificationCurrentState', 'accessDateView');
   }
   return (
     <div className="upsell-warning-light">
@@ -296,12 +296,12 @@ AccessExpirationDateBanner.propTypes = {
   timezoneFormatArgs: PropTypes.shape({
     timeZone: PropTypes.string,
   }),
-  setCurrentState: PropTypes.func,
+  setupgradeNotificationCurrentState: PropTypes.func,
 };
 
 AccessExpirationDateBanner.defaultProps = {
   timezoneFormatArgs: {},
-  setCurrentState: null,
+  setupgradeNotificationCurrentState: null,
 };
 
 function UpgradeNotification({
@@ -310,7 +310,7 @@ function UpgradeNotification({
   courseId,
   offer,
   org,
-  setCurrentState,
+  setupgradeNotificationCurrentState,
   shouldDisplayBorder,
   timeOffsetMillis,
   upsellPageName,
@@ -389,7 +389,7 @@ function UpgradeNotification({
         expirationBanner = (
           <ExpirationCountdown
             hoursToExpiration={hoursToDiscountExpiration}
-            setCurrentState={setCurrentState}
+            setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
             type="offer"
           />
         );
@@ -404,7 +404,7 @@ function UpgradeNotification({
           <AccessExpirationDateBanner
             accessExpirationDate={accessExpirationDate}
             timezoneFormatArgs={timezoneFormatArgs}
-            setCurrentState={setCurrentState}
+            setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
           />
         );
       }
@@ -419,7 +419,7 @@ function UpgradeNotification({
       expirationBanner = (
         <ExpirationCountdown
           hoursToExpiration={hoursToAccessExpiration}
-          setCurrentState={setCurrentState}
+          setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
           type="access"
         />
       );
@@ -488,7 +488,7 @@ UpgradeNotification.propTypes = {
     code: PropTypes.string,
   }),
   shouldDisplayBorder: PropTypes.bool,
-  setCurrentState: PropTypes.func,
+  setupgradeNotificationCurrentState: PropTypes.func,
   timeOffsetMillis: PropTypes.number,
   upsellPageName: PropTypes.string.isRequired,
   userTimezone: PropTypes.string,
@@ -503,7 +503,7 @@ UpgradeNotification.defaultProps = {
   accessExpiration: null,
   contentTypeGatingEnabled: false,
   offer: null,
-  setCurrentState: null,
+  setupgradeNotificationCurrentState: null,
   shouldDisplayBorder: null,
   timeOffsetMillis: 0,
   userTimezone: null,


### PR DESCRIPTION
[REV-2297](https://openedx.atlassian.net/browse/REV-2297) captures the following behavior for the red dot functionality: 

1) After the sidebar has shown for 3 seconds, red dot goes away
2) If the learner re-loads the browser or comes back, their state should be remembered (save in localStorage)
3) Then when the user reaches one of the next phases, the red dot should reappear so they read the new message, disappear after 3 seconds, and be remembered upon reload (like above). The  7 defined phases do not overlap, so whenever the current phase is different from the last seen, we bring back the red dot (and then as above it disappears after 3 seconds). See Figma docs linked in ticket- first we have 3 phases for first purchase discount (having days, hours, or minutes left til it expires), then 4 for audit access: more than a week left (show the expiration date), or days, hours, or minutes until expiration (reusing the same components for display). 


**I've added new variables to do this:** 
- _notificationStatus_ ('active' or 'inactive') for whether or not to show red dot. This is a prop for the current experience, and saved to local storage for persistence when the user comes back. 
- _upgradeNotificationCurrentState_: prop to capture the learner's notification phase (ex: days until first purchase discount expires, hours until audit access expires, etc)
- _upgradeNotificationLastSeen_: last phase they've had an upgrade notification for (localStorage-only, for checking when they come back)

**How it works:** 
1) notificationStatus starts as 'active' so a red dot will show on the NotificationTray icon. Then in NotificationTray, 3 seconds after it loads we call onNotificationSeen(), which sets the notification status to 'inactive' (the prop and in local storage)
2) The UpgradeNotification component is where we know what phase the learner is in, so we save it from there (localStorage for persistence, and the prop to trigger re-mounting). Note: where components are shared for both types of messages (first purchase discount and access expiration), I pass in a 'type' to differentiate ('offer' or 'access'). 
3) The NotificationTrigger checks the state when this mounts: if there's a upgradeNotificationCurrentState that's different from upgradeNotificationLastSeen, we set notificationStatus back to 'active', and update upgradeNotificationLastSeen with the value from upgradeNotificationCurrentState.  (This prop change makes it re-mount, and since notificationStatus is active, its NotificationIcon shows the red dot). 

**Testing:** 
Automated: npm test -- src/courseware/course/NotificationTrigger.test.js

Manual: 
1. log in with edx@example.com/edit, enroll as audit learner in demo course, and navigate to course home. 
2. From there, "View this course as Audit"
3. From outline, click a lesson to go to courseware
4. Result: NotificationTrigger shows the red dot icon at first, then switches to no-dot after three seconds
5. Masquerade mode doesn't have a way to mimic the various phases yet (see [TNL-8327](https://openedx.atlassian.net/browse/TNL-8327)), so I updated the code manually to see them

<img width="1285" alt="Screen Shot 2021-08-23 at 4 47 36 PM" src="https://user-images.githubusercontent.com/5384216/130517444-4fcc3165-e44d-485a-beed-f13f395fc2aa.png">
<img width="1284" alt="Screen Shot 2021-08-23 at 4 48 08 PM" src="https://user-images.githubusercontent.com/5384216/130517456-ef5f85cb-51e0-4aae-b31e-8c9c31e6f918.png">
