### PR TITLE
fix: disable the call to ecommerce for now

### DIFF
--- a/src/shared/streak-celebration/StreakCelebrationModal.jsx
+++ b/src/shared/streak-celebration/StreakCelebrationModal.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+// import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+// import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import {
   FormattedMessage, injectIntl, intlShape,
 } from '@edx/frontend-platform/i18n';
@@ -44,12 +44,14 @@ function getRandomFactoid(intl, streakLength) {
   return factoids[Math.floor(Math.random() * (factoids.length))];
 }
 
+/*
 async function calculateVoucherDiscount(voucher, sku, username) {
   const urlBase = `${getConfig().ECOMMERCE_BASE_URL}/api/v2/baskets/calculate`;
   const url = `${urlBase}/?code=${voucher}&sku=${sku}&username=${username}`;
   return getAuthenticatedHttpClient().get(url)
     .then(res => camelCaseObject(res));
 }
+*/
 
 function StreakModal({
   courseId, metadataModel, streakLengthToCelebrate, intl, isStreakCelebrationOpen,
@@ -86,6 +88,7 @@ function StreakModal({
 
   // Ask ecommerce to calculate discount savings
   useEffect(() => {
+    /*
     if (streakDiscountCouponEnabled && verifiedMode && getConfig().ECOMMERCE_BASE_URL) {
       calculateVoucherDiscount(discountCode, verifiedMode.sku, username)
         .then(
@@ -110,6 +113,14 @@ function StreakModal({
             setDiscountPercent(0);
           },
         );
+   */
+    // TEMPORARY code to bypass the above call-to-ecom feature since it didn't work as expected in prod
+    if (streakDiscountCouponEnabled && verifiedMode) {
+      setDiscountPercent(0.15);
+      sendTrackEvent('edx.bi.course.streak_discount_enabled', {
+        course_id: courseId,
+        sku: verifiedMode.sku,
+      });
     } else {
       setDiscountPercent(0);
     }

--- a/src/shared/streak-celebration/StreakCelebrationModal.test.jsx
+++ b/src/shared/streak-celebration/StreakCelebrationModal.test.jsx
@@ -32,10 +32,12 @@ describe('Loaded Tab Page', () => {
     });
   }
 
+  /*
   function setDiscountError() {
     mockData.streakDiscountCouponEnabled = true;
     axiosMock.onGet(calculateUrl).reply(500);
   }
+  */
 
   async function renderModal() {
     await act(async () => render(<StreakModal {...mockData} />, { store: testStore }));
@@ -68,6 +70,8 @@ describe('Loaded Tab Page', () => {
     });
   });
 
+  // TEMPORARY disable these tests until we can debug why this feature doesn't work
+  /*
   it('shows normal streak celebration modal when discount call fails', async () => {
     setDiscountError();
     await renderModal();
@@ -83,6 +87,7 @@ describe('Loaded Tab Page', () => {
     // This text is only for the non-discount case
     expect(screen.getByText('Keep it up')).toBeInTheDocument();
   });
+  */
 
   it('shows discount version of streak celebration modal when available', async () => {
     Object.defineProperty(window, 'matchMedia', {
@@ -105,7 +110,8 @@ describe('Loaded Tab Page', () => {
     await renderModal();
 
     const endDateText = `Ends ${new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toLocaleDateString({ timeZone: 'UTC' })}.`;
-    expect(screen.getByText('You’ve unlocked a 14% off discount when you upgrade this course for a limited time only.')).toBeInTheDocument();
+    // TEMPORARY set this discount back to 14 once we fix this feature
+    expect(screen.getByText('You’ve unlocked a 15% off discount when you upgrade this course for a limited time only.')).toBeInTheDocument();
     expect(screen.getByText(endDateText)).toBeInTheDocument();
     expect(screen.getByText('Continue with course')).toBeInTheDocument();
     expect(screen.queryByText('Keep it up')).not.toBeInTheDocument();


### PR DESCRIPTION
It doesn't seem to be working - instead never calling ecommerce and
always showing the normal non-discount version of the streak modal.

Going to investigate later, but this is just a quick shutoff for
now.