### PR TITLE
feat: Add NotificationTray persistence by course

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -54,6 +54,7 @@ function Course({
   // Responsive breakpoints for showing the notification button/tray
   const shouldDisplayNotificationTriggerInCourse = useWindowSize().width >= responsiveBreakpoints.small.minWidth;
   const shouldDisplayNotificationTrayOpenOnLoad = useWindowSize().width > responsiveBreakpoints.medium.minWidth;
+
   // Course specific notification tray open/closed persistance by browser session
   if (!getSessionStorage(`notificationTrayStatus.${courseId}`)) {
     if (shouldDisplayNotificationTrayOpenOnLoad) {

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -51,7 +51,7 @@ function Course({
     courseId, sequenceId, unitId, celebrateFirstSection, dispatch, celebrations,
   );
 
-  // Responsive breakpoints for showing the notificaiton button/tray
+  // Responsive breakpoints for showing the notification button/tray
   const shouldDisplayNotificationTriggerInCourse = useWindowSize().width >= responsiveBreakpoints.small.minWidth;
   const shouldDisplayNotificationTrayOpenOnLoad = useWindowSize().width > responsiveBreakpoints.medium.minWidth;
   // Course specific notification tray open/closed persistance by browser session

--- a/src/courseware/course/Course.test.jsx
+++ b/src/courseware/course/Course.test.jsx
@@ -9,6 +9,7 @@ import * as celebrationUtils from './celebration/utils';
 import useWindowSize from '../../generic/tabs/useWindowSize';
 
 jest.mock('@edx/frontend-platform/analytics');
+jest.mock('./NotificationTray', () => () => <div data-testid="NotificationTray" />);
 jest.mock('../../generic/tabs/useWindowSize');
 useWindowSize.mockReturnValue({ width: 1200 });
 
@@ -17,6 +18,8 @@ celebrationUtils.recordFirstSectionCelebration = recordFirstSectionCelebration;
 
 describe('Course', () => {
   let store;
+  let getItemSpy;
+  let setItemSpy;
   const mockData = {
     nextSequenceHandler: () => {},
     previousSequenceHandler: () => {},
@@ -32,6 +35,13 @@ describe('Course', () => {
       sequenceId,
       unitId: Object.values(models.units)[0].id,
     });
+    getItemSpy = jest.spyOn(Object.getPrototypeOf(window.sessionStorage), 'getItem');
+    setItemSpy = jest.spyOn(Object.getPrototypeOf(window.sessionStorage), 'setItem');
+  });
+
+  afterAll(() => {
+    getItemSpy.mockRestore();
+    setItemSpy.mockRestore();
   });
 
   it('loads learning sequence', async () => {
@@ -89,6 +99,55 @@ describe('Course', () => {
     expect(notificationTrigger).toHaveClass('trigger-active');
     fireEvent.click(notificationTrigger);
     expect(notificationTrigger).not.toHaveClass('trigger-active');
+  });
+
+  it('handles click to open/close notification tray', async () => {
+    sessionStorage.clear();
+    render(<Course {...mockData} />);
+    expect(sessionStorage.getItem(`notificationTrayStatus.${mockData.courseId}`)).toBe('"open"');
+    const notificationShowButton = await screen.findByRole('button', { name: /Show notification tray/i });
+    expect(screen.queryByTestId('NotificationTray')).toBeInTheDocument();
+    fireEvent.click(notificationShowButton);
+    expect(sessionStorage.getItem(`notificationTrayStatus.${mockData.courseId}`)).toBe('"closed"');
+    expect(screen.queryByTestId('NotificationTray')).not.toBeInTheDocument();
+  });
+
+  it('handles reload persisting notification tray status', async () => {
+    sessionStorage.clear();
+    render(<Course {...mockData} />);
+    const notificationShowButton = await screen.findByRole('button', { name: /Show notification tray/i });
+    fireEvent.click(notificationShowButton);
+    expect(sessionStorage.getItem(`notificationTrayStatus.${mockData.courseId}`)).toBe('"closed"');
+
+    // Mock reload window, this doesn't happen in the Course component,
+    // calling the reload to check if the tray remains closed
+    const { location } = window;
+    delete window.location;
+    window.location = { reload: jest.fn() };
+    window.location.reload();
+    expect(window.location.reload).toHaveBeenCalled();
+    window.location = location;
+    expect(sessionStorage.getItem(`notificationTrayStatus.${mockData.courseId}`)).toBe('"closed"');
+    expect(screen.queryByTestId('NotificationTray')).not.toBeInTheDocument();
+  });
+
+  it('handles sessionStorage from a different course for the notification tray', async () => {
+    sessionStorage.clear();
+    const courseMetadataSecondCourse = Factory.build('courseMetadata');
+
+    // set sessionStorage for a different course before rendering Course
+    sessionStorage.setItem(`notificationTrayStatus.${courseMetadataSecondCourse.id}`, '"open"');
+
+    render(<Course {...mockData} />);
+    expect(sessionStorage.getItem(`notificationTrayStatus.${mockData.courseId}`)).toBe('"open"');
+    const notificationShowButton = await screen.findByRole('button', { name: /Show notification tray/i });
+    fireEvent.click(notificationShowButton);
+
+    // Verify sessionStorage was updated for the original course
+    expect(sessionStorage.getItem(`notificationTrayStatus.${mockData.courseId}`)).toBe('"closed"');
+
+    // Verify the second course sessionStorage was not changed
+    expect(sessionStorage.getItem(`notificationTrayStatus.${courseMetadataSecondCourse.id}`)).toBe('"open"');
   });
 
   it('renders course breadcrumbs as expected', async () => {

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -52,7 +52,7 @@ function Sequence({
   const sequence = useModel('sequences', sequenceId);
   const unit = useModel('units', unitId);
   const sequenceStatus = useSelector(state => state.courseware.sequenceStatus);
-  const shouldDisplayNotificationTrigger = useWindowSize().width < responsiveBreakpoints.small.minWidth;
+  const shouldDisplayNotificationTriggerInSequence = useWindowSize().width < responsiveBreakpoints.small.minWidth;
 
   const handleNext = () => {
     const nextIndex = sequence.unitIds.indexOf(unitId) + 1;
@@ -156,7 +156,7 @@ function Sequence({
 
   const defaultContent = (
     <div className="sequence-container" style={{ display: 'inline-flex', flexDirection: 'row' }}>
-      <div className={classNames('sequence', { 'position-relative': shouldDisplayNotificationTrigger })} style={{ width: '100%' }}>
+      <div className={classNames('sequence', { 'position-relative': shouldDisplayNotificationTriggerInSequence })} style={{ width: '100%' }}>
         <SequenceNavigation
           sequenceId={sequenceId}
           unitId={unitId}
@@ -180,7 +180,7 @@ function Sequence({
           goToCourseExitPage={() => goToCourseExitPage()}
         />
 
-        {shouldDisplayNotificationTrigger ? (
+        {shouldDisplayNotificationTriggerInSequence ? (
           <NotificationTrigger
             courseId={courseId}
             toggleNotificationTray={toggleNotificationTray}

--- a/src/courseware/course/sequence/Sequence.test.jsx
+++ b/src/courseware/course/sequence/Sequence.test.jsx
@@ -31,6 +31,8 @@ describe('Sequence', () => {
       unitNavigationHandler: () => {},
       nextSequenceHandler: () => {},
       previousSequenceHandler: () => {},
+      toggleNotificationTray: () => {},
+      setNotificationStatus: () => {},
     };
   });
 
@@ -388,6 +390,19 @@ describe('Sequence', () => {
       };
       render(<Sequence {...testData} />);
       expect(await screen.findByText('Notifications')).toBeInTheDocument();
+    });
+
+    it('handles click on notification tray close button', async () => {
+      const toggleNotificationTray = jest.fn();
+      const testData = {
+        ...mockData,
+        toggleNotificationTray,
+        notificationTrayVisible: true,
+      };
+      render(<Sequence {...testData} />);
+      const notificationCloseIconButton = await screen.findByRole('button', { name: /Close notification tray/i });
+      fireEvent.click(notificationCloseIconButton);
+      expect(toggleNotificationTray).toHaveBeenCalledTimes(1);
     });
 
     it('does not render notification tray in sequence by default if in responsive view', async () => {

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -44,7 +44,7 @@ function SequenceNavigation({
     sequence.gatedContent !== undefined && sequence.gatedContent.gated
   ) : undefined;
 
-  const shouldDisplayNotificationTrigger = useWindowSize().width < responsiveBreakpoints.small.minWidth;
+  const shouldDisplayNotificationTriggerInSequence = useWindowSize().width < responsiveBreakpoints.small.minWidth;
 
   const renderUnitButtons = () => {
     if (isLocked) {
@@ -76,7 +76,7 @@ function SequenceNavigation({
 
     return (
       <Button variant="link" className="next-btn" onClick={buttonOnClick} disabled={disabled} iconAfter={nextArrow}>
-        {shouldDisplayNotificationTrigger ? null : buttonText}
+        {shouldDisplayNotificationTriggerInSequence ? null : buttonText}
       </Button>
     );
   };
@@ -84,9 +84,9 @@ function SequenceNavigation({
   const prevArrow = isRtl(getLocale()) ? ChevronRight : ChevronLeft;
 
   return sequenceStatus === LOADED && (
-    <nav id="courseware-sequenceNavigation" className={classNames('sequence-navigation', className)} style={{ width: shouldDisplayNotificationTrigger ? '90%' : null }}>
+    <nav id="courseware-sequenceNavigation" className={classNames('sequence-navigation', className)} style={{ width: shouldDisplayNotificationTriggerInSequence ? '90%' : null }}>
       <Button variant="link" className="previous-btn" onClick={previousSequenceHandler} disabled={isFirstUnit} iconBefore={prevArrow}>
-        {shouldDisplayNotificationTrigger ? null : intl.formatMessage(messages.previousButton)}
+        {shouldDisplayNotificationTriggerInSequence ? null : intl.formatMessage(messages.previousButton)}
       </Button>
       {renderUnitButtons()}
       {renderNextButton()}

--- a/src/data/sessionStorage.js
+++ b/src/data/sessionStorage.js
@@ -1,0 +1,34 @@
+// This file holds some convenience methods for dealing with sessionStorage. Unlike localStorage that never expires,
+// sessionStorage is cleared when the browser tab is closed since the page session ends
+//
+// NOTE: These storage keys are not namespaced.  That means that it's shared for the current fully
+// qualified domain.  Namespacing could be added, but we'll cross that bridge when we need it.
+
+function getSessionStorage(key) {
+  try {
+    if (global.sessionStorage) {
+      const rawItem = global.sessionStorage.getItem(key);
+      if (rawItem) {
+        return JSON.parse(rawItem);
+      }
+    }
+  } catch (e) {
+    // If this fails for some reason, just return null.
+  }
+  return null;
+}
+
+function setSessionStorage(key, value) {
+  try {
+    if (global.sessionStorage) {
+      global.sessionStorage.setItem(key, JSON.stringify(value));
+    }
+  } catch (e) {
+    // If this fails, just bail.
+  }
+}
+
+export {
+  getSessionStorage,
+  setSessionStorage,
+};


### PR DESCRIPTION
[REV-2424](https://openedx.atlassian.net/browse/REV-2424).
When the `NotificationTray` was first implemented, it was not specific to a course - when the user closed the tray it would persist as they navigated through the units however if they reloaded the page or went to course home and then back to courseware, it would display the tray open even if the user had closed it.

This PR adds the functionality to have this open/closed persist by course and session. User session is saved for each course until the browser is closed. Once the browser is closed, when the user opens the browser again, courseware loads with the tray open for all courses.

**Note on unit tests:**
The tray touches 3 generations of components, which with Jest/jsdom and frontend testing by component makes it difficult to fully cover a real user behavior across multiple components.
Codecov was happy without any tests added, but I added some tests to cover the behavior when the button is clicked to open/close the tray and a test to see that with multiple courses.

**This PR:**
- Changes the `NotificationTray` functionality to be course specific. 
- Adds tests. 
- Renames some variables: `shouldDisplayNotificationTriggerInSequence` or `...InCourse` and `shouldDisplayNotificationTrayOpenOnLoad`

**How to test:**
- Checkout my branch `julianajlk/REV-2424/value-prop-notification-tray-course-specific`
- Create a new course other than the Demo course with at least verified mode available, via [Ecommerce Course Admin](http://localhost:18130/courses/). Make sure you create the course in studio first.
- Enroll in both courses, and open each course in a different tab.
- On the first course, go to courseware, and close the tray. It should load open at first.
- On the second course, go to courseware, and leave it open. 
- Reload both tabs.
- First course should load with the tray closed. Second course should load with the tray open.
- Close the tab for the first course to end the session.
- Open a new tab and go to the first course again. Tray should load open.