### PR TITLE
fix: don't show 3-day streak discount if it won't provide a discount

### DIFF
--- a/src/courseware/data/__factories__/courseMetadata.factory.js
+++ b/src/courseware/data/__factories__/courseMetadata.factory.js
@@ -63,4 +63,5 @@ Factory.define('courseMetadata')
     related_programs: null,
     user_needs_integrity_signature: false,
     recommendations: null,
+    username: 'testuser',
   });

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -221,6 +221,7 @@ function normalizeMetadata(metadata) {
     relatedPrograms: camelCaseObject(data.related_programs),
     userNeedsIntegritySignature: data.user_needs_integrity_signature,
     isMasquerading: data.original_user_is_staff && !data.is_staff,
+    username: data.username,
   };
 }
 

--- a/src/generic/upgrade-button/UpgradeNowButton.jsx
+++ b/src/generic/upgrade-button/UpgradeNowButton.jsx
@@ -15,7 +15,7 @@ function UpgradeNowButton(props) {
     ...rest
   } = props;
 
-  // Prefer offer's url in case it is ever different (though it is not at time of this writing)
+  // Prefer offer's url in case it is different (might hold a coupon code that the normal does not)
   const url = offer ? offer.upgradeUrl : verifiedMode.upgradeUrl;
 
   return (

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -123,7 +123,7 @@ export function loadUnit(message = messageEvent) {
 export function logUnhandledRequests(axiosMock) {
   axiosMock.onAny().reply((config) => {
     // eslint-disable-next-line no-console
-    console.log(config.method, config.url.href);
+    console.log(config.method, config.url);
     return [200, {}];
   });
 }

--- a/src/shared/data/__factories__/courseMetadataBase.factory.js
+++ b/src/shared/data/__factories__/courseMetadataBase.factory.js
@@ -12,10 +12,10 @@ export default new Factory()
     original_user_is_staff: false,
     number: 'DemoX',
     org: 'edX',
-    verifiedMode: {
-      upgradeUrl: 'test',
+    verified_mode: {
+      upgrade_url: 'test',
       price: 10,
-      currencySymbol: '$',
+      currency_symbol: '$',
     },
   })
   .attr(

--- a/src/shared/streak-celebration/StreakCelebrationModal.test.jsx
+++ b/src/shared/streak-celebration/StreakCelebrationModal.test.jsx
@@ -1,26 +1,62 @@
 import React from 'react';
 import { Factory } from 'rosie';
+import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { initializeTestStore, render, screen } from '../../setupTest';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import MockAdapter from 'axios-mock-adapter';
+
+import {
+  act,
+  initializeMockApp,
+  initializeTestStore,
+  render,
+  screen,
+} from '../../setupTest';
 import StreakModal from './StreakCelebrationModal';
 
+initializeMockApp();
 jest.mock('@edx/frontend-platform/analytics');
 
 describe('Loaded Tab Page', () => {
-  const mockData = { metadataModel: 'coursewareMeta' };
+  let mockData;
+  let testStore;
+  let axiosMock;
+  const calculateUrl = `${getConfig().ECOMMERCE_BASE_URL}/api/v2/baskets/calculate/?code=ZGY11119949&sku=8CF08E5&username=testuser`;
+  const courseMetadata = Factory.build('courseMetadata', { celebrations: { streak_length_to_celebrate: 3 } });
+
+  function setDiscount(percent) {
+    mockData.streakDiscountCouponEnabled = true;
+    axiosMock.onGet(calculateUrl).reply(200, {
+      total_incl_tax: 100 - percent,
+      total_incl_tax_excl_discounts: 100,
+    });
+  }
+
+  function setDiscountError() {
+    mockData.streakDiscountCouponEnabled = true;
+    axiosMock.onGet(calculateUrl).reply(500);
+  }
+
+  async function renderModal() {
+    await act(async () => render(<StreakModal {...mockData} />, { store: testStore }));
+  }
 
   beforeAll(async () => {
-    mockData.isStreakCelebrationOpen = true;
-    mockData.streakLengthToCelebrate = 3;
+    mockData = { // props for StreakModal
+      closeStreakCelebration: jest.fn(),
+      courseId: courseMetadata.id,
+      isStreakCelebrationOpen: true,
+      metadataModel: 'coursewareMeta',
+      streakLengthToCelebrate: 3,
+      verifiedMode: camelCaseObject(courseMetadata.verified_mode),
+    };
+
+    testStore = await initializeTestStore({ courseMetadata }, false);
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
   });
 
   it('shows streak celebration modal', async () => {
-    const courseMetadata = Factory.build('courseMetadata', { celebrations: { streakLengthToCelebrate: 3 } });
-    mockData.courseId = courseMetadata.id;
-    mockData.verifiedMode = courseMetadata.verifiedMode;
-    mockData.closeStreakCelebration = jest.fn();
-    const testStore = await initializeTestStore({ courseMetadata }, false);
-    render(<StreakModal {...mockData} courseId={courseMetadata.id} />, { store: testStore });
+    await renderModal();
 
     expect(screen.getByText('3 day streak')).toBeInTheDocument();
     expect(screen.getByText('Keep it up, you’re on a roll!')).toBeInTheDocument();
@@ -32,7 +68,23 @@ describe('Loaded Tab Page', () => {
     });
   });
 
-  it('shows streak celebration discount modal', async () => {
+  it('shows normal streak celebration modal when discount call fails', async () => {
+    setDiscountError();
+    await renderModal();
+
+    // This text is only for the non-discount case
+    expect(screen.getByText('Keep it up')).toBeInTheDocument();
+  });
+
+  it('shows normal streak celebration modal when discount is zero', async () => {
+    setDiscount(0);
+    await renderModal();
+
+    // This text is only for the non-discount case
+    expect(screen.getByText('Keep it up')).toBeInTheDocument();
+  });
+
+  it('shows discount version of streak celebration modal when available', async () => {
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: jest.fn().mockImplementation(query => {
@@ -49,15 +101,17 @@ describe('Loaded Tab Page', () => {
         };
       }),
     });
-    const courseMetadata = Factory.build('courseMetadata', { celebrations: { shouldCelebrateStreak: 3 } });
-    mockData.courseId = courseMetadata.id;
-    mockData.verifiedMode = courseMetadata.verifiedMode;
-    mockData.StreakDiscountCouponEnabled = true;
-    const testStore = await initializeTestStore({ courseMetadata }, false);
-    render(<StreakModal {...mockData} courseId={courseMetadata.id} />, { store: testStore });
+    setDiscount(14);
+    await renderModal();
+
     const endDateText = `Ends ${new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toLocaleDateString({ timeZone: 'UTC' })}.`;
-    expect(screen.getByText('You’ve unlocked a 15% off discount when you upgrade this course for a limited time only.')).toBeInTheDocument();
+    expect(screen.getByText('You’ve unlocked a 14% off discount when you upgrade this course for a limited time only.')).toBeInTheDocument();
     expect(screen.getByText(endDateText)).toBeInTheDocument();
     expect(screen.getByText('Continue with course')).toBeInTheDocument();
+    expect(screen.queryByText('Keep it up')).not.toBeInTheDocument();
+    expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.course.streak_discount_enabled', {
+      course_id: mockData.courseId,
+      sku: mockData.verifiedMode.sku,
+    });
   });
 });

--- a/src/shared/streak-celebration/messages.js
+++ b/src/shared/streak-celebration/messages.js
@@ -39,7 +39,7 @@ const messages = defineMessages({
   },
   streakDiscountMessage: {
     id: 'learning.streakCelebration.streakDiscountMessage',
-    defaultMessage: 'You’ve unlocked a 15% off discount when you upgrade this course for a limited time only.',
+    defaultMessage: 'You’ve unlocked a {percent}% off discount when you upgrade this course for a limited time only.',
     description: 'This message describes a discount the user becomes eligible for when they hit their three day streak',
   },
 });

--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -37,7 +37,7 @@ function LoadedTabPage({
   const activeTab = tabs.filter(tab => tab.slug === activeTabSlug)[0];
 
   const streakLengthToCelebrate = celebrations && celebrations.streakLengthToCelebrate;
-  const StreakDiscountCouponEnabled = celebrations && celebrations.streakDiscountEnabled && verifiedMode;
+  const streakDiscountCouponEnabled = celebrations && celebrations.streakDiscountEnabled && verifiedMode;
   const [isStreakCelebrationOpen,, closeStreakCelebration] = useToggle(streakLengthToCelebrate);
 
   return (
@@ -59,7 +59,7 @@ function LoadedTabPage({
         streakLengthToCelebrate={streakLengthToCelebrate}
         isStreakCelebrationOpen={!!isStreakCelebrationOpen}
         closeStreakCelebration={closeStreakCelebration}
-        StreakDiscountCouponEnabled={StreakDiscountCouponEnabled}
+        streakDiscountCouponEnabled={streakDiscountCouponEnabled}
         verifiedMode={verifiedMode}
       />
       <main id="main-content" className="d-flex flex-column flex-grow-1">


### PR DESCRIPTION
Also, this will pull the actual discount percent from ecommerce, instead of hardcoding it.

When a once-only coupon is already claimed by a user, ecommerce will tell us there isn't a discount to be had.

Here is the other PRs related to this: https://github.com/edx/edx-platform/pull/28868

https://openedx.atlassian.net/browse/AA-1012