### PR TITLE
fix: skip inaccessible learning sequence data

### DIFF
--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -98,12 +98,40 @@ export function normalizeLearningSequencesData(learningSequencesData) {
     sequences: {},
   };
 
+  // Sequences
+  Object.entries(learningSequencesData.outline.sequences).forEach(([seqId, sequence]) => {
+    if (!sequence.accessible) {
+      // Skipping inaccessible sequences replicates the behavior of the legacy course blocks API
+      return;
+    }
+
+    models.sequences[seqId] = {
+      id: seqId,
+      title: sequence.title,
+    };
+  });
+
+  // Sections
+  learningSequencesData.outline.sections.forEach(section => {
+    // Skipping sections with only inaccessible sequences replicates the behavior of the legacy course blocks API
+    const accessibleSequenceIds = section.sequence_ids.filter(seqId => seqId in models.sequences);
+    if (accessibleSequenceIds.length === 0) {
+      return;
+    }
+
+    models.sections[section.id] = {
+      id: section.id,
+      title: section.title,
+      sequenceIds: accessibleSequenceIds,
+    };
+  });
+
   // Course
   const now = new Date();
   models.courses[learningSequencesData.course_key] = {
     id: learningSequencesData.course_key,
     title: learningSequencesData.title,
-    sectionIds: learningSequencesData.outline.sections.map(section => section.id),
+    sectionIds: Object.entries(models.sections).map(([sectionId]) => sectionId),
 
     // Scan through all the sequences and look for ones that aren't accessible
     // to us yet because the start date has not yet passed. (Some may be
@@ -112,23 +140,6 @@ export function normalizeLearningSequencesData(learningSequencesData) {
       seq => !seq.accessible && now < Date.parse(seq.effective_start),
     ),
   };
-
-  // Sections
-  learningSequencesData.outline.sections.forEach(section => {
-    models.sections[section.id] = {
-      id: section.id,
-      title: section.title,
-      sequenceIds: section.sequence_ids,
-    };
-  });
-
-  // Sequences
-  Object.entries(learningSequencesData.outline.sequences).forEach(([seqId, sequence]) => {
-    models.sequences[seqId] = {
-      id: seqId,
-      title: sequence.title,
-    };
-  });
 
   return models;
 }

--- a/src/pacts/frontend-app-learning-lms.json
+++ b/src/pacts/frontend-app-learning-lms.json
@@ -623,6 +623,135 @@
         "headers": {
         }
       }
+    },
+    {
+      "description": "a request to get a learning sequence outline",
+      "providerState": "Learning sequence outline exists for course_id course-v1:edX+DemoX+Demo_Course",
+      "request": {
+        "method": "GET",
+        "path": "/api/learning_sequences/v1/course_outline/course-v1:edX+DemoX+Demo_Course"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "course_key": "block-v1:edX+DemoX+Demo_Course",
+          "title": "Demo Course",
+          "outline": {
+            "sections": [
+
+            ],
+            "sequences": [
+
+            ]
+          }
+        },
+        "matchingRules": {
+          "$.body.course_key": {
+            "match": "type"
+          },
+          "$.body.title": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "a request to get an outline",
+      "providerState": "Outline exists for course_id course-v1:edX+DemoX+Demo_Course",
+      "request": {
+        "method": "GET",
+        "path": "/api/learning_sequences/v1/course_outline/course-v1:edX+DemoX+Demo_Course"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "course_key": "block-v1:edX+DemoX+Demo_Course",
+          "title": "Demo Course",
+          "outline": {
+            "sections": [
+
+            ],
+            "sequences": {
+            }
+          }
+        },
+        "matchingRules": {
+          "$.body.course_key": {
+            "match": "type"
+          },
+          "$.body.title": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "a request to get an outline",
+      "providerState": "Outline exists with inaccessible sequences for course_id course-v1:edX+DemoX+Demo_Course",
+      "request": {
+        "method": "GET",
+        "path": "/api/learning_sequences/v1/course_outline/course-v1:edX+DemoX+Demo_Course"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+        },
+        "body": {
+          "course_key": "block-v1:edX+DemoX+Demo_Course",
+          "title": "Demo Course",
+          "outline": {
+            "sections": [
+              {
+                "id": "block-v1:edX+DemoX+Demo_Course+type@chapter+block@partial",
+                "title": "Partially accessible",
+                "sequence_ids": [
+                  "block-v1:edX+DemoX+Demo_Course+type@sequential+block@accessible",
+                  "block-v1:edX+DemoX+Demo_Course+type@sequential+block@nope1"
+                ]
+              },
+              {
+                "id": "block-v1:edX+DemoX+Demo_Course+type@chapter+block@nope",
+                "title": "Wholly inaccessible",
+                "sequence_ids": [
+                  "block-v1:edX+DemoX+Demo_Course+type@sequential+block@nope2"
+                ]
+              }
+            ],
+            "sequences": {
+              "block-v1:edX+DemoX+Demo_Course+type@sequential+block@accessible": {
+                "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@accessible",
+                "title": "Can access",
+                "accessible": true
+              },
+              "block-v1:edX+DemoX+Demo_Course+type@sequential+block@nope1": {
+                "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@nope1",
+                "title": "Cannot access",
+                "accessible": false
+              },
+              "block-v1:edX+DemoX+Demo_Course+type@sequential+block@nope2": {
+                "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@nope2",
+                "title": "Still cannot access",
+                "accessible": false
+              }
+            }
+          }
+        },
+        "matchingRules": {
+          "$.body.course_key": {
+            "match": "type"
+          },
+          "$.body.title": {
+            "match": "type"
+          },
+          "$.body.outline": {
+            "match": "type"
+          }
+        }
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
When normalizing learning sequences, skip inaccessible sequences
and also skip sections with only inaccessible sequences.

This both imitates the legacy course block behavior and also
avoids a failure when merging course block data with LS data
when they disagree about which sequences exist.