### PR TITLE
chore: update frontend-lib-special-exams to 1.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4045,9 +4045,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.14.0.tgz",
-      "integrity": "sha512-Z6rsUZyc6NJO2M+wPphcm58CdU03gVH5HKQ+FqAKtZn0K+50xAp6cKlaI83UdB+t5w4Ok44UOVv7vjWjLzJDQQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.14.1.tgz",
+      "integrity": "sha512-HTsoU7jbIT66YCEt7CSFVSeRC77iE+UfnFXCzE9FjS82Xip/Zg4TKipX0dnRK3LHCjrrqzLILiti4/qyyQDM9w==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-enterprise-utils": "1.1.1",
-    "@edx/frontend-lib-special-exams": "1.14.0",
+    "@edx/frontend-lib-special-exams": "1.14.1",
     "@edx/frontend-platform": "1.14.2",
     "@edx/paragon": "16.18.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
This update adds logging on worker failure when attempting to start a proctored exam.

https://github.com/edx/frontend-lib-special-exams/pull/53