### PR TITLE
fix: upgrade the frontend-lib-special-exams library to v1.13.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3663,9 +3663,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.13.2.tgz",
-      "integrity": "sha512-NzMgyVAg63x6vg0vSe00MhREyeRSyXE16aBt/34XQHXQKG0ieEVnu3o3oQdlgzu2JWzGxxVmZr4gGeYB3qA7hQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.13.3.tgz",
+      "integrity": "sha512-WTjOPh/Rr6wAKImRdmJaO4g2u+Q0pxw/FLzS7PJ0cE63hoMM8VsVL6diS1Alg01mG5DYXuiX8QyHb9lk0pJzdw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-enterprise-utils": "1.0.0",
-    "@edx/frontend-lib-special-exams": "1.13.2",
+    "@edx/frontend-lib-special-exams": "1.13.3",
     "@edx/frontend-platform": "1.12.7",
     "@edx/paragon": "16.13.3",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
prevents confusing exam errors in non-exam situations

MST-905