### PR TITLE
refactor: [REV-2388] remove "non-profit" MM-P2P language

### DIFF
--- a/src/experiments/mm-p2p/BlockModalContent.jsx
+++ b/src/experiments/mm-p2p/BlockModalContent.jsx
@@ -55,7 +55,7 @@ export const BlockModal = () => (
             &nbsp;including graded assignments, even after the course ends.
           </BulletList>
           <BulletList>
-            Support our non-profit mission at edx
+            Support our mission at edx
           </BulletList>
         </div>
 

--- a/src/experiments/mm-p2p/SidecardContent.jsx
+++ b/src/experiments/mm-p2p/SidecardContent.jsx
@@ -106,7 +106,7 @@ const Sidecard = ({
           Earn a {certLink} of completion to showcase on your resumé
         </BulletList>
         <BulletList>
-          Support our <span style={{ fontWeight: 600 }}>non-profit mission</span> at edX
+          Support our <span style={{ fontWeight: 600 }}>mission</span> at edX
         </BulletList>
       </div>
 


### PR DESCRIPTION
## Description

We want to make sure learners aren't mislead into thinking edX is a non-profit, now that we are no longer one.

This PR removes non-profit language from the MicroMasters Preview to Pay (MM-P2P) Optimizely experiment in frontend-app-learning.

The MM-P2P experiment has already ended and is scheduled for deprecation. As a result, this change will not be user facing. It is for cleanup purposes only.

## Supporting information
<!--
Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.
-->
* JIRA: [REV-2388](https://openedx.atlassian.net/browse/REV-2388)
* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3229155368/REV-2388)