### PR TITLE
fix: Value Prop miscellaneous styling fixes

### DIFF
--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -119,7 +119,7 @@ export default function CourseBreadcrumbs({
     return temp;
   }, [courseStatus, sections, sequences]);
   return (
-    <nav aria-label="breadcrumb" className="my-1 d-inline-block col-sm-10">
+    <nav aria-label="breadcrumb" className="my-4 d-inline-block col-sm-10">
       <ol className="list-unstyled d-flex align-items-center m-0">
         <li>
           <a

--- a/src/courseware/course/NotificationTrigger.scss
+++ b/src/courseware/course/NotificationTrigger.scss
@@ -1,7 +1,7 @@
 .notification-trigger-btn {
     border: 1px solid $light-400;
     background: none;
-    margin-top: 0.625rem;
+    margin-top: 1rem;
 
     position: absolute;
     right: 0;

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -149,7 +149,7 @@ function LockPaywall({
 
         <div
           className={
-            classNames('p-md-0 d-md-flex align-items-md-center text-right', {
+            classNames('d-md-flex align-items-md-center text-right', {
               'col-md-5 mx-md-0': notificationTrayVisible, 'col-md-4 mx-md-3 justify-content-center': !notificationTrayVisible && !shouldDisplayGatedContentTwoColumnsHalf, 'col-md-11 justify-content-end': shouldDisplayGatedContentOneColumn && !shouldDisplayGatedContentTwoColumns, 'col-md-6 justify-content-center': shouldDisplayGatedContentTwoColumnsHalf,
             })
           }

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -463,13 +463,14 @@ function UpgradeNotification({
       <div className="upgrade-notification-message">
         {upsellMessage}
       </div>
-      <UpgradeButton
-        offer={offer}
-        onClick={logClick}
-        verifiedMode={verifiedMode}
-        className="upgrade-notification-button"
-        block
-      />
+      <div className="upgrade-notification-button">
+        <UpgradeButton
+          offer={offer}
+          onClick={logClick}
+          verifiedMode={verifiedMode}
+          block
+        />
+      </div>
       {offerCode}
     </section>
   );

--- a/src/generic/upgrade-notification/UpgradeNotification.scss
+++ b/src/generic/upgrade-notification/UpgradeNotification.scss
@@ -34,9 +34,8 @@
 }
 
 .upgrade-notification-button {
-  width: 90%;
-  margin: 0 auto;
-  margin-bottom: 1.25rem;
+  padding: 1.25rem;
+  padding-top: 0;
 }
 
 .discount-info {

--- a/src/generic/upgrade-notification/UpgradeNotification.scss
+++ b/src/generic/upgrade-notification/UpgradeNotification.scss
@@ -19,9 +19,7 @@
 }
 
 .upgrade-notification-ul {
-  margin-left: 3rem;
-  padding-top: 0.875rem;
-  padding-right: 1.25rem;
+  padding: 0.875rem 1.25rem 0 1.25rem;
 }
 
 .upgrade-notification-li {


### PR DESCRIPTION
[REV-2183](https://openedx.atlassian.net/browse/REV-2188). 
Original ticket was to fix the layout for the Spanish version of the `LockPaywall` (aka gated content). This was fixed in another ticket, but I noticed there were other layout fixes that could be improved in our Value Prop work in Learning MFE.

A bug was also introduced in https://github.com/edx/frontend-app-learning/pull/641 by TNL and this PR also has a temporary fix for that. Please note TNL is working on replacing the `Breadcrumb` component with a jump navigation and things may look temporarily off.

**This PR:**
1) Fixes the padding issue on the `UpgradeButton` in the `LockPaywall` at long text lengths (Spanish and discounted price). 

Before (prod):
<img width="1225" alt="VP_GatedContent_1100px_Spanish_TrayOpen_ShorterText" src="https://user-images.githubusercontent.com/13632680/135160051-2a268bab-0909-4f1d-b922-0248c1336fb8.png">

After (local):
<img width="1191" alt="VP_GatedContent_1100px_Spanish_ShorterText_PaddingFixed" src="https://user-images.githubusercontent.com/13632680/135161476-a965ef97-884c-48e7-a603-1535f81e2cc3.png">

2) Fixes the width of the button at medium screen sizes. CSS is applied to all screen sizes, desktop version looks the same.

Before:
<img width="574" alt="Screen Shot 2021-09-28 at 8 49 15 PM" src="https://user-images.githubusercontent.com/13632680/135195948-d2fc3e98-3225-49b7-8b2a-649ba10669e4.png">

After:
<img width="573" alt="Screen Shot 2021-09-28 at 8 50 41 PM" src="https://user-images.githubusercontent.com/13632680/135184820-a9f15525-d9f4-4cf6-ab10-3271cc3be370.png">

Large screen size:
<img width="284" alt="Screen Shot 2021-09-28 at 8 51 15 PM" src="https://user-images.githubusercontent.com/13632680/135185177-4f5d4c93-7b20-4a99-95b8-d497fe48eb6e.png">

3) Fixes the alignment of the checkmarks bullet points in the `UpgradeNotification`

Before:
<img width="284" alt="Screen Shot 2021-09-28 at 10 58 19 PM" src="https://user-images.githubusercontent.com/13632680/135195716-3110d4d6-8dec-4375-940a-0665e5758ef1.png">

After:
<img width="284" alt="Screen Shot 2021-09-28 at 10 57 08 PM" src="https://user-images.githubusercontent.com/13632680/135195733-9ed80ac9-8c5c-43cc-a2c4-d2eaea7b83a5.png">

Before responsive: 
<img width="565" alt="Screen Shot 2021-09-28 at 11 09 55 PM" src="https://user-images.githubusercontent.com/13632680/135196775-c7bb3f61-54f1-468a-a909-bcf2af25d7a2.png">

After responsive:
<img width="565" alt="Screen Shot 2021-09-28 at 11 10 17 PM" src="https://user-images.githubusercontent.com/13632680/135196797-2385937a-48b7-4d0e-9ae0-5b571ee83483.png">

4) Fixes a bug introduced by TNL in the breadcrumb margin.

Before:
<img width="1207" alt="Screen Shot 2021-09-29 at 9 32 58 AM" src="https://user-images.githubusercontent.com/13632680/135278948-6d7016e1-1d3f-4612-9bc9-0be91a946ffa.png">

After:
<img width="971" alt="Screen Shot 2021-09-29 at 9 37 46 AM" src="https://user-images.githubusercontent.com/13632680/135279695-89cf2a86-56e0-4be7-a287-50327f69d50c.png">


