### PR TITLE
refactor: create generic bullets to reuse in all upsell messaging

### DIFF
--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Alert } from '@edx/paragon';
 import { Locked } from '@edx/paragon/icons';
 import messages from './messages';
@@ -12,6 +10,12 @@ import certificateLocked from '../../../../generic/assets/edX_locked_certificate
 import { useModel } from '../../../../generic/model-store';
 import useWindowSize, { responsiveBreakpoints } from '../../../../generic/tabs/useWindowSize';
 import { UpgradeButton } from '../../../../generic/upgrade-button';
+import {
+  VerifiedCertBullet,
+  UnlockGradedBullet,
+  FullAccessBullet,
+  SupportMissionBullet,
+} from '../../../../generic/upsell-bullets/UpsellBullets';
 
 function LockPaywall({
   intl,
@@ -56,32 +60,6 @@ function LockPaywall({
     });
   };
 
-  const verifiedCertLink = (
-    <Alert.Link
-      href="https://www.edx.org/verified-certificate"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet1.linktext'])}
-    </Alert.Link>
-  );
-
-  const gradedAssignments = (
-    <span className="font-weight-bold">
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet2.boldtext'])}
-    </span>
-  );
-  const fullAccess = (
-    <span className="font-weight-bold">
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet3.boldtext'])}
-    </span>
-  );
-  const nonProfitMission = (
-    <span className="font-weight-bold">
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet4.boldtext'])}
-    </span>
-  );
-
   return (
     <Alert variant="light" aria-live="off" icon={Locked} className="lock-paywall-container">
       <div className="row">
@@ -109,39 +87,10 @@ function LockPaywall({
                 {intl.formatMessage(messages['learn.lockPaywall.list.intro'])}
               </div>
               <ul className="fa-ul ml-4 pl-2">
-                <li>
-                  <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletOne"
-                    defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
-                    values={{ verifiedCertLink }}
-                    className="bullet-text"
-                  />
-                </li>
-                <li>
-                  <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletTwo"
-                    defaultMessage="Unlock access to all course activities, including {gradedAssignments}"
-                    values={{ gradedAssignments }}
-                  />
-                </li>
-                <li>
-                  <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletThree"
-                    defaultMessage="{fullAccess} to course content and materials, even after the course ends"
-                    values={{ fullAccess }}
-                  />
-                </li>
-                <li>
-                  <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletFour"
-                    defaultMessage="Support our {nonProfitMission} at edX"
-                    values={{ nonProfitMission }}
-                  />
-                </li>
+                <VerifiedCertBullet />
+                <UnlockGradedBullet />
+                <FullAccessBullet />
+                <SupportMissionBullet />
               </ul>
             </div>
           </div>

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Alert } from '@edx/paragon';
 import { Locked } from '@edx/paragon/icons';
 import messages from './messages';
+import genericMessages from '../../../../generic/messages';
 import certificateLocked from '../../../../generic/assets/edX_locked_certificate.png';
 import { useModel } from '../../../../generic/model-store';
 import useWindowSize, { responsiveBreakpoints } from '../../../../generic/tabs/useWindowSize';
@@ -56,29 +58,29 @@ function LockPaywall({
     });
   };
 
-  const verifiedCertLink = (
+  const verifiedCert = (
     <Alert.Link
-      href="https://www.edx.org/verified-certificate"
+      href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
       target="_blank"
       rel="noopener noreferrer"
     >
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet1.linktext'])}
+      {intl.formatMessage(genericMessages['upsell.verifiedCertMessageBullet.verifiedCert'])}
     </Alert.Link>
   );
 
   const gradedAssignments = (
     <span className="font-weight-bold">
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet2.boldtext'])}
+      {intl.formatMessage(genericMessages['upsell.unlockGradedBullet.gradedAssignments'])}
     </span>
   );
   const fullAccess = (
     <span className="font-weight-bold">
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet3.boldtext'])}
+      {intl.formatMessage(genericMessages['upsell.fullAccessBullet.fullAccess'])}
     </span>
   );
-  const nonProfitMission = (
+  const mission = (
     <span className="font-weight-bold">
-      {intl.formatMessage(messages['learn.lockPaywall.list.bullet4.boldtext'])}
+      {intl.formatMessage(genericMessages['upsell.supportMissionBullet.mission'])}
     </span>
   );
 
@@ -111,36 +113,31 @@ function LockPaywall({
               <ul className="fa-ul ml-4 pl-2">
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletOne"
-                    defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
-                    values={{ verifiedCertLink }}
-                    className="bullet-text"
-                  />
+                  {intl.formatMessage(
+                    genericMessages['upsell.verifiedCertMessageBullet'],
+                    { verifiedCert },
+                  )}
                 </li>
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletTwo"
-                    defaultMessage="Unlock access to all course activities, including {gradedAssignments}"
-                    values={{ gradedAssignments }}
-                  />
+                  {intl.formatMessage(
+                    genericMessages['upsell.unlockGradedBullet'],
+                    { gradedAssignments },
+                  )}
                 </li>
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletThree"
-                    defaultMessage="{fullAccess} to course content and materials, even after the course ends"
-                    values={{ fullAccess }}
-                  />
+                  {intl.formatMessage(
+                    genericMessages['upsell.fullAccessBullet'],
+                    { fullAccess },
+                  )}
                 </li>
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  <FormattedMessage
-                    id="gatedContent.paragraph.bulletFour"
-                    defaultMessage="Support our {nonProfitMission} at edX"
-                    values={{ nonProfitMission }}
-                  />
+                  {intl.formatMessage(
+                    genericMessages['upsell.supportMissionBullet'],
+                    { mission },
+                  )}
                 </li>
               </ul>
             </div>

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -3,13 +3,11 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
-import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Alert } from '@edx/paragon';
 import { Locked } from '@edx/paragon/icons';
 import messages from './messages';
-import genericMessages from '../../../../generic/messages';
 import certificateLocked from '../../../../generic/assets/edX_locked_certificate.png';
 import { useModel } from '../../../../generic/model-store';
 import useWindowSize, { responsiveBreakpoints } from '../../../../generic/tabs/useWindowSize';
@@ -58,29 +56,29 @@ function LockPaywall({
     });
   };
 
-  const verifiedCert = (
+  const verifiedCertLink = (
     <Alert.Link
-      href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}
+      href="https://www.edx.org/verified-certificate"
       target="_blank"
       rel="noopener noreferrer"
     >
-      {intl.formatMessage(genericMessages['upsell.verifiedCertMessageBullet.verifiedCert'])}
+      {intl.formatMessage(messages['learn.lockPaywall.list.bullet1.linktext'])}
     </Alert.Link>
   );
 
   const gradedAssignments = (
     <span className="font-weight-bold">
-      {intl.formatMessage(genericMessages['upsell.unlockGradedBullet.gradedAssignments'])}
+      {intl.formatMessage(messages['learn.lockPaywall.list.bullet2.boldtext'])}
     </span>
   );
   const fullAccess = (
     <span className="font-weight-bold">
-      {intl.formatMessage(genericMessages['upsell.fullAccessBullet.fullAccess'])}
+      {intl.formatMessage(messages['learn.lockPaywall.list.bullet3.boldtext'])}
     </span>
   );
-  const mission = (
+  const nonProfitMission = (
     <span className="font-weight-bold">
-      {intl.formatMessage(genericMessages['upsell.supportMissionBullet.mission'])}
+      {intl.formatMessage(messages['learn.lockPaywall.list.bullet4.boldtext'])}
     </span>
   );
 
@@ -113,31 +111,36 @@ function LockPaywall({
               <ul className="fa-ul ml-4 pl-2">
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  {intl.formatMessage(
-                    genericMessages['upsell.verifiedCertMessageBullet'],
-                    { verifiedCert },
-                  )}
+                  <FormattedMessage
+                    id="gatedContent.paragraph.bulletOne"
+                    defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
+                    values={{ verifiedCertLink }}
+                    className="bullet-text"
+                  />
                 </li>
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  {intl.formatMessage(
-                    genericMessages['upsell.unlockGradedBullet'],
-                    { gradedAssignments },
-                  )}
+                  <FormattedMessage
+                    id="gatedContent.paragraph.bulletTwo"
+                    defaultMessage="Unlock access to all course activities, including {gradedAssignments}"
+                    values={{ gradedAssignments }}
+                  />
                 </li>
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  {intl.formatMessage(
-                    genericMessages['upsell.fullAccessBullet'],
-                    { fullAccess },
-                  )}
+                  <FormattedMessage
+                    id="gatedContent.paragraph.bulletThree"
+                    defaultMessage="{fullAccess} to course content and materials, even after the course ends"
+                    values={{ fullAccess }}
+                  />
                 </li>
                 <li>
                   <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
-                  {intl.formatMessage(
-                    genericMessages['upsell.supportMissionBullet'],
-                    { mission },
-                  )}
+                  <FormattedMessage
+                    id="gatedContent.paragraph.bulletFour"
+                    defaultMessage="Support our {nonProfitMission} at edX"
+                    values={{ nonProfitMission }}
+                  />
                 </li>
               </ul>
             </div>

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
@@ -6,13 +6,8 @@
     color: $primary-700;
 }
 
-.fa-li {
-    left: -31px;
-    padding-right: 22px;
-}
-
-    @media only screen and (min-width: 992px) and (max-width: 1100px) {
-        .list-div {
-            width: 62%;
+@media only screen and (min-width: 992px) and (max-width: 1100px) {
+    .list-div {
+        width: 62%;
     }
 }

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
@@ -7,9 +7,8 @@
 }
 
 .fa-li {
-    left: -31px !important;
+    left: -31px;
     padding-right: 22px;
-    top: 0;
 }
 
     @media only screen and (min-width: 992px) and (max-width: 1100px) {

--- a/src/courseware/course/sequence/lock-paywall/messages.js
+++ b/src/courseware/course/sequence/lock-paywall/messages.js
@@ -21,6 +21,26 @@ const messages = defineMessages({
     defaultMessage: 'When you upgrade, you:',
     description: 'Text displayed to introduce the list of benefits from upgrading.',
   },
+  'learn.lockPaywall.list.bullet1.linktext': {
+    id: 'learn.lockPaywall.list.bullet1.linktext',
+    defaultMessage: 'verified certificate',
+    description: 'Link text for verified certificate info page.',
+  },
+  'learn.lockPaywall.list.bullet2.boldtext': {
+    id: 'learn.lockPaywall.list.bullet2.boldtext',
+    defaultMessage: 'graded assignments',
+    description: 'Bolded text for graded assignments.',
+  },
+  'learn.lockPaywall.list.bullet3.boldtext': {
+    id: 'learn.lockPaywall.list.bullet3.boldtext',
+    defaultMessage: 'Full access',
+    description: 'Bolded text for full access.',
+  },
+  'learn.lockPaywall.list.bullet4.boldtext': {
+    id: 'learn.lockPaywall.list.bullet4.boldtext',
+    defaultMessage: 'non-profit mission',
+    description: 'Bolded text to highlight our non-profit status.',
+  },
 });
 
 export default messages;

--- a/src/courseware/course/sequence/lock-paywall/messages.js
+++ b/src/courseware/course/sequence/lock-paywall/messages.js
@@ -21,26 +21,6 @@ const messages = defineMessages({
     defaultMessage: 'When you upgrade, you:',
     description: 'Text displayed to introduce the list of benefits from upgrading.',
   },
-  'learn.lockPaywall.list.bullet1.linktext': {
-    id: 'learn.lockPaywall.list.bullet1.linktext',
-    defaultMessage: 'verified certificate',
-    description: 'Link text for verified certificate info page.',
-  },
-  'learn.lockPaywall.list.bullet2.boldtext': {
-    id: 'learn.lockPaywall.list.bullet2.boldtext',
-    defaultMessage: 'graded assignments',
-    description: 'Bolded text for graded assignments.',
-  },
-  'learn.lockPaywall.list.bullet3.boldtext': {
-    id: 'learn.lockPaywall.list.bullet3.boldtext',
-    defaultMessage: 'Full access',
-    description: 'Bolded text for full access.',
-  },
-  'learn.lockPaywall.list.bullet4.boldtext': {
-    id: 'learn.lockPaywall.list.bullet4.boldtext',
-    defaultMessage: 'non-profit mission',
-    description: 'Bolded text to highlight our non-profit status.',
-  },
 });
 
 export default messages;

--- a/src/generic/messages.js
+++ b/src/generic/messages.js
@@ -26,6 +26,46 @@ const messages = defineMessages({
     defaultMessage: 'Sign in',
     description: 'Text in a button, prompting the user to log in.',
   },
+  'upsell.fullAccessBullet': {
+    id: 'learning.generic.upsell.fullAccessBullet',
+    defaultMessage: '{fullAccess} to course content and materials, even after the course ends',
+    description: 'Bullet showcasing upgrade lifts access durations.',
+  },
+  'upsell.fullAccessBullet.fullAccess': {
+    id: 'learning.generic.upsell.fullAccessBullet.fullAccess',
+    defaultMessage: 'Full access',
+    description: 'Bolded phrase "full access".',
+  },
+  'upsell.supportMissionBullet': {
+    id: 'learning.generic.upsell.supportMissionBullet',
+    defaultMessage: 'Support our {mission} at edX',
+    description: 'Bullet encouraging user to support edX.',
+  },
+  'upsell.supportMissionBullet.mission': {
+    id: 'learning.generic.upsell.supportMissionBullet.mission',
+    defaultMessage: 'mission',
+    description: 'Bolded word "mission".',
+  },
+  'upsell.unlockGradedBullet': {
+    id: 'learning.generic.upsell.unlockGradedBullet',
+    defaultMessage: 'Unlock your access to all course activities, including {gradedAssignments}',
+    description: 'Bullet showcasing benefit of additional course material.',
+  },
+  'upsell.unlockGradedBullet.gradedAssignments': {
+    id: 'learning.generic.upsell.unlockGradedBullet.gradedAssignments',
+    defaultMessage: 'graded assignments',
+    description: 'Bolded name of unlocked feature with upgrade.',
+  },
+  'upsell.verifiedCertMessageBullet': {
+    id: 'learning.generic.upsell.verifiedCertMessageBullet',
+    defaultMessage: 'Earn a {verifiedCert} of completion to showcase on your resumé',
+    description: 'Bullet showcasing benefit of earned credential.',
+  },
+  'upsell.verifiedCertMessageBullet.verifiedCert': {
+    id: 'learning.generic.upsell.verifiedCertMessageBullet.verifiedCert',
+    defaultMessage: 'verified certificate',
+    description: 'Bolded name of credential the learner receieves.',
+  },
 });
 
 export default messages;

--- a/src/generic/messages.js
+++ b/src/generic/messages.js
@@ -26,46 +26,6 @@ const messages = defineMessages({
     defaultMessage: 'Sign in',
     description: 'Text in a button, prompting the user to log in.',
   },
-  'upsell.fullAccessBullet': {
-    id: 'learning.generic.upsell.fullAccessBullet',
-    defaultMessage: '{fullAccess} to course content and materials, even after the course ends',
-    description: 'Bullet showcasing upgrade lifts access durations.',
-  },
-  'upsell.fullAccessBullet.fullAccess': {
-    id: 'learning.generic.upsell.fullAccessBullet.fullAccess',
-    defaultMessage: 'Full access',
-    description: 'Bolded phrase "full access".',
-  },
-  'upsell.supportMissionBullet': {
-    id: 'learning.generic.upsell.supportMissionBullet',
-    defaultMessage: 'Support our {mission} at edX',
-    description: 'Bullet encouraging user to support edX.',
-  },
-  'upsell.supportMissionBullet.mission': {
-    id: 'learning.generic.upsell.supportMissionBullet.mission',
-    defaultMessage: 'mission',
-    description: 'Bolded word "mission".',
-  },
-  'upsell.unlockGradedBullet': {
-    id: 'learning.generic.upsell.unlockGradedBullet',
-    defaultMessage: 'Unlock your access to all course activities, including {gradedAssignments}',
-    description: 'Bullet showcasing benefit of additional course material.',
-  },
-  'upsell.unlockGradedBullet.gradedAssignments': {
-    id: 'learning.generic.upsell.unlockGradedBullet.gradedAssignments',
-    defaultMessage: 'graded assignments',
-    description: 'Bolded name of unlocked feature with upgrade.',
-  },
-  'upsell.verifiedCertMessageBullet': {
-    id: 'learning.generic.upsell.verifiedCertMessageBullet',
-    defaultMessage: 'Earn a {verifiedCert} of completion to showcase on your resumé',
-    description: 'Bullet showcasing benefit of earned credential.',
-  },
-  'upsell.verifiedCertMessageBullet.verifiedCert': {
-    id: 'learning.generic.upsell.verifiedCertMessageBullet.verifiedCert',
-    defaultMessage: 'verified certificate',
-    description: 'Bolded name of credential the learner receieves.',
-  },
 });
 
 export default messages;

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -3,84 +3,76 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
 import { sendTrackEvent, sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
-import { FormattedDate, FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
+import {
+  FormattedDate, FormattedMessage, injectIntl, intlShape,
+} from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 import { setLocalStorage } from '../../data/localStorage';
-
+import genericMessages from '../messages';
 import { UpgradeButton } from '../upgrade-button';
 
-function UpsellNoFBECardContent() {
-  const verifiedCertLink = (
+function IntlUpsellNoFBECardContent({ intl }) {
+  const verifiedCert = (
     <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.verifiedCertLink"
-        defaultMessage="verified certificate"
-      />
+      {intl.formatMessage(genericMessages['upsell.verifiedCertMessageBullet.verifiedCert'])}
     </a>
+  );
+
+  const mission = (
+    <span className="font-weight-bold">
+      {intl.formatMessage(genericMessages['upsell.supportMissionBullet.mission'])}
+    </span>
   );
 
   return (
     <ul className="fa-ul upgrade-notification-ul pt-0">
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.verifiedCertMessage"
-          defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
-          values={{ verifiedCertLink }}
-        />
+        {intl.formatMessage(
+          genericMessages['upsell.verifiedCertMessageBullet'],
+          { verifiedCert },
+        )}
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.noFBE.nonProfitMission"
-          defaultMessage="Support our {nonProfitMission} at edX"
-          values={{
-            nonProfitMission: (
-              <span className="font-weight-bold">non-profit mission</span>
-            ),
-          }}
-        />
+        {intl.formatMessage(
+          genericMessages['upsell.supportMissionBullet'],
+          { mission },
+        )}
       </li>
     </ul>
   );
 }
 
-function UpsellFBEFarAwayCardContent() {
-  const verifiedCertLink = (
+IntlUpsellNoFBECardContent.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+const UpsellNoFBECardContent = injectIntl(IntlUpsellNoFBECardContent);
+
+function IntlUpsellFBEFarAwayCardContent({ intl }) {
+  const verifiedCert = (
     <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.verifiedCertLink"
-        defaultMessage="verified certificate"
-      />
+      {intl.formatMessage(genericMessages['upsell.verifiedCertMessageBullet.verifiedCert'])}
     </a>
   );
 
   const gradedAssignments = (
     <span className="font-weight-bold">
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.gradedAssignments"
-        defaultMessage="graded assignments"
-      />
+      {intl.formatMessage(genericMessages['upsell.unlockGradedBullet.gradedAssignments'])}
     </span>
   );
 
   const fullAccess = (
     <span className="font-weight-bold">
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.verifiedCertLink.fullAccess"
-        defaultMessage="Full access"
-      />
+      {intl.formatMessage(genericMessages['upsell.fullAccessBullet.fullAccess'])}
     </span>
   );
 
-  const nonProfitMission = (
+  const mission = (
     <span className="font-weight-bold">
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.FBE.nonProfitMission"
-        defaultMessage="non-profit mission"
-      />
+      {intl.formatMessage(genericMessages['upsell.supportMissionBullet.mission'])}
     </span>
   );
 
@@ -88,39 +80,41 @@ function UpsellFBEFarAwayCardContent() {
     <ul className="fa-ul upgrade-notification-ul">
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.verifiedCertMessage"
-          defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
-          values={{ verifiedCertLink }}
-        />
+        {intl.formatMessage(
+          genericMessages['upsell.verifiedCertMessageBullet'],
+          { verifiedCert },
+        )}
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.unlockGraded"
-          defaultMessage="Unlock your access to all course activities, including {gradedAssignments}"
-          values={{ gradedAssignments }}
-        />
+        {intl.formatMessage(
+          genericMessages['upsell.unlockGradedBullet'],
+          { gradedAssignments },
+        )}
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.fullAccess"
-          defaultMessage="{fullAccess} to course content and materials, even after the course ends"
-          values={{ fullAccess }}
-        />
+        {intl.formatMessage(
+          genericMessages['upsell.fullAccessBullet'],
+          { fullAccess },
+        )}
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.nonProfitMission"
-          defaultMessage="Support our {nonProfitMission} at edX"
-          values={{ nonProfitMission }}
-        />
+        {intl.formatMessage(
+          genericMessages['upsell.supportMissionBullet'],
+          { mission },
+        )}
       </li>
     </ul>
   );
 }
+
+IntlUpsellFBEFarAwayCardContent.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+const UpsellFBEFarAwayCardContent = injectIntl(IntlUpsellFBEFarAwayCardContent);
 
 function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) {
   const includingAnyProgress = (

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -1,123 +1,33 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
 import { sendTrackEvent, sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { FormattedDate, FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
-import { getConfig } from '@edx/frontend-platform';
 import { setLocalStorage } from '../../data/localStorage';
-
 import { UpgradeButton } from '../upgrade-button';
+import {
+  VerifiedCertBullet,
+  UnlockGradedBullet,
+  FullAccessBullet,
+  SupportMissionBullet,
+} from '../upsell-bullets/UpsellBullets';
 
 function UpsellNoFBECardContent() {
-  const verifiedCertLink = (
-    <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.verifiedCertLink"
-        defaultMessage="verified certificate"
-      />
-    </a>
-  );
-
   return (
     <ul className="fa-ul upgrade-notification-ul pt-0">
-      <li>
-        <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.verifiedCertMessage"
-          defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
-          values={{ verifiedCertLink }}
-        />
-      </li>
-      <li>
-        <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.noFBE.nonProfitMission"
-          defaultMessage="Support our {nonProfitMission} at edX"
-          values={{
-            nonProfitMission: (
-              <span className="font-weight-bold">non-profit mission</span>
-            ),
-          }}
-        />
-      </li>
+      <VerifiedCertBullet />
+      <SupportMissionBullet />
     </ul>
   );
 }
 
 function UpsellFBEFarAwayCardContent() {
-  const verifiedCertLink = (
-    <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.verifiedCertLink"
-        defaultMessage="verified certificate"
-      />
-    </a>
-  );
-
-  const gradedAssignments = (
-    <span className="font-weight-bold">
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.gradedAssignments"
-        defaultMessage="graded assignments"
-      />
-    </span>
-  );
-
-  const fullAccess = (
-    <span className="font-weight-bold">
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.verifiedCertLink.fullAccess"
-        defaultMessage="Full access"
-      />
-    </span>
-  );
-
-  const nonProfitMission = (
-    <span className="font-weight-bold">
-      <FormattedMessage
-        id="learning.generic.upgradeNotification.FBE.nonProfitMission"
-        defaultMessage="non-profit mission"
-      />
-    </span>
-  );
-
   return (
     <ul className="fa-ul upgrade-notification-ul">
-      <li>
-        <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.verifiedCertMessage"
-          defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
-          values={{ verifiedCertLink }}
-        />
-      </li>
-      <li>
-        <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.unlockGraded"
-          defaultMessage="Unlock your access to all course activities, including {gradedAssignments}"
-          values={{ gradedAssignments }}
-        />
-      </li>
-      <li>
-        <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.fullAccess"
-          defaultMessage="{fullAccess} to course content and materials, even after the course ends"
-          values={{ fullAccess }}
-        />
-      </li>
-      <li>
-        <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        <FormattedMessage
-          id="learning.generic.upgradeNotification.nonProfitMission"
-          defaultMessage="Support our {nonProfitMission} at edX"
-          values={{ nonProfitMission }}
-        />
-      </li>
+      <VerifiedCertBullet />
+      <UnlockGradedBullet />
+      <FullAccessBullet />
+      <SupportMissionBullet />
     </ul>
   );
 }

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -3,76 +3,84 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import { sendTrackEvent, sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
-import {
-  FormattedDate, FormattedMessage, injectIntl, intlShape,
-} from '@edx/frontend-platform/i18n';
+import { FormattedDate, FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
 import { getConfig } from '@edx/frontend-platform';
 import { setLocalStorage } from '../../data/localStorage';
-import genericMessages from '../messages';
+
 import { UpgradeButton } from '../upgrade-button';
 
-function IntlUpsellNoFBECardContent({ intl }) {
-  const verifiedCert = (
+function UpsellNoFBECardContent() {
+  const verifiedCertLink = (
     <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
-      {intl.formatMessage(genericMessages['upsell.verifiedCertMessageBullet.verifiedCert'])}
+      <FormattedMessage
+        id="learning.generic.upgradeNotification.verifiedCertLink"
+        defaultMessage="verified certificate"
+      />
     </a>
-  );
-
-  const mission = (
-    <span className="font-weight-bold">
-      {intl.formatMessage(genericMessages['upsell.supportMissionBullet.mission'])}
-    </span>
   );
 
   return (
     <ul className="fa-ul upgrade-notification-ul pt-0">
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        {intl.formatMessage(
-          genericMessages['upsell.verifiedCertMessageBullet'],
-          { verifiedCert },
-        )}
+        <FormattedMessage
+          id="learning.generic.upgradeNotification.verifiedCertMessage"
+          defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
+          values={{ verifiedCertLink }}
+        />
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        {intl.formatMessage(
-          genericMessages['upsell.supportMissionBullet'],
-          { mission },
-        )}
+        <FormattedMessage
+          id="learning.generic.upgradeNotification.noFBE.nonProfitMission"
+          defaultMessage="Support our {nonProfitMission} at edX"
+          values={{
+            nonProfitMission: (
+              <span className="font-weight-bold">non-profit mission</span>
+            ),
+          }}
+        />
       </li>
     </ul>
   );
 }
 
-IntlUpsellNoFBECardContent.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-const UpsellNoFBECardContent = injectIntl(IntlUpsellNoFBECardContent);
-
-function IntlUpsellFBEFarAwayCardContent({ intl }) {
-  const verifiedCert = (
+function UpsellFBEFarAwayCardContent() {
+  const verifiedCertLink = (
     <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
-      {intl.formatMessage(genericMessages['upsell.verifiedCertMessageBullet.verifiedCert'])}
+      <FormattedMessage
+        id="learning.generic.upgradeNotification.verifiedCertLink"
+        defaultMessage="verified certificate"
+      />
     </a>
   );
 
   const gradedAssignments = (
     <span className="font-weight-bold">
-      {intl.formatMessage(genericMessages['upsell.unlockGradedBullet.gradedAssignments'])}
+      <FormattedMessage
+        id="learning.generic.upgradeNotification.gradedAssignments"
+        defaultMessage="graded assignments"
+      />
     </span>
   );
 
   const fullAccess = (
     <span className="font-weight-bold">
-      {intl.formatMessage(genericMessages['upsell.fullAccessBullet.fullAccess'])}
+      <FormattedMessage
+        id="learning.generic.upgradeNotification.verifiedCertLink.fullAccess"
+        defaultMessage="Full access"
+      />
     </span>
   );
 
-  const mission = (
+  const nonProfitMission = (
     <span className="font-weight-bold">
-      {intl.formatMessage(genericMessages['upsell.supportMissionBullet.mission'])}
+      <FormattedMessage
+        id="learning.generic.upgradeNotification.FBE.nonProfitMission"
+        defaultMessage="non-profit mission"
+      />
     </span>
   );
 
@@ -80,41 +88,39 @@ function IntlUpsellFBEFarAwayCardContent({ intl }) {
     <ul className="fa-ul upgrade-notification-ul">
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        {intl.formatMessage(
-          genericMessages['upsell.verifiedCertMessageBullet'],
-          { verifiedCert },
-        )}
+        <FormattedMessage
+          id="learning.generic.upgradeNotification.verifiedCertMessage"
+          defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
+          values={{ verifiedCertLink }}
+        />
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        {intl.formatMessage(
-          genericMessages['upsell.unlockGradedBullet'],
-          { gradedAssignments },
-        )}
+        <FormattedMessage
+          id="learning.generic.upgradeNotification.unlockGraded"
+          defaultMessage="Unlock your access to all course activities, including {gradedAssignments}"
+          values={{ gradedAssignments }}
+        />
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        {intl.formatMessage(
-          genericMessages['upsell.fullAccessBullet'],
-          { fullAccess },
-        )}
+        <FormattedMessage
+          id="learning.generic.upgradeNotification.fullAccess"
+          defaultMessage="{fullAccess} to course content and materials, even after the course ends"
+          values={{ fullAccess }}
+        />
       </li>
       <li>
         <span className="fa-li upgrade-notification-li"><FontAwesomeIcon icon={faCheck} /></span>
-        {intl.formatMessage(
-          genericMessages['upsell.supportMissionBullet'],
-          { mission },
-        )}
+        <FormattedMessage
+          id="learning.generic.upgradeNotification.nonProfitMission"
+          defaultMessage="Support our {nonProfitMission} at edX"
+          values={{ nonProfitMission }}
+        />
       </li>
     </ul>
   );
 }
-
-IntlUpsellFBEFarAwayCardContent.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-const UpsellFBEFarAwayCardContent = injectIntl(IntlUpsellFBEFarAwayCardContent);
 
 function UpsellFBESoonCardContent({ accessExpirationDate, timezoneFormatArgs }) {
   const includingAnyProgress = (

--- a/src/generic/upgrade-notification/UpgradeNotification.scss
+++ b/src/generic/upgrade-notification/UpgradeNotification.scss
@@ -38,11 +38,3 @@
   padding-top: .75rem;
   padding-bottom: .75rem;
 }
-
-.inline-link-underline {
-  text-decoration: underline;
-}
-
-.upgrade-notification .upgrade-notification-message a {
-  color: $primary-500;
-}

--- a/src/generic/upgrade-notification/UpgradeNotification.scss
+++ b/src/generic/upgrade-notification/UpgradeNotification.scss
@@ -24,10 +24,6 @@
   padding-right: 1.25rem;
 }
 
-.upgrade-notification-li {
-  left: -2.125rem;
-}
-
 .upgrade-notification-text {
   padding: 0.875rem 1.25rem 0 1.25rem;
 }

--- a/src/generic/upgrade-notification/UpgradeNotification.scss
+++ b/src/generic/upgrade-notification/UpgradeNotification.scss
@@ -19,14 +19,13 @@
 }
 
 .upgrade-notification-ul {
-  padding-left: 1.25rem !important;
+  padding-left: 1.25rem;
   padding-top: 0.875rem;
   padding-right: 1.25rem;
 }
 
 .upgrade-notification-li {
   left: -2.125rem;
-  top: 0 !important;
 }
 
 .upgrade-notification-text {

--- a/src/generic/upgrade-notification/UpgradeNotification.test.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.test.jsx
@@ -51,7 +51,7 @@ describe('Upgrade Notification', () => {
     buildAndRender();
     expect(screen.getByRole('heading', { name: 'Pursue a verified certificate' })).toBeInTheDocument();
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByRole('link', { name: 'Upgrade for $149' })).toBeInTheDocument();
   });
 
@@ -65,7 +65,7 @@ describe('Upgrade Notification', () => {
     });
     expect(screen.getByRole('heading', { name: 'Pursue a verified certificate' })).toBeInTheDocument();
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByRole('link', { name: 'Upgrade for $149' })).toBeInTheDocument();
   });
 
@@ -75,7 +75,7 @@ describe('Upgrade Notification', () => {
     });
     expect(screen.getByRole('heading', { name: 'Pursue a verified certificate' })).toBeInTheDocument();
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByRole('link', { name: 'Upgrade for $149' })).toBeInTheDocument();
   });
 
@@ -94,7 +94,7 @@ describe('Upgrade Notification', () => {
     });
     expect(screen.getByRole('heading', { name: 'Pursue a verified certificate' })).toBeInTheDocument();
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByText(/Upgrade for/).textContent).toMatch('$126.65 ($149)');
     expect(screen.getByText(/Use code.*?at checkout/s).textContent).toMatch('Use code Welcome15 at checkout');
   });
@@ -161,7 +161,7 @@ describe('Upgrade Notification', () => {
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
     expect(screen.getByText(/Unlock your access/s).textContent).toMatch('Unlock your access to all course activities, including graded assignments');
     expect(screen.getByText(/to course content and materials/s).textContent).toMatch('Full access to course content and materials, even after the course ends');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByRole('link', { name: 'Upgrade for $149' })).toBeInTheDocument();
   });
 
@@ -189,7 +189,7 @@ describe('Upgrade Notification', () => {
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
     expect(screen.getByText(/Unlock your access/s).textContent).toMatch('Unlock your access to all course activities, including graded assignments');
     expect(screen.getByText(/to course content and materials/s).textContent).toMatch('Full access to course content and materials, even after the course ends');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByText(/Upgrade for/).textContent).toMatch('$126.65 ($149)');
     expect(screen.getByText(/Use code.*?at checkout/s).textContent).toMatch('Use code Welcome15 at checkout');
   });
@@ -218,7 +218,7 @@ describe('Upgrade Notification', () => {
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
     expect(screen.getByText(/Unlock your access/s).textContent).toMatch('Unlock your access to all course activities, including graded assignments');
     expect(screen.getByText(/to course content and materials/s).textContent).toMatch('Full access to course content and materials, even after the course ends');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByText(/Upgrade for/).textContent).toMatch('$126.65 ($149)');
     expect(screen.getByText(/Use code.*?at checkout/s).textContent).toMatch('Use code Welcome15 at checkout');
   });
@@ -247,7 +247,7 @@ describe('Upgrade Notification', () => {
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
     expect(screen.getByText(/Unlock your access/s).textContent).toMatch('Unlock your access to all course activities, including graded assignments');
     expect(screen.getByText(/to course content and materials/s).textContent).toMatch('Full access to course content and materials, even after the course ends');
-    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our non-profit mission at edX');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
     expect(screen.getByText(/Upgrade for/).textContent).toMatch('$126.65 ($149)');
     expect(screen.getByText(/Use code.*?at checkout/s).textContent).toMatch('Use code Welcome15 at checkout');
   });

--- a/src/generic/upsell-bullets/UpsellBullets.jsx
+++ b/src/generic/upsell-bullets/UpsellBullets.jsx
@@ -17,7 +17,7 @@ export function VerifiedCertBullet() {
       <FormattedMessage
         id="learning.generic.upsell.verifiedCertBullet.verifiedCert"
         defaultMessage="verified certificate"
-        description="Bolded name of credential the learner receives."
+        description="Bolded words 'verified certificate', which is the name of credential the learner receives."
       />
     </a>
   );
@@ -41,7 +41,7 @@ export function UnlockGradedBullet() {
       <FormattedMessage
         id="learning.generic.upsell.unlockGradedBullet.gradedAssignments"
         defaultMessage="graded assignments"
-        description="Bolded name of unlocked feature with upgrade."
+        description="Bolded words 'graded assignment', which is the name of unlocked feature with upgrade."
       />
     </span>
   );

--- a/src/generic/upsell-bullets/UpsellBullets.jsx
+++ b/src/generic/upsell-bullets/UpsellBullets.jsx
@@ -17,7 +17,7 @@ export function VerifiedCertBullet() {
       <FormattedMessage
         id="learning.generic.upsell.verifiedCertBullet.verifiedCert"
         defaultMessage="verified certificate"
-        description="Bolded name of credential the learner receieves."
+        description="Bolded name of credential the learner receives."
       />
     </a>
   );

--- a/src/generic/upsell-bullets/UpsellBullets.jsx
+++ b/src/generic/upsell-bullets/UpsellBullets.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { getConfig } from '@edx/frontend-platform';
+
+function CheckmarkBullet() {
+  return (
+    <span className="fa-li"><FontAwesomeIcon icon={faCheck} /></span>
+  );
+}
+
+// Must be child of a <ul className="fa-ul">
+export function VerifiedCertBullet() {
+  const verifiedCertLink = (
+    <a className="inline-link-underline font-weight-bold" rel="noopener noreferrer" target="_blank" href={`${getConfig().MARKETING_SITE_BASE_URL}/verified-certificate`}>
+      <FormattedMessage
+        id="learning.generic.upsell.verifiedCertBullet.verifiedCert"
+        defaultMessage="verified certificate"
+        description="Bolded name of credential the learner receieves."
+      />
+    </a>
+  );
+  return (
+    <li className="upsell-bullet">
+      <CheckmarkBullet />
+      <FormattedMessage
+        id="learning.generic.upsell.verifiedCertBullet"
+        defaultMessage="Earn a {verifiedCertLink} of completion to showcase on your resumé"
+        description="Bullet showcasing benefit of earned credential."
+        values={{ verifiedCertLink }}
+      />
+    </li>
+  );
+}
+
+// Must be child of a <ul className="fa-ul">
+export function UnlockGradedBullet() {
+  const gradedAssignmentsInBoldText = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="learning.generic.upsell.unlockGradedBullet.gradedAssignments"
+        defaultMessage="graded assignments"
+        description="Bolded name of unlocked feature with upgrade."
+      />
+    </span>
+  );
+  return (
+    <li className="upsell-bullet">
+      <CheckmarkBullet />
+      <FormattedMessage
+        id="learning.generic.upsell.unlockGradedBullet"
+        defaultMessage="Unlock your access to all course activities, including {gradedAssignmentsInBoldText}"
+        description="Bullet showcasing benefit of additional course material."
+        values={{ gradedAssignmentsInBoldText }}
+      />
+    </li>
+  );
+}
+
+// Must be child of a <ul className="fa-ul">
+export function FullAccessBullet() {
+  const fullAccessInBoldText = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="learning.generic.upsell.fullAccessBullet.fullAccess"
+        defaultMessage="Full access"
+        description="Bolded phrase 'Full access'."
+      />
+    </span>
+  );
+  return (
+    <li className="upsell-bullet">
+      <CheckmarkBullet />
+      <FormattedMessage
+        id="learning.generic.upsell.fullAccessBullet"
+        defaultMessage="{fullAccessInBoldText} to course content and materials, even after the course ends"
+        description="Bullet showcasing upgrade lifts access durations."
+        values={{ fullAccessInBoldText }}
+      />
+    </li>
+  );
+}
+
+// Must be child of a <ul className="fa-ul">
+export function SupportMissionBullet() {
+  const missionInBoldText = (
+    <span className="font-weight-bold">
+      <FormattedMessage
+        id="learning.generic.upsell.supportMissionBullet.mission"
+        defaultMessage="mission"
+        description="Bolded word 'mission'."
+      />
+    </span>
+  );
+  return (
+    <li className="upsell-bullet">
+      <CheckmarkBullet />
+      <FormattedMessage
+        id="learning.generic.upsell.supportMissionBullet"
+        defaultMessage="Support our {missionInBoldText} at edX"
+        description="Bullet encouraging user to support edX."
+        values={{ missionInBoldText }}
+      />
+    </li>
+  );
+}

--- a/src/generic/upsell-bullets/UpsellBullets.scss
+++ b/src/generic/upsell-bullets/UpsellBullets.scss
@@ -3,3 +3,11 @@
     padding-right: 22px;
 }
 
+.inline-link-underline {
+  text-decoration: underline;
+}
+
+.upsell-bullet a {
+  color: $primary-500;
+}
+

--- a/src/generic/upsell-bullets/UpsellBullets.scss
+++ b/src/generic/upsell-bullets/UpsellBullets.scss
@@ -1,0 +1,5 @@
+.upsell-bullet > .fa-li {
+    left: -31px;
+    padding-right: 22px;
+}
+

--- a/src/generic/upsell-bullets/UpsellBullets.test.jsx
+++ b/src/generic/upsell-bullets/UpsellBullets.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import {
+  initializeMockApp,
+  render,
+  screen,
+} from '../../setupTest';
+
+import {
+  VerifiedCertBullet,
+  UnlockGradedBullet,
+  FullAccessBullet,
+  SupportMissionBullet,
+} from './UpsellBullets';
+
+initializeMockApp();
+
+describe('UpsellBullets', () => {
+  const bullets = (
+    <>
+      <VerifiedCertBullet />
+      <UnlockGradedBullet />
+      <FullAccessBullet />
+      <SupportMissionBullet />
+    </>
+  );
+
+  it('properly expands translations strings in English', async () => {
+    render(bullets);
+    expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
+    expect(screen.getByText(/Unlock your access/s).textContent).toMatch('Unlock your access to all course activities, including graded assignments');
+    expect(screen.getByText(/to course content and materials/s).textContent).toMatch('Full access to course content and materials, even after the course ends');
+    expect(screen.getByText(/Support our.*?at edX/s).textContent).toMatch('Support our mission at edX');
+  });
+});

--- a/src/generic/upsell-bullets/UpsellBullets.test.jsx
+++ b/src/generic/upsell-bullets/UpsellBullets.test.jsx
@@ -25,7 +25,7 @@ describe('UpsellBullets', () => {
     </>
   );
 
-  it('properly expands translations strings in English', async () => {
+  it('upsell bullet text properly rendered', async () => {
     render(bullets);
     expect(screen.getByText(/Earn a.*?of completion to showcase on your resumé/s).textContent).toMatch('Earn a verified certificate of completion to showcase on your resumé');
     expect(screen.getByText(/Unlock your access/s).textContent).toMatch('Unlock your access to all course activities, including graded assignments');

--- a/src/index.scss
+++ b/src/index.scss
@@ -390,6 +390,7 @@
 @import "courseware/course/content-tools/contentTools.scss";
 @import "course-home/dates-tab/timeline/Day.scss";
 @import "generic/upgrade-notification/UpgradeNotification.scss";
+@import "generic/upsell-bullets/UpsellBullets.scss";
 @import "course-home/outline-tab/widgets/ProctoringInfoPanel.scss";
 @import "course-home/progress-tab/course-completion/CompletionDonutChart.scss";
 @import "course-home/progress-tab/grades/course-grade/GradeBar.scss";


### PR DESCRIPTION
# Description
This PR implements [REV-2262](https://openedx.atlassian.net/browse/REV-2262) to refactor text bullets in frontend-app-learning that are duplicated between components `<UpgradeNotification>` and `<GatedContent>` into new React components.

# Purpose
* Duplicated strings cause a headache for our translators, who have to translate the same string multiple times. 
* In preparation for possible future uses of these bullets elsewhere in our application.

# Implementation
This PR creates 4 new components called:

* `<VerifiedCertBullet>`
* `<UnlockGradedBullet>`
* `<FullAccessBullet>`
* `<SupportMissionBullet>`

taking code out of `<UpgradeNotification>` and `<GatedContent>` for the text bullets:

* "Earn a verified certificate of completion to showcase on your resumé"
* "Unlock your access to all course activities, including graded assignments"
* "Full access to course content and materials, even after the course ends"
* "Support our mission at edX"

# Testing
Since this is a refactor, the goal is not to significantly change the look and feel of anything. To prove this, this is a screenshot of after (in devstack, on top half of screenshot) and before (in production, on bottom half of screenshot):

For `<GatedContent>`:

<img width="640" alt="course-lock-paywall-comparison" src="https://user-images.githubusercontent.com/3790674/138015073-b342a0c3-e185-48fb-9462-f743ca5aff45.png">

For `<UpgradeNotification>`:

<img width="641" alt="upgrade-notification-comparison" src="https://user-images.githubusercontent.com/3790674/138015092-4f6aa126-a44b-4c65-9b6b-ab5f52b19818.png">

Also tested for non-FBE and in mobile. Screenshots available on request.

## Examples in Production
* FBE: https://learning.edx.org/course/course-v1:MichiganX+py4e101x+3T2020/home
* Non-FBE: https://learning.edx.org/course/course-v1:JaverianaX+TDPx+2T2021/home

# Notes

This PR modifies the names of many translation strings. While the overall number of translation strings has dropped from 17 to 8, the new strings do not use old names and will need to be re-translated. This was discussed and accepted as a consequence of this ticket.

This PR performs some work to remove language regarding edX being a non-profit in [REV-2388](https://openedx.atlassian.net/browse/REV-2388). Spreadsheet for REV-2388 updated.

# Attachments

* [Diff of translation strings](https://github.com/edx/frontend-app-learning/files/7368499/transifex_input.json.diff.txt)
* [Implementation notes](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3186098448/REV-2262)
