### PR TITLE
[MST-973] Prevent integrity signature creation while masquerading

### DIFF
--- a/src/courseware/course/sequence/honor-code/HonorCode.jsx
+++ b/src/courseware/course/sequence/honor-code/HonorCode.jsx
@@ -5,19 +5,19 @@ import { getConfig, history } from '@edx/frontend-platform';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { ActionRow, Alert, Button } from '@edx/paragon';
 
+import { useModel } from '../../../../generic/model-store';
 import { saveIntegritySignature } from '../../../data';
 import messages from './messages';
 
 function HonorCode({ intl, courseId }) {
   const dispatch = useDispatch();
+  const { isMasquerading } = useModel('coursewareMeta', courseId);
   const siteName = getConfig().SITE_NAME;
-  const honorCodeUrl = `${process.env.TERMS_OF_SERVICE_URL}#honor-code`;
+  const honorCodeUrl = `${getConfig().TERMS_OF_SERVICE_URL}#honor-code`;
 
   const handleCancel = () => history.push(`/course/${courseId}/home`);
 
-  const handleAgree = () => {
-    dispatch(saveIntegritySignature(courseId));
-  };
+  const handleAgree = () => dispatch(saveIntegritySignature(courseId, isMasquerading));
 
   return (
     <Alert variant="light" aria-live="off">

--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -303,10 +303,15 @@ export function saveSequencePosition(courseId, sequenceId, activeUnitIndex) {
   };
 }
 
-export function saveIntegritySignature(courseId) {
+export function saveIntegritySignature(courseId, isMasquerading) {
   return async (dispatch) => {
     try {
-      await postIntegritySignature(courseId);
+      // If the request is made by a staff user masquerading as a learner,
+      // don't actually create a signature for them on the backend. Only
+      // frontend state will be updated.
+      if (!isMasquerading) {
+        await postIntegritySignature(courseId);
+      }
       dispatch(updateModel({
         modelType: 'coursewareMeta',
         model: {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -101,6 +101,7 @@ initialize({
         SUPPORT_URL_CALCULATOR_MATH: process.env.SUPPORT_URL_CALCULATOR_MATH || null,
         SUPPORT_URL_ID_VERIFICATION: process.env.SUPPORT_URL_ID_VERIFICATION || null,
         SUPPORT_URL_VERIFIED_CERTIFICATE: process.env.SUPPORT_URL_VERIFIED_CERTIFICATE || null,
+        TERMS_OF_SERVICE_URL: process.env.TERMS_OF_SERVICE_URL || null,
         TWITTER_HASHTAG: process.env.TWITTER_HASHTAG || null,
         TWITTER_URL: process.env.TWITTER_URL || null,
       }, 'LearnerAppConfig');


### PR DESCRIPTION
[MST-973](https://openedx.atlassian.net/browse/MST-973)

If a staff user encounters the Honor Code panel while masquerading as a learner, accepting the conditions should not actually create a signature for that user in the database; it should only remove the panel and display content. If the masquerading user refreshes, the panel will reappear.

This also fixes a minor issue where `TERMS_OF_SERVICE_URL` was being accessed with `process.env` and not `getConfig()`.