### PR TITLE
fix: re-enable access error redirects for course home

### DIFF
--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -199,10 +199,12 @@ export async function getDatesTabData(courseId) {
     const { httpErrorStatus } = error && error.customAttributes;
     if (httpErrorStatus === 404) {
       global.location.replace(`${getConfig().LMS_BASE_URL}/courses/${courseId}/dates`);
+      return {};
     }
-    // 401 can be returned for unauthenticated users or users who are not enrolled
     if (httpErrorStatus === 401) {
-      global.location.replace(`${getConfig().BASE_URL}/course/${courseId}/home`);
+      // The backend sends this for unenrolled and unauthenticated learners, but we handle those cases by examining
+      // courseAccess in the metadata call, so just ignore this status for now.
+      return {};
     }
     throw error;
   }
@@ -266,10 +268,12 @@ export async function getProgressTabData(courseId, targetUserId) {
     const { httpErrorStatus } = error && error.customAttributes;
     if (httpErrorStatus === 404) {
       global.location.replace(`${getConfig().LMS_BASE_URL}/courses/${courseId}/progress`);
+      return {};
     }
-    // 401 can be returned for unauthenticated users or users who are not enrolled
     if (httpErrorStatus === 401) {
-      global.location.replace(`${getConfig().BASE_URL}/course/${courseId}/home`);
+      // The backend sends this for unenrolled and unauthenticated learners, but we handle those cases by examining
+      // courseAccess in the metadata call, so just ignore this status for now.
+      return {};
     }
     throw error;
   }

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -17,7 +17,7 @@ import {
 } from '../../generic/model-store';
 
 import {
-  // fetchTabDenied,
+  fetchTabDenied,
   fetchTabFailure,
   fetchTabRequest,
   fetchTabSuccess,
@@ -63,10 +63,9 @@ export function fetchTab(courseId, tab, getTabData, targetUserId) {
       }
 
       // Disable the access-denied path for now - it caused a regression
-      /* if (fetchedCourseHomeCourseMetadata && !courseHomeCourseMetadataResult.value.courseAccess.hasAccess) {
+      if (fetchedCourseHomeCourseMetadata && !courseHomeCourseMetadataResult.value.courseAccess.hasAccess) {
         dispatch(fetchTabDenied({ courseId }));
-      } else */
-      if (fetchedCourseHomeCourseMetadata && fetchedTabData) {
+      } else if (fetchedCourseHomeCourseMetadata && fetchedTabData) {
         dispatch(fetchTabSuccess({ courseId, targetUserId }));
       } else {
         dispatch(fetchTabFailure({ courseId }));

--- a/src/course-home/dates-tab/DatesTab.test.jsx
+++ b/src/course-home/dates-tab/DatesTab.test.jsx
@@ -299,7 +299,7 @@ describe('DatesTab', () => {
     });
   });
 
-  describe.skip('when receiving an access denied error', () => {
+  describe('when receiving an access denied error', () => {
     // These tests could go into any particular tab, as they all go through the same flow. But dates tab works.
 
     async function renderDenied(errorCode) {
@@ -337,6 +337,16 @@ describe('DatesTab', () => {
     it('redirects to the dashboard with a notlive start date for a course_not_started error code', async () => {
       await renderDenied('course_not_started');
       expect(global.location.href).toEqual('http://localhost/redirect/dashboard?notlive=2/5/2013'); // date from factory
+    });
+
+    it('redirects to the home page when unauthenticated', async () => {
+      await renderDenied('authentication_required');
+      expect(global.location.href).toEqual(`http://localhost/redirect/course-home/${courseMetadata.id}`);
+    });
+
+    it('redirects to the home page when unenrolled', async () => {
+      await renderDenied('enrollment_required');
+      expect(global.location.href).toEqual(`http://localhost/redirect/course-home/${courseMetadata.id}`);
     });
   });
 });

--- a/src/generic/model-store/hooks.js
+++ b/src/generic/model-store/hooks.js
@@ -2,7 +2,7 @@ import { useSelector, shallowEqual } from 'react-redux';
 
 export function useModel(type, id) {
   return useSelector(
-    state => (state.models[type] !== undefined ? state.models[type][id] : undefined),
+    state => (state.models[type] !== undefined ? state.models[type][id] : {}),
     shallowEqual,
   );
 }
@@ -10,7 +10,7 @@ export function useModel(type, id) {
 export function useModels(type, ids) {
   return useSelector(
     state => ids.map(
-      id => (state.models[type] !== undefined ? state.models[type][id] : undefined),
+      id => (state.models[type] !== undefined ? state.models[type][id] : {}),
     ),
     shallowEqual,
   );

--- a/src/shared/access-denied-redirect/index.js
+++ b/src/shared/access-denied-redirect/index.js
@@ -1,3 +1,0 @@
-import AccessDeniedRedirect from './AccessDeniedRedirect';
-
-export default AccessDeniedRedirect;

--- a/src/shared/access.js
+++ b/src/shared/access.js
@@ -1,26 +1,11 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+/* eslint-disable import/prefer-default-export */
 import { getLocale } from '@edx/frontend-platform/i18n';
-import { Redirect } from 'react-router';
-import { useModel } from '../../generic/model-store';
 
-// This component inspects an access denied error and redirects to a /redirect/... path, which then renders a nice
-// little message while the browser loads the next page.
+// This function inspects an access denied error and provides a redirect url (looks like a /redirect/... path),
+// which then renders a nice little message while the browser loads the next page.
 // This is basically a frontend version of check_course_access_with_redirect in the backend.
-
-function AccessDeniedRedirect(props) {
-  const {
-    courseId,
-    metadataModel,
-    unitId,
-  } = props;
-
-  const {
-    courseAccess,
-    start,
-  } = useModel(metadataModel, courseId);
-
-  let url = `/redirect/course-home/${courseId}`;
+export function getAccessDeniedRedirectUrl(courseId, activeTabSlug, courseAccess, start, unitId) {
+  let url = null;
   switch (courseAccess.errorCode) {
     case 'audit_expired':
       url = `/redirect/dashboard?access_response_error=${courseAccess.additionalContextUserMessage}`;
@@ -48,20 +33,9 @@ function AccessDeniedRedirect(props) {
     case 'authentication_required':
     case 'enrollment_required':
     default:
+      if (activeTabSlug !== 'outline') {
+        url = `/redirect/course-home/${courseId}`;
+      }
   }
-  return (
-    <Redirect to={url} />
-  );
+  return url;
 }
-
-AccessDeniedRedirect.defaultProps = {
-  unitId: null,
-};
-
-AccessDeniedRedirect.propTypes = {
-  courseId: PropTypes.string.isRequired,
-  metadataModel: PropTypes.string.isRequired,
-  unitId: PropTypes.string,
-};
-
-export default AccessDeniedRedirect;


### PR DESCRIPTION
These redirects are already in place for the courseware, and will redirect to the outline page, or the dashboard, or wherever, based on the type of access error (unenrolled, access expired, survey needed, etc).

This commit stops the course home tabs from paying attention to the 401 error messages coming from the backend - course_access in the metadata API handles that now.

This commit also changes our useModel hook to more gracefully handle not being able to find the model - it is a valid case we want to allow (still will cause problems if you actually try to use the data, but will at least provide an object you can inspect).