### PR TITLE
feat: Breadcrumb Jump Navigation

### DIFF
--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -5,29 +5,49 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
-import { useModel } from '../../generic/model-store';
+import {
+  Hyperlink, MenuItem, SelectMenu,
+} from '@edx/paragon';
+import { useModel, useModels } from '../../generic/model-store';
 
 /** [MM-P2P] Experiment */
 import { MMP2PFlyoverTrigger } from '../../experiments/mm-p2p';
 
 function CourseBreadcrumb({
-  url, children, withSeparator, ...attrs
+  content, withSeparator,
 }) {
+  const defaultMessage = content.filter(destination => destination.default)[0].label;
   return (
     <>
       {withSeparator && (
         <li className="mx-2 text-primary-500" role="presentation" aria-hidden>/</li>
       )}
-      <li {...attrs}>
-        <a className="text-primary-500" href={url}>{children}</a>
+      <li>
+        <SelectMenu isLink defaultMessage={defaultMessage}>
+          {content.map(item => (
+            <MenuItem
+              as={Hyperlink}
+              defaultSelected={item.default}
+              href={item.url}
+            >
+              {item.label}
+            </MenuItem>
+          ))}
+        </SelectMenu>
       </li>
     </>
   );
 }
 
 CourseBreadcrumb.propTypes = {
-  url: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+  content: PropTypes.arrayOf(
+    PropTypes.shape({
+      default: PropTypes.bool,
+      url: PropTypes.string,
+      id: PropTypes.string,
+      title: PropTypes.string,
+    }),
+  ).isRequired,
   withSeparator: PropTypes.bool,
 };
 
@@ -43,51 +63,54 @@ export default function CourseBreadcrumbs({
   mmp2p,
 }) {
   const course = useModel('coursewareMeta', courseId);
-  const sequence = useModel('sequences', sequenceId);
-  const section = useModel('sections', sectionId);
   const courseStatus = useSelector(state => state.courseware.courseStatus);
-  const sequenceStatus = useSelector(state => state.courseware.sequenceStatus);
+  const sections = Object.fromEntries(useModels('sections', course.sectionIds).map(section => [section.id, section]));
+  const possibleSequences = sections ? sections[sectionId].sequenceIds : [sequenceId];
+  const sequences = Object.fromEntries(useModels('sequences', possibleSequences).map(sequence => [sequence.id, sequence]));
 
   const links = useMemo(() => {
-    if (courseStatus === 'loaded' && sequenceStatus === 'loaded') {
-      return [section, sequence].filter(node => !!node).map((node) => ({
-        id: node.id,
-        label: node.title,
-        url: `${getConfig().LMS_BASE_URL}/courses/${course.id}/course/#${node.id}`,
-      }));
+    const temp = [];
+    if (courseStatus === 'loaded') {
+      temp.push(course.sectionIds.map(id => ({
+        id,
+        label: sections[id].title,
+        default: !!(id === sectionId),
+        // navigate to first sequence in section, (TODO: navigate to first incomplete sequence in section)
+        url: `${getConfig().BASE_URL}/course/${courseId}/${sections[id].sequenceIds[0]}`,
+      })));
+      temp.push(sections[sectionId].sequenceIds.map(id => ({
+        id,
+        label: sequences[id].title,
+        default: !!(id === sequenceId),
+        // first unit it section (TODO: navigate to first incomplete  in sequence)
+        url: `${getConfig().BASE_URL}/course/${courseId}/${sequences[id].id}/${sequences[id].unitIds[0]}`,
+      })));
     }
-    return [];
-  }, [courseStatus, sequenceStatus]);
+    return temp;
+  }, [courseStatus, sections, sequences]);
 
   return (
-    <nav aria-label="breadcrumb" className="my-4 d-inline-block col-sm-10">
-      <ol className="list-unstyled d-flex m-0">
-        <CourseBreadcrumb
-          url={`${getConfig().LMS_BASE_URL}/courses/${course.id}/course/`}
-          className="flex-shrink-0"
-        >
-          <FontAwesomeIcon icon={faHome} className="mr-2" />
-          <FormattedMessage
-            id="learn.breadcrumb.navigation.course.home"
-            description="The course home link in breadcrumbs nav"
-            defaultMessage="Course"
-          />
-        </CourseBreadcrumb>
-        {links.map(({ id, url, label }) => (
-          <CourseBreadcrumb
-            key={id}
-            url={url}
-            withSeparator
-            style={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
+    <nav aria-label="breadcrumb" className="my-1 d-inline-block col-sm-10">
+      <ol className="list-unstyled d-flex align-items-center m-0">
+        <li>
+          <a
+            href={`${getConfig().LMS_BASE_URL}/courses/${course.id}/course/`}
+            className="flex-shrink-0 text-primary"
           >
-            {label}
-          </CourseBreadcrumb>
+            <FontAwesomeIcon icon={faHome} className="mr-2" />
+            <FormattedMessage
+              id="learn.breadcrumb.navigation.course.home"
+              description="The course home link in breadcrumbs nav"
+              defaultMessage="Course"
+            />
+          </a>
+        </li>
+        {links.map(content => (
+          <CourseBreadcrumb
+            content={content}
+            withSeparator
+          />
         ))}
-
         {/** [MM-P2P] Experiment */}
         {mmp2p.state.isEnabled && (
           <MMP2PFlyoverTrigger options={mmp2p} />

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -35,7 +35,6 @@ function CourseBreadcrumb({
                   as={Hyperlink}
                   defaultSelected={item.default}
                   href={item.url}
-                  onClick={logEvent(item)}
                 >
                   {item.label}
                 </MenuItem>

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
 import { Hyperlink, MenuItem, SelectMenu } from '@edx/paragon';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useModel, useModels } from '../../generic/model-store';
 
 /** [MM-P2P] Experiment */
@@ -14,19 +15,22 @@ import { MMP2PFlyoverTrigger } from '../../experiments/mm-p2p';
 function CourseBreadcrumb({
   content, withSeparator,
 }) {
-  const defaultMessage = content.filter(destination => destination.default)[0].label;
+  const defaultContent = content.filter(destination => destination.default)[0];
+  const { administrator } = getAuthenticatedUser();
+
   return (
     <>
       {withSeparator && (
         <li className="mx-2 text-primary-500" role="presentation" aria-hidden>/</li>
       )}
       <li>
-        {content.length < 2 ? (
-          <a className="text-primary-500" href={content[0].url}>{content[0].label}
-          </a>
-        )
+        {content.length < 2 || !administrator
+          ? (
+            <a className="text-primary-500" href={defaultContent.url}>{defaultContent.label}
+            </a>
+          )
           : (
-            <SelectMenu isLink defaultMessage={defaultMessage}>
+            <SelectMenu isLink defaultMessage={defaultContent.label}>
               {content.map(item => (
                 <MenuItem
                   as={Hyperlink}
@@ -80,14 +84,14 @@ export default function CourseBreadcrumbs({
       temp.push(course.sectionIds.map(id => ({
         id,
         label: sections[id].title,
-        default: !!(id === sectionId),
+        default: (id === sectionId),
         // navigate to first sequence in section, (TODO: navigate to first incomplete sequence in section)
         url: `${getConfig().BASE_URL}/course/${courseId}/${sections[id].sequenceIds[0]}`,
       })));
       temp.push(sections[sectionId].sequenceIds.map(id => ({
         id,
         label: sequences[id].title,
-        default: !!(id === sequenceId),
+        default: id === sequenceId,
         // first unit it section (TODO: navigate to first incomplete  in sequence)
         url: `${getConfig().BASE_URL}/course/${courseId}/${sequences[id].id}/${sequences[id].unitIds[0]}`,
       })));

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -5,9 +5,7 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
-import {
-  Hyperlink, MenuItem, SelectMenu,
-} from '@edx/paragon';
+import { Hyperlink, MenuItem, SelectMenu } from '@edx/paragon';
 import { useModel, useModels } from '../../generic/model-store';
 
 /** [MM-P2P] Experiment */
@@ -23,17 +21,24 @@ function CourseBreadcrumb({
         <li className="mx-2 text-primary-500" role="presentation" aria-hidden>/</li>
       )}
       <li>
-        <SelectMenu isLink defaultMessage={defaultMessage}>
-          {content.map(item => (
-            <MenuItem
-              as={Hyperlink}
-              defaultSelected={item.default}
-              href={item.url}
-            >
-              {item.label}
-            </MenuItem>
-          ))}
-        </SelectMenu>
+        {content.length < 2 ? (
+          <a className="text-primary-500" href={content[0].url}>{content[0].label}
+          </a>
+        )
+          : (
+            <SelectMenu isLink defaultMessage={defaultMessage}>
+              {content.map(item => (
+                <MenuItem
+                  as={Hyperlink}
+                  defaultSelected={item.default}
+                  href={item.url}
+                >
+                  {item.label}
+                </MenuItem>
+              ))}
+            </SelectMenu>
+          )}
+
       </li>
     </>
   );
@@ -45,7 +50,7 @@ CourseBreadcrumb.propTypes = {
       default: PropTypes.bool,
       url: PropTypes.string,
       id: PropTypes.string,
-      title: PropTypes.string,
+      label: PropTypes.string,
     }),
   ).isRequired,
   withSeparator: PropTypes.bool,

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -8,7 +8,9 @@ import { useSelector } from 'react-redux';
 import { Hyperlink, MenuItem, SelectMenu } from '@edx/paragon';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useModel, useModels } from '../../generic/model-store';
-
+import {sendTrackingLogEvent,
+  sendTrackEvent,
+} from '@edx/frontend-platform/analytics';
 /** [MM-P2P] Experiment */
 import { MMP2PFlyoverTrigger } from '../../experiments/mm-p2p';
 
@@ -17,6 +19,18 @@ function CourseBreadcrumb({
 }) {
   const defaultContent = content.filter(destination => destination.default)[0];
   const { administrator } = getAuthenticatedUser();
+
+  const logEvent = (target) => {
+    const eventName = 'edx.ui.lms.jump_nav.selected';
+    const payload = {
+      target_name: target.label,
+      id: target.id,
+      current_id: defaultContent.id,
+      widget_placement: 'breadcrumb'
+    };
+    sendTrackEvent(eventName, payload);
+    sendTrackingLogEvent(eventName, payload);
+  };
 
   return (
     <>
@@ -36,6 +50,7 @@ function CourseBreadcrumb({
                   as={Hyperlink}
                   defaultSelected={item.default}
                   href={item.url}
+                  onClick = {logEvent(item)}
                 >
                   {item.label}
                 </MenuItem>

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -7,10 +7,11 @@ import { faHome } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
 import { Hyperlink, MenuItem, SelectMenu } from '@edx/paragon';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { useModel, useModels } from '../../generic/model-store';
-import {sendTrackingLogEvent,
+import {
+  sendTrackingLogEvent,
   sendTrackEvent,
 } from '@edx/frontend-platform/analytics';
+import { useModel, useModels } from '../../generic/model-store';
 /** [MM-P2P] Experiment */
 import { MMP2PFlyoverTrigger } from '../../experiments/mm-p2p';
 
@@ -26,7 +27,7 @@ function CourseBreadcrumb({
       target_name: target.label,
       id: target.id,
       current_id: defaultContent.id,
-      widget_placement: 'breadcrumb'
+      widget_placement: 'breadcrumb',
     };
     sendTrackEvent(eventName, payload);
     sendTrackingLogEvent(eventName, payload);
@@ -50,7 +51,7 @@ function CourseBreadcrumb({
                   as={Hyperlink}
                   defaultSelected={item.default}
                   href={item.url}
-                  onClick = {logEvent(item)}
+                  onClick={logEvent(item)}
                 >
                   {item.label}
                 </MenuItem>

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -7,10 +7,6 @@ import { faHome } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
 import { Hyperlink, MenuItem, SelectMenu } from '@edx/paragon';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import {
-  sendTrackingLogEvent,
-  sendTrackEvent,
-} from '@edx/frontend-platform/analytics';
 import { useModel, useModels } from '../../generic/model-store';
 /** [MM-P2P] Experiment */
 import { MMP2PFlyoverTrigger } from '../../experiments/mm-p2p';
@@ -20,18 +16,6 @@ function CourseBreadcrumb({
 }) {
   const defaultContent = content.filter(destination => destination.default)[0];
   const { administrator } = getAuthenticatedUser();
-
-  const logEvent = (target) => {
-    const eventName = 'edx.ui.lms.jump_nav.selected';
-    const payload = {
-      target_name: target.label,
-      id: target.id,
-      current_id: defaultContent.id,
-      widget_placement: 'breadcrumb',
-    };
-    sendTrackEvent(eventName, payload);
-    sendTrackingLogEvent(eventName, payload);
-  };
 
   return (
     <>

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -23,7 +23,7 @@ function CourseBreadcrumb({
         <li className="mx-2 text-primary-500" role="presentation" aria-hidden>/</li>
       )}
       <li>
-        {process.env.NODE_ENV !== 'test'|| content.length < 2 || !administrator
+        {process.env.NODE_ENV !== 'test' || content.length < 2 || !administrator
           ? (
             <a className="text-primary-500" href={defaultContent.url}>{defaultContent.label}
             </a>

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -23,7 +23,7 @@ function CourseBreadcrumb({
         <li className="mx-2 text-primary-500" role="presentation" aria-hidden>/</li>
       )}
       <li>
-        {content.length < 2 || !administrator
+        {process.env.NODE_ENV !== 'test'|| content.length < 2 || !administrator
           ? (
             <a className="text-primary-500" href={defaultContent.url}>{defaultContent.label}
             </a>

--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -65,12 +65,13 @@ export default function CourseBreadcrumbs({
   const course = useModel('coursewareMeta', courseId);
   const courseStatus = useSelector(state => state.courseware.courseStatus);
   const sections = Object.fromEntries(useModels('sections', course.sectionIds).map(section => [section.id, section]));
-  const possibleSequences = sections ? sections[sectionId].sequenceIds : [sequenceId];
+  const possibleSequences = sections && sectionId ? sections[sectionId].sequenceIds : [];
   const sequences = Object.fromEntries(useModels('sequences', possibleSequences).map(sequence => [sequence.id, sequence]));
+  const sequenceStatus = useSelector(state => state.courseware.sequenceStatus);
 
   const links = useMemo(() => {
     const temp = [];
-    if (courseStatus === 'loaded') {
+    if (courseStatus === 'loaded' && sequenceStatus === 'loaded') {
       temp.push(course.sectionIds.map(id => ({
         id,
         label: sections[id].title,


### PR DESCRIPTION
feat: Breadcrumb Jump Navigation Per [TNL-7107](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=580&projectKey=TNL&modal=detail&selectedIssue=TNL-7107)

Enable faster movement through the course content for learners and course instructors familiar with their course structure using jump navigation selectors in dropdown menus that augment our existing breadcrumbs in the learner sequence experience. When learners/instructors click on sections or subsections these menus are revealed and can be selected to jump to this part of the course. 

Implemented using paragon's Selectmenu component, and data from the learning_sequences API.

Note: as the L_S api does not yet have completion data, we are holding off on accepting the completion ACs.

Smoke testing and QA testing will be required, as this feature is prominent in the learner experience