### PR TITLE
fix: LockPaywall container display issue on mobile

### DIFF
--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
@@ -1,3 +1,7 @@
+.alert-content.lock-paywall-container {
+    display: inline-flex;
+}
+
 .lock-paywall-container svg {
     color: $primary-700;
 }


### PR DESCRIPTION
[REV-2357](https://openedx.atlassian.net/browse/REV-2357).

The `LockPaywall` component uses the `Alert` component from Paragon, which has `display: flex`. Adding CSS to override that with `inline-flex`.

**Before:**
<img width="187" alt="Screen Shot 2021-09-24 at 12 28 05 PM" src="https://user-images.githubusercontent.com/13632680/134710790-453a4fb5-f6e0-457c-ab08-ea9859ebed1e.png">

**After:**
<img width="188" alt="Screen Shot 2021-09-24 at 12 26 38 PM" src="https://user-images.githubusercontent.com/13632680/134710773-68f11d61-daa6-476b-9bc1-267112c421eb.png">

I've checked other screen sizes and it looks the same.