### PR TITLE
chore: update special exams lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3673,9 +3673,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.13.3.tgz",
-      "integrity": "sha512-WTjOPh/Rr6wAKImRdmJaO4g2u+Q0pxw/FLzS7PJ0cE63hoMM8VsVL6diS1Alg01mG5DYXuiX8QyHb9lk0pJzdw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.13.4.tgz",
+      "integrity": "sha512-yAN2gRF7F1gaP6ZYRx6VvvnGuhBYsp1r7g6MyoT1giQoaUqitl3t0UnpKyBvPyUFTQnyouDnOksvHtUVu6AhrQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-enterprise-utils": "1.1.0",
-    "@edx/frontend-lib-special-exams": "1.13.3",
+    "@edx/frontend-lib-special-exams": "1.13.4",
     "@edx/frontend-platform": "1.12.7",
     "@edx/paragon": "16.14.9",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
Update frontend-special-exams-lib to latest release version, which removes the use of the `ready_to_resume` status.