### PR TITLE
fix: UpgradeNotification bullet point padding override

### DIFF
--- a/src/generic/upgrade-notification/UpgradeNotification.scss
+++ b/src/generic/upgrade-notification/UpgradeNotification.scss
@@ -19,7 +19,9 @@
 }
 
 .upgrade-notification-ul {
-  padding: 0.875rem 1.25rem 0 1.25rem;
+  padding-left: 1.25rem !important;
+  padding-top: 0.875rem;
+  padding-right: 1.25rem;
 }
 
 .upgrade-notification-li {


### PR DESCRIPTION
[REV-2188](https://openedx.atlassian.net/browse/REV-2188).

The class `fa-ul` `padding-left: 0` overrides my changes in prod on the bullet points for the `UpgradeNotification` (but not locally). This PR adds an `!important` to the left padding.

Before (prod):
<img width="318" alt="Screen Shot 2021-09-29 at 11 11 58 AM" src="https://user-images.githubusercontent.com/13632680/135299823-2fd130c0-2c69-4be0-bbdf-212b2d982a76.png">

After (local, both with and without `!important` looks the same):
<img width="294" alt="Screen Shot 2021-09-29 at 11 14 12 AM" src="https://user-images.githubusercontent.com/13632680/135299850-9f88b003-287c-4891-9eab-96607cdc1557.png">

