### PR TITLE
chore: update frontend-lib-special-exams version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3663,9 +3663,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.12.1.tgz",
-      "integrity": "sha512-p+R7yQa8Zy1/5qEMYdcfX1qs+acjOKKsQvnC5WmyTggJwG7Z2Sh5Dp38higsuMUvfQxIvkX2zn4cO5fIdtGi7Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.12.2.tgz",
+      "integrity": "sha512-DFGJ5mNDed7t6ECjqHoJCT8Fc4l5362cny1MnXhOz05dwo6xyO0zHiEOPfB8/TvXuLSZ3YSKI3rdWje6z+fmkw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-enterprise-utils": "1.0.0",
-    "@edx/frontend-lib-special-exams": "1.12.1",
+    "@edx/frontend-lib-special-exams": "1.12.2",
     "@edx/frontend-platform": "1.12.4",
     "@edx/paragon": "16.9.1",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
The latest version of this library contains a fix for the special exams masquerading message. Previously this message would show for any content if a user was masquerading, while the fix limits this message to only show for time gated content while masquerading.