### PR TITLE
feat: Update notification feature to be course specific

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -74,7 +74,7 @@ function Course({
 
   const onNotificationSeen = () => {
     setNotificationStatus('inactive');
-    setLocalStorage('notificationStatus', 'inactive');
+    setLocalStorage(`notificationStatus.${courseId}`, 'inactive');
   };
 
   /** [MM-P2P] Experiment */

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -61,16 +61,16 @@ function Course({
     if (notificationTrayVisible) { setNotificationTray(false); } else { setNotificationTray(true); }
   };
 
-  if (!getLocalStorage('notificationStatus')) {
-    setLocalStorage('notificationStatus', 'active'); // Show red dot on notificationTrigger until seen
+  if (!getLocalStorage(`notificationStatus.${courseId}`)) {
+    setLocalStorage(`notificationStatus.${courseId}`, 'active'); // Show red dot on notificationTrigger until seen
   }
 
-  if (!getLocalStorage('upgradeNotificationCurrentState')) {
-    setLocalStorage('upgradeNotificationCurrentState', 'initialize');
+  if (!getLocalStorage(`upgradeNotificationCurrentState.${courseId}`)) {
+    setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'initialize');
   }
 
-  const [notificationStatus, setNotificationStatus] = useState(getLocalStorage('notificationStatus'));
-  const [upgradeNotificationCurrentState, setupgradeNotificationCurrentState] = useState(getLocalStorage('upgradeNotificationCurrentState'));
+  const [notificationStatus, setNotificationStatus] = useState(getLocalStorage(`notificationStatus.${courseId}`));
+  const [upgradeNotificationCurrentState, setupgradeNotificationCurrentState] = useState(getLocalStorage(`upgradeNotificationCurrentState.${courseId}`));
 
   const onNotificationSeen = () => {
     setNotificationStatus('inactive');
@@ -98,6 +98,7 @@ function Course({
 
         { shouldDisplayNotificationTrigger ? (
           <NotificationTrigger
+            courseId={courseId}
             toggleNotificationTray={toggleNotificationTray}
             isNotificationTrayVisible={isNotificationTrayVisible}
             notificationStatus={notificationStatus}

--- a/src/courseware/course/NotificationTrigger.jsx
+++ b/src/courseware/course/NotificationTrigger.jsx
@@ -8,7 +8,7 @@ import NotificationIcon from './NotificationIcon';
 import messages from './messages';
 
 function NotificationTrigger({
-  intl, toggleNotificationTray, isNotificationTrayVisible, notificationStatus, setNotificationStatus,
+  courseId, intl, toggleNotificationTray, isNotificationTrayVisible, notificationStatus, setNotificationStatus,
   upgradeNotificationCurrentState,
 }) {
   /* Re-show a red dot beside the notification trigger for each of the 7 UpgradeNotification stages
@@ -16,10 +16,10 @@ function NotificationTrigger({
   compare with the last state they've seen, and if it's different then set dot back to red */
   function UpdateUpgradeNotificationLastSeen() {
     if (upgradeNotificationCurrentState) {
-      if (getLocalStorage('upgradeNotificationLastSeen') !== upgradeNotificationCurrentState) {
+      if (getLocalStorage(`upgradeNotificationLastSeen.${courseId}`) !== upgradeNotificationCurrentState) {
         setNotificationStatus('active');
-        setLocalStorage('notificationStatus', 'active');
-        setLocalStorage('upgradeNotificationLastSeen', upgradeNotificationCurrentState);
+        setLocalStorage(`notificationStatus.${courseId}`, 'active');
+        setLocalStorage(`upgradeNotificationLastSeen.${courseId}`, upgradeNotificationCurrentState);
       }
     }
   }
@@ -39,6 +39,7 @@ function NotificationTrigger({
 }
 
 NotificationTrigger.propTypes = {
+  courseId: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
   toggleNotificationTray: PropTypes.func.isRequired,
   notificationStatus: PropTypes.string.isRequired,

--- a/src/courseware/course/NotificationTrigger.test.jsx
+++ b/src/courseware/course/NotificationTrigger.test.jsx
@@ -4,10 +4,11 @@ import {
   render, initializeTestStore, screen, fireEvent,
 } from '../../setupTest';
 import NotificationTrigger from './NotificationTrigger';
-import { getLocalStorage } from '../../data/localStorage';
 
 describe('Notification Trigger', () => {
   let mockData;
+  let getItemSpy;
+  let setItemSpy;
   // let mockDataSameState;
   // let mockDataDifferentState;
   const courseMetadata = Factory.build('courseMetadata');
@@ -15,40 +16,21 @@ describe('Notification Trigger', () => {
   beforeEach(async () => {
     await initializeTestStore({ courseMetadata, excludeFetchCourse: true, excludeFetchSequence: true });
     mockData = {
+      courseId: courseMetadata.id,
       toggleNotificationTray: () => {},
       isNotificationTrayVisible: () => {},
-      notificationStatus: 'active',
+      notificationStatus: 'inactive',
       setNotificationStatus: () => {},
       upgradeNotificationCurrentState: 'FPDdaysLeft',
     };
+    // Jest does not support calls to localStorage, spying on localStorage's prototype directly instead
+    getItemSpy = jest.spyOn(Object.getPrototypeOf(window.localStorage), 'getItem');
+    setItemSpy = jest.spyOn(Object.getPrototypeOf(window.localStorage), 'setItem');
   });
 
-  it('renders notification trigger icon with red dot when notificationStatus is active', async () => {
-    const { container } = render(<NotificationTrigger {...mockData} />);
-    expect(container).toBeInTheDocument();
-    const buttonIcon = container.querySelectorAll('svg');
-    expect(buttonIcon).toHaveLength(1);
-    expect(screen.getByTestId('notification-dot')).toBeInTheDocument();
-  });
-
-  it('renders notification trigger icon WITHOUT red dot 3 seconds later', async () => {
-    const { container } = render(<NotificationTrigger {...mockData} />);
-    expect(container).toBeInTheDocument();
-    jest.useFakeTimers();
-    setTimeout(() => {
-      expect(screen.queryByRole('notification-dot')).not.toBeInTheDocument();
-    }, 3000);
-    jest.runAllTimers();
-  });
-
-  it('renders notification trigger icon WITHOUT red dot within the same phase', async () => {
-    const { container } = render(
-      <NotificationTrigger {...mockData} upgradeNotificationCurrentState="sameState" upgradeNotificationLastSeen="sameState" />,
-    );
-    expect(container).toBeInTheDocument();
-    const buttonIcon = container.querySelectorAll('svg');
-    expect(buttonIcon).toHaveLength(1);
-    expect(screen.queryByRole('notification-dot')).not.toBeInTheDocument();
+  afterAll(() => {
+    getItemSpy.mockRestore();
+    setItemSpy.mockRestore();
   });
 
   it('handles onClick event toggling the notification tray', async () => {
@@ -65,15 +47,62 @@ describe('Notification Trigger', () => {
     expect(toggleNotificationTray).toHaveBeenCalledTimes(1);
   });
 
-  // rendering NotificationTrigger has the effect of calling UpdateUpgradeNotificationLastSeen()
-  // Verify that local storage was updated accordingly
-  it('we make the right updates when rendering a new phase (before -> after)', async () => {
+  it('renders notification trigger icon with red dot when notificationStatus is active', async () => {
+    const { container } = render(<NotificationTrigger {...mockData} notificationStatus="active" />);
+    expect(container).toBeInTheDocument();
+    const buttonIcon = container.querySelectorAll('svg');
+    expect(buttonIcon).toHaveLength(1);
+    expect(screen.getByTestId('notification-dot')).toBeInTheDocument();
+  });
+
+  it('renders notification trigger icon WITHOUT red dot 3 seconds later', async () => {
+    const { container } = render(<NotificationTrigger {...mockData} notificationStatus="active" />);
+    expect(container).toBeInTheDocument();
+    expect(screen.getByTestId('notification-dot')).toBeInTheDocument();
+    jest.useFakeTimers();
+    setTimeout(() => {
+      expect(localStorage.setItem).toHaveBeenCalledTimes(2);
+      expect(screen.queryByRole('notification-dot')).not.toBeInTheDocument();
+    }, 3000);
+    jest.runAllTimers();
+  });
+
+  it('renders notification trigger icon WITHOUT red dot within the same phase', async () => {
     const { container } = render(
-      <NotificationTrigger {...mockData} upgradeNotificationLastSeen="before" upgradeNotificationCurrentState="after" />,
+      <NotificationTrigger
+        {...mockData}
+        upgradeNotificationCurrentState="sameState"
+        upgradeNotificationLastSeen="sameState"
+      />,
+    );
+    expect(container).toBeInTheDocument();
+    expect(localStorage.getItem).toHaveBeenCalledWith(`upgradeNotificationLastSeen.${mockData.courseId}`);
+    expect(localStorage.getItem(`upgradeNotificationLastSeen.${mockData.courseId}`)).toBe('"sameState"');
+    const buttonIcon = container.querySelectorAll('svg');
+    expect(buttonIcon).toHaveLength(1);
+    expect(screen.queryByRole('notification-dot')).not.toBeInTheDocument();
+  });
+
+  // Rendering NotificationTrigger has the effect of calling UpdateUpgradeNotificationLastSeen(),
+  // if upgradeNotificationLastSeen is different than upgradeNotificationCurrentState
+  // it should update localStorage accordingly
+  it('makes the right updates when rendering a new phase from an UpgradeNotification change (before -> after)', async () => {
+    const { container } = render(
+      <NotificationTrigger
+        {...mockData}
+        upgradeNotificationLastSeen="before"
+        upgradeNotificationCurrentState="after"
+      />,
     );
     expect(container).toBeInTheDocument();
 
-    expect(getLocalStorage('notificationStatus')).toBe('active');
-    expect(getLocalStorage('upgradeNotificationLastSeen')).toBe('after');
+    // verify localStorage get/set are called with correct arguments
+    expect(localStorage.getItem).toHaveBeenCalledWith(`upgradeNotificationLastSeen.${mockData.courseId}`);
+    expect(localStorage.setItem).toHaveBeenCalledWith(`notificationStatus.${mockData.courseId}`, '"active"');
+    expect(localStorage.setItem).toHaveBeenCalledWith(`upgradeNotificationLastSeen.${mockData.courseId}`, '"after"');
+
+    // verify localStorage is updated accordingly
+    expect(localStorage.getItem(`upgradeNotificationLastSeen.${mockData.courseId}`)).toBe('"after"');
+    expect(localStorage.getItem(`notificationStatus.${mockData.courseId}`)).toBe('"active"');
   });
 });

--- a/src/courseware/course/NotificationTrigger.test.jsx
+++ b/src/courseware/course/NotificationTrigger.test.jsx
@@ -103,4 +103,27 @@ describe('Notification Trigger', () => {
     expect(localStorage.getItem(`upgradeNotificationLastSeen.${mockData.courseId}`)).toBe('"after"');
     expect(localStorage.getItem(`notificationStatus.${mockData.courseId}`)).toBe('"active"');
   });
+
+  it('handles localStorage from a different course', async () => {
+    const courseMetadataSecondCourse = Factory.build('courseMetadata');
+    // set localStorage for a different course before rendering NotificationTrigger
+    localStorage.setItem(`upgradeNotificationLastSeen.${courseMetadataSecondCourse.id}`, '"accessDateView"');
+    localStorage.setItem(`notificationStatus.${courseMetadataSecondCourse.id}`, '"inactive"');
+
+    const { container } = render(
+      <NotificationTrigger
+        {...mockData}
+        upgradeNotificationLastSeen="before"
+        upgradeNotificationCurrentState="after"
+      />,
+    );
+    expect(container).toBeInTheDocument();
+    // Verify localStorage was updated for the original course
+    expect(localStorage.getItem(`upgradeNotificationLastSeen.${mockData.courseId}`)).toBe('"after"');
+    expect(localStorage.getItem(`notificationStatus.${mockData.courseId}`)).toBe('"active"');
+
+    // Verify the second course localStorage was not changed
+    expect(localStorage.getItem(`upgradeNotificationLastSeen.${courseMetadataSecondCourse.id}`)).toBe('"accessDateView"');
+    expect(localStorage.getItem(`notificationStatus.${courseMetadataSecondCourse.id}`)).toBe('"inactive"');
+  });
 });

--- a/src/courseware/course/NotificationTrigger.test.jsx
+++ b/src/courseware/course/NotificationTrigger.test.jsx
@@ -9,8 +9,6 @@ describe('Notification Trigger', () => {
   let mockData;
   let getItemSpy;
   let setItemSpy;
-  // let mockDataSameState;
-  // let mockDataDifferentState;
   const courseMetadata = Factory.build('courseMetadata');
 
   beforeEach(async () => {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -182,6 +182,7 @@ function Sequence({
 
         {shouldDisplayNotificationTrigger ? (
           <NotificationTrigger
+            courseId={courseId}
             toggleNotificationTray={toggleNotificationTray}
             isNotificationTrayVisible={isNotificationTrayVisible}
             notificationStatus={notificationStatus}

--- a/src/generic/upgrade-notification/UpgradeNotification.jsx
+++ b/src/generic/upgrade-notification/UpgradeNotification.jsx
@@ -185,18 +185,20 @@ UpsellFBESoonCardContent.defaultProps = {
   timezoneFormatArgs: {},
 };
 
-function ExpirationCountdown({ hoursToExpiration, setupgradeNotificationCurrentState, type }) {
+function ExpirationCountdown({
+  courseId, hoursToExpiration, setupgradeNotificationCurrentState, type,
+}) {
   let expirationText;
   if (hoursToExpiration >= 24) {
     // setupgradeNotificationCurrentState is available in NotificationTray (not course home)
     if (setupgradeNotificationCurrentState) {
       if (type === 'access') {
         setupgradeNotificationCurrentState('accessDaysLeft');
-        setLocalStorage('upgradeNotificationCurrentState', 'accessDaysLeft');
+        setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'accessDaysLeft');
       }
       if (type === 'offer') {
         setupgradeNotificationCurrentState('FPDdaysLeft');
-        setLocalStorage('upgradeNotificationCurrentState', 'FPDdaysLeft');
+        setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'FPDdaysLeft');
       }
     }
     expirationText = (
@@ -215,11 +217,11 @@ function ExpirationCountdown({ hoursToExpiration, setupgradeNotificationCurrentS
     if (setupgradeNotificationCurrentState) {
       if (type === 'access') {
         setupgradeNotificationCurrentState('accessHoursLeft');
-        setLocalStorage('upgradeNotificationCurrentState', 'accessHoursLeft');
+        setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'accessHoursLeft');
       }
       if (type === 'offer') {
         setupgradeNotificationCurrentState('FPDHoursLeft');
-        setLocalStorage('upgradeNotificationCurrentState', 'FPDHoursLeft');
+        setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'FPDHoursLeft');
       }
     }
     expirationText = (
@@ -238,11 +240,11 @@ function ExpirationCountdown({ hoursToExpiration, setupgradeNotificationCurrentS
     if (setupgradeNotificationCurrentState) {
       if (type === 'access') {
         setupgradeNotificationCurrentState('accessLastHour');
-        setLocalStorage('upgradeNotificationCurrentState', 'accessLastHour');
+        setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'accessLastHour');
       }
       if (type === 'offer') {
         setupgradeNotificationCurrentState('FPDLastHour');
-        setLocalStorage('upgradeNotificationCurrentState', 'FPDLastHour');
+        setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'FPDLastHour');
       }
     }
     expirationText = (
@@ -256,6 +258,7 @@ function ExpirationCountdown({ hoursToExpiration, setupgradeNotificationCurrentS
 }
 
 ExpirationCountdown.propTypes = {
+  courseId: PropTypes.string.isRequired,
   hoursToExpiration: PropTypes.number.isRequired,
   setupgradeNotificationCurrentState: PropTypes.func,
   type: PropTypes.string,
@@ -265,10 +268,12 @@ ExpirationCountdown.defaultProps = {
   type: null,
 };
 
-function AccessExpirationDateBanner({ accessExpirationDate, timezoneFormatArgs, setupgradeNotificationCurrentState }) {
+function AccessExpirationDateBanner({
+  courseId, accessExpirationDate, timezoneFormatArgs, setupgradeNotificationCurrentState,
+}) {
   if (setupgradeNotificationCurrentState) {
     setupgradeNotificationCurrentState('accessDateView');
-    setLocalStorage('upgradeNotificationCurrentState', 'accessDateView');
+    setLocalStorage(`upgradeNotificationCurrentState.${courseId}`, 'accessDateView');
   }
   return (
     <div className="upsell-warning-light">
@@ -292,6 +297,7 @@ function AccessExpirationDateBanner({ accessExpirationDate, timezoneFormatArgs, 
 }
 
 AccessExpirationDateBanner.propTypes = {
+  courseId: PropTypes.string.isRequired,
   accessExpirationDate: PropTypes.PropTypes.instanceOf(Date).isRequired,
   timezoneFormatArgs: PropTypes.shape({
     timeZone: PropTypes.string,
@@ -388,6 +394,7 @@ function UpgradeNotification({
         );
         expirationBanner = (
           <ExpirationCountdown
+            courseId={courseId}
             hoursToExpiration={hoursToDiscountExpiration}
             setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
             type="offer"
@@ -402,6 +409,7 @@ function UpgradeNotification({
         );
         expirationBanner = (
           <AccessExpirationDateBanner
+            courseId={courseId}
             accessExpirationDate={accessExpirationDate}
             timezoneFormatArgs={timezoneFormatArgs}
             setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
@@ -418,6 +426,7 @@ function UpgradeNotification({
       );
       expirationBanner = (
         <ExpirationCountdown
+          courseId={courseId}
           hoursToExpiration={hoursToAccessExpiration}
           setupgradeNotificationCurrentState={setupgradeNotificationCurrentState}
           type="access"


### PR DESCRIPTION
[REV-2360](https://openedx.atlassian.net/browse/REV-2360).

When the notification feature was updated to have the "red dot" functionality in https://github.com/edx/frontend-app-learning/pull/569 it was not course specific, meaning that while it persisted whether the learner had seen the notification or not for a course, when in another course that information was applied as if it was the same course.

This PR makes the "red dot" functionality be course specific and persist by a course, no matter how many courses a learner is enrolled in.

**Below is a screenshot of 2 different courses (local):**
<img width="876" alt="Screen Shot 2021-11-08 at 3 55 38 PM" src="https://user-images.githubusercontent.com/13632680/140816781-21720bfa-efbf-4a4b-9f7f-5168de57a1f0.png">

<img width="877" alt="Screen Shot 2021-11-08 at 3 53 44 PM" src="https://user-images.githubusercontent.com/13632680/140816782-8bb7cc59-333e-436c-bfa7-5e5fa806ea77.png">

**Note on Codecov:**
For the `codecov/patch` coverage, it's below the target since in the original implementation it was below (it was at 53%,  it's now at 70%). 
It's understood that as long as the `codecov/project` coverage is within target we're good to go. 

**How to test:**
- Checkout my branch `julianajlk/REV-2360/vp-notification-red-dot`
- Create a new course other than the Demo course with verified mode available, via [Ecommerce Course Admin](http://localhost:18130/courses/).
- Make sure you enroll in one course first, go to courseware, check the "red dot" notification goes away after in 3 seconds when the `NotificationTray` is open (it should load open). 
- Now enroll in the second course you're created, and you should see the "red dot" notification for this course. 
