### PR TITLE
[SE-4650] OEP-15 - add support for course-wide custom resources

### DIFF
--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -222,6 +222,8 @@ function normalizeMetadata(metadata) {
     specialExamsEnabledWaffleFlag: data.is_mfe_special_exams_enabled,
     proctoredExamsEnabledWaffleFlag: data.is_mfe_proctored_exams_enabled,
     isMasquerading: data.original_user_is_staff && !data.is_staff,
+    courseWideJs: data.course_wide_js,
+    courseWideCss: data.course_wide_css,
   };
 }
 

--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -48,7 +48,7 @@ function LoadedTabPage({
     <>
       <Helmet>
         <title>{`${activeTab ? `${activeTab.title} | ` : ''}${title} | ${getConfig().SITE_NAME}`}</title>
-        {courseWideJs && courseWideJs.map(js => <script key={js} src={js} />)}
+        {courseWideJs && courseWideJs.map(js => <script key={js} type="text/javascript" src={js} />)}
         {courseWideCss && courseWideCss.map(css => <link key={css} rel="stylesheet" href={css} />)}
       </Helmet>
       <Header

--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -29,6 +29,8 @@ function LoadedTabPage({
     celebrations,
     canViewLegacyCourseware,
     verifiedMode,
+    courseWideJs,
+    courseWideCss,
   } = useModel(metadataModel, courseId);
 
   // Logistration and enrollment alerts are only really used for the outline tab, but loaded here to put them above
@@ -46,6 +48,8 @@ function LoadedTabPage({
     <>
       <Helmet>
         <title>{`${activeTab ? `${activeTab.title} | ` : ''}${title} | ${getConfig().SITE_NAME}`}</title>
+        {courseWideJs && courseWideJs.map(js => <script key={js} src={js} />)}
+        {courseWideCss && courseWideCss.map(css => <link key={css} rel="stylesheet" href={css} />)}
       </Helmet>
       <Header
         courseOrg={org}


### PR DESCRIPTION
## Description

Details about the purpose of this PR can be found in [edx-platform#28411](https://github.com/edx/edx-platform/pull/28411).

In this PR we're just taking the course-wide JS and CSS URLs from the course metadata and adding them to then pager `<head>`.

## Testing Instructions

- Run a devstack and checkout both `edx-platform` and `frontend-app-learning` repo to the `hadi/se-4650/oep-15` branch
- Follow the testing instructions [edx-platform#28411](https://github.com/edx/edx-platform/pull/28411) to add course-wide scripts to the course via the studio
- Visit a course page, check that the scripts are added to the page head

(If there's a simple way for me to get the Learning MFE running on the OCIM sandbox in [edx-platform#28411](https://github.com/edx/edx-platform/pull/28411) let me know and I could do that instead, I didn't want to spend too much time seeing whether I could do that or not)

## Reviewers
- [ ] @nizarmah
- [ ] @bradenmacdonald

@edx/engage-squad