### PR TITLE
fix: assume that Learning Sequences is available

### DIFF
--- a/src/courseware/CoursewareContainer.test.jsx
+++ b/src/courseware/CoursewareContainer.test.jsx
@@ -17,6 +17,7 @@ import CoursewareContainer from './CoursewareContainer';
 import { buildSimpleCourseBlocks, buildBinaryCourseBlocks } from '../shared/data/__factories__/courseBlocks.factory';
 import initializeStore from '../store';
 import { appendBrowserTimezoneToUrl } from '../utils';
+import { buildOutlineFromBlocks } from './data/__factories__/learningSequencesOutline.factory';
 
 // NOTE: Because the unit creates an iframe, we choose to mock it out as its rendering isn't
 // pertinent to this test.  Instead, we render a simple div that displays the properties we expect
@@ -100,6 +101,7 @@ describe('CoursewareContainer', () => {
   function setUpMockRequests(options = {}) {
     // If we weren't given course blocks or metadata, use the defaults.
     const courseBlocks = options.courseBlocks || defaultCourseBlocks;
+    const courseOutline = buildOutlineFromBlocks(courseBlocks);
     const courseMetadata = options.courseMetadata || defaultCourseMetadata;
     const courseId = courseMetadata.id;
     // If we weren't given a list of sequence metadatas for URL mocking,
@@ -122,7 +124,7 @@ describe('CoursewareContainer', () => {
     axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);
 
     const learningSequencesUrlRegExp = new RegExp(`${getConfig().LMS_BASE_URL}/api/learning_sequences/v1/course_outline/*`);
-    axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
+    axiosMock.onGet(learningSequencesUrlRegExp).reply(200, courseOutline);
 
     const courseMetadataUrl = appendBrowserTimezoneToUrl(`${getConfig().LMS_BASE_URL}/api/courseware/course/${courseId}`);
     axiosMock.onGet(courseMetadataUrl).reply(200, courseMetadata);
@@ -188,7 +190,7 @@ describe('CoursewareContainer', () => {
       const sequenceBlock = defaultSequenceBlock;
       const unitBlocks = defaultUnitBlocks;
 
-      it('should use the resume block repsonse to pick a unit if it contains one', async () => {
+      it('should use the resume block response to pick a unit if it contains one', async () => {
         axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/courseware/resume/${courseId}`).reply(200, {
           sectionId: sequenceBlock.id,
           unitId: unitBlocks[1].id,

--- a/src/courseware/course/sequence/Sequence.test.jsx
+++ b/src/courseware/course/sequence/Sequence.test.jsx
@@ -47,7 +47,7 @@ describe('Sequence', () => {
   it('renders correctly for gated content', async () => {
     const sequenceBlocks = [Factory.build(
       'block',
-      { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
+      { type: 'sequential', children: unitBlocks.map(block => block.id) },
       { courseId: courseMetadata.id },
     )];
     const gatedContent = {
@@ -86,7 +86,7 @@ describe('Sequence', () => {
   it('renders correctly for hidden after due content', async () => {
     const sequenceBlocks = [Factory.build(
       'block',
-      { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
+      { type: 'sequential', children: unitBlocks.map(block => block.id) },
       { courseId: courseMetadata.id },
     )];
     const sequenceMetadata = [Factory.build(
@@ -138,11 +138,11 @@ describe('Sequence', () => {
     let testStore;
     const sequenceBlocks = [Factory.build(
       'block',
-      { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
+      { type: 'sequential', children: unitBlocks.map(block => block.id) },
       { courseId: courseMetadata.id },
     ), Factory.build(
       'block',
-      { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
+      { type: 'sequential', children: unitBlocks.map(block => block.id) },
       { courseId: courseMetadata.id },
     )];
 
@@ -291,7 +291,7 @@ describe('Sequence', () => {
     it('handles the navigation buttons for empty sequence', async () => {
       const testSequenceBlocks = [Factory.build(
         'block',
-        { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
+        { type: 'sequential', children: unitBlocks.map(block => block.id) },
         { courseId: courseMetadata.id },
       ), Factory.build(
         'block',
@@ -299,7 +299,7 @@ describe('Sequence', () => {
         { courseId: courseMetadata.id },
       ), Factory.build(
         'block',
-        { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
+        { type: 'sequential', children: unitBlocks.map(block => block.id) },
         { courseId: courseMetadata.id },
       )];
       const testSequenceMetadata = testSequenceBlocks.map(block => Factory.build(

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -18,7 +18,7 @@ describe('Unit', () => {
   const unitBlocks = [
     Factory.build(
       'block',
-      { type: 'problem', graded: 'true' },
+      { type: 'vertical', graded: 'true' },
       { courseId: courseMetadata.id },
     ), Factory.build(
       'block',
@@ -32,7 +32,7 @@ describe('Unit', () => {
     ),
     Factory.build(
       'block',
-      { type: 'problem', graded: false },
+      { type: 'vertical', graded: false },
       { courseId: courseMetadata.id },
     ),
   ];

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -15,7 +15,7 @@ describe('Sequence Navigation', () => {
   const courseMetadata = Factory.build('courseMetadata');
   const unitBlocks = Array.from({ length: 3 }).map(() => Factory.build(
     'block',
-    { type: 'problem' },
+    { type: 'vertical' },
     { courseId: courseMetadata.id },
   ));
 
@@ -48,7 +48,7 @@ describe('Sequence Navigation', () => {
   it('renders locked button for gated content', async () => {
     const sequenceBlocks = [Factory.build(
       'block',
-      { type: 'sequential', children: [unitBlocks.map(block => block.id)] },
+      { type: 'sequential', children: unitBlocks.map(block => block.id) },
       { courseId: courseMetadata.id },
     )];
     const sequenceMetadata = [Factory.build(
@@ -70,7 +70,7 @@ describe('Sequence Navigation', () => {
     expect(testData.onNavigate).not.toHaveBeenCalled();
     // TODO: Not sure if this is working as expected, because the `contentType="lock"` will be overridden by the value
     //  from Redux. To make this provide a `fa-icon` lock we could introduce something like `overriddenContentType`.
-    expect(unitButton.firstChild).toHaveClass('fa-edit');
+    expect(unitButton.firstChild).toHaveClass('fa-tasks');
   });
 
   it('renders correctly and handles unit button clicks', () => {

--- a/src/courseware/data/__factories__/index.js
+++ b/src/courseware/data/__factories__/index.js
@@ -1,3 +1,4 @@
 import './courseMetadata.factory';
 import './sequenceMetadata.factory';
 import './courseRecommendations.factory';
+import './learningSequencesOutline.factory';

--- a/src/courseware/data/__factories__/learningSequencesOutline.factory.js
+++ b/src/courseware/data/__factories__/learningSequencesOutline.factory.js
@@ -40,14 +40,14 @@ export function buildOutlineFromBlocks(courseBlocks) {
     } else if (block.type === 'chapter') {
       sections[block.id] = {
         id: block.id,
-        title: block.title,
+        title: block.display_name,
         start: null,
         sequence_ids: [...block.children],
       };
     } else if (block.type === 'sequential') {
       sequences[block.id] = {
         id: block.id,
-        title: block.title,
+        title: block.display_name,
         accessible: true,
         start: null,
       };

--- a/src/courseware/data/redux.test.js
+++ b/src/courseware/data/redux.test.js
@@ -79,7 +79,7 @@ describe('Data layer integration tests', () => {
 
       axiosMock.onGet(forbiddenCourseUrl).reply(200, forbiddenCourseMetadata);
       axiosMock.onGet(courseBlocksUrlRegExp).reply(200, forbiddenCourseBlocks);
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
+      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(forbiddenCourseBlocks));
 
       await executeThunk(thunks.fetchCourse(forbiddenCourseMetadata.id), store.dispatch);
 
@@ -94,7 +94,7 @@ describe('Data layer integration tests', () => {
     it('Should fetch, normalize, and save metadata', async () => {
       axiosMock.onGet(courseUrl).reply(200, courseMetadata);
       axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
+      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(courseBlocks));
 
       await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
 
@@ -189,7 +189,7 @@ describe('Data layer integration tests', () => {
     it('Should fetch and normalize metadata, and then update existing models with sequence metadata', async () => {
       axiosMock.onGet(courseUrl).reply(200, courseMetadata);
       axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
+      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(courseBlocks));
       axiosMock.onGet(sequenceUrl).reply(200, sequenceMetadata);
 
       // setting course with blocks before sequence to check that blocks receive

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -25,6 +25,7 @@ import appMessages from './i18n';
 import { fetchCourse, fetchSequence } from './courseware/data';
 import { appendBrowserTimezoneToUrl, executeThunk } from './utils';
 import buildSimpleCourseAndSequenceMetadata from './courseware/data/__factories__/sequenceMetadata.factory';
+import { buildOutlineFromBlocks } from './courseware/data/__factories__/learningSequencesOutline.factory';
 
 class MockLoggingService {
   logInfo = jest.fn();
@@ -157,7 +158,7 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
 
   axiosMock.onGet(forbiddenCourseUrl).reply(200, courseMetadata);
   axiosMock.onGet(courseBlocksUrlRegExp).reply(200, courseBlocks);
-  axiosMock.onGet(learningSequencesUrlRegExp).reply(403, {});
+  axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(courseBlocks));
   sequenceMetadata.forEach(metadata => {
     const sequenceMetadataUrl = `${getConfig().LMS_BASE_URL}/api/courseware/sequence/${metadata.item_id}`;
     axiosMock.onGet(sequenceMetadataUrl).reply(200, metadata);

--- a/src/shared/data/__factories__/courseBlocks.factory.js
+++ b/src/shared/data/__factories__/courseBlocks.factory.js
@@ -84,7 +84,7 @@ export function buildSimpleCourseBlocks(courseId, title, options = {}) {
       {
         courseId,
         hasScheduledContent: options.hasScheduledContent || false,
-        title: 'Demo Course',
+        title,
       },
       {
         units: unitBlocks,
@@ -225,7 +225,7 @@ export function buildBinaryCourseBlocks(courseId, title) {
     // work with.
     courseBlocks: Factory.build(
       'courseBlocks',
-      { courseId },
+      { courseId, title },
       {
         units: unitBlocks,
         sequences: sequenceBlocks,


### PR DESCRIPTION
Now that it's been rolled out and the feature flag is gone, we can simplify our handling and just assume it will return a valid response.

https://openedx.atlassian.net/browse/AA-1040