### PR TITLE
build: git ignore local environment overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ logs
 
 # Local package dependencies
 module.config.js
+
+# Local environment overrides
+.env.private


### PR DESCRIPTION
Git ignore for `.env.private` to enable local environment
overrides as detailed by `frontend-build`. See:
https://github.com/edx/frontend-build#override-default-envdevelopment-environment-variables-with-envprivate