### PR TITLE
fix: [AA-1076] show grade override notice

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -706,27 +706,6 @@ describe('Progress Tab', () => {
 
     it('renders override notice', async () => {
       setTabData({
-        grading_policy: {
-          assignment_policies: [
-            {
-              num_droppable: 1,
-              num_total: 2,
-              short_label: 'HW',
-              type: 'Homework',
-              weight: 0.5,
-            },
-            {
-              num_droppable: 0,
-              num_total: 1,
-              short_label: 'Ex',
-              type: 'Exam',
-              weight: 0.5,
-            },
-          ],
-          grade_range: {
-            pass: 0.75,
-          },
-        },
         section_scores: [
           {
             display_name: 'First section',

--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -725,7 +725,6 @@ describe('Progress Tab', () => {
                 }],
                 show_correctness: 'always',
                 show_grades: true,
-                url: 'http://learning.edx.org/course/course-v1:edX+Test+run/first_subsection',
               },
             ],
           },

--- a/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
@@ -6,7 +6,11 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Collapsible, Icon, Row } from '@edx/paragon';
-import { ArrowDropDown, ArrowDropUp, Blocked } from '@edx/paragon/icons';
+import {
+  ArrowDropDown, ArrowDropUp, Blocked,
+} from '@edx/paragon/icons';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import messages from '../messages';
 import { useModel } from '../../../../generic/model-store';
@@ -79,7 +83,16 @@ function SubsectionTitleCell({ intl, subsection }) {
         </span>
       </Row>
       <Collapsible.Body className="d-flex w-100">
-        <ProblemScoreDrawer problemScores={problemScores} subsection={subsection} />
+        <div className="col w-100">
+          { subsection.override
+            && (
+            <div className="row w-100 m-0 x-small ml-4 pt-2 pl-1 text-gray-700 flex-nowrap">
+              <div><FontAwesomeIcon icon={faInfoCircle} className="fa-lg mr-1 text-primary-500" /></div>
+              <div data-testid="override-message">{intl.formatMessage(messages.sectionGradeOverridden)}</div>
+            </div>
+            )}
+          <ProblemScoreDrawer problemScores={problemScores} subsection={subsection} />
+        </div>
       </Collapsible.Body>
     </Collapsible.Advanced>
   );
@@ -91,6 +104,10 @@ SubsectionTitleCell.propTypes = {
     blockKey: PropTypes.string.isRequired,
     displayName: PropTypes.string.isRequired,
     learnerHasAccess: PropTypes.bool.isRequired,
+    override: PropTypes.shape({
+      system: PropTypes.string,
+      reason: PropTypes.string,
+    }),
     problemScores: PropTypes.arrayOf(PropTypes.shape({
       earned: PropTypes.number.isRequired,
       possible: PropTypes.number.isRequired,

--- a/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
@@ -7,10 +7,8 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Collapsible, Icon, Row } from '@edx/paragon';
 import {
-  ArrowDropDown, ArrowDropUp, Blocked,
+  ArrowDropDown, ArrowDropUp, Blocked, Info,
 } from '@edx/paragon/icons';
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import messages from '../messages';
 import { useModel } from '../../../../generic/model-store';
@@ -83,14 +81,19 @@ function SubsectionTitleCell({ intl, subsection }) {
         </span>
       </Row>
       <Collapsible.Body className="d-flex w-100">
-        <div className="col w-100">
-          { subsection.override
-            && (
+        <div className="col">
+          { subsection.override && (
             <div className="row w-100 m-0 x-small ml-4 pt-2 pl-1 text-gray-700 flex-nowrap">
-              <div><FontAwesomeIcon icon={faInfoCircle} className="fa-lg mr-1 text-primary-500" /></div>
-              <div data-testid="override-message">{intl.formatMessage(messages.sectionGradeOverridden)}</div>
+              <div>
+                <Icon
+                  src={Info}
+                  className="x-small mr-1 text-primary-500"
+                  style={{ height: '16.67px', width: '16.67px' }}
+                />
+              </div>
+              <div>{intl.formatMessage(messages.sectionGradeOverridden)}</div>
             </div>
-            )}
+          )}
           <ProblemScoreDrawer problemScores={problemScores} subsection={subsection} />
         </div>
       </Collapsible.Body>

--- a/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
@@ -88,7 +88,7 @@ function SubsectionTitleCell({ intl, subsection }) {
                 <Icon
                   src={Info}
                   className="x-small mr-1 text-primary-500"
-                  style={{ height: '16.67px', width: '16.67px' }}
+                  style={{ height: '1.3em', width: '1.3em' }}
                 />
               </div>
               <div>{intl.formatMessage(messages.sectionGradeOverridden)}</div>

--- a/src/course-home/progress-tab/grades/messages.js
+++ b/src/course-home/progress-tab/grades/messages.js
@@ -115,6 +115,14 @@ const messages = defineMessages({
       + 'By multiplying your grade by the weight for that assignment type, your weighted grade is calculated. '
       + "Your weighted grade is what's used to determine if you pass the course.",
   },
+  noAccessToAssignmentType: {
+    id: 'progress.noAcessToAssignmentType',
+    defaultMessage: 'You do not have access to assignments of type {assignmentType}',
+  },
+  noAccessToSubsection: {
+    id: 'progress.noAcessToSubsection',
+    defaultMessage: 'You do not have access to subsection {displayName}',
+  },
   passingGradeLabel: {
     id: 'progress.courseGrade.label.passingGrade',
     defaultMessage: 'Passing grade',
@@ -126,6 +134,10 @@ const messages = defineMessages({
   problemScoreToggleAltText: {
     id: 'progress.detailedGrades.problemScore.toggleButton',
     defaultMessage: 'Toggle individual problem scores for {subsectionTitle}',
+  },
+  sectionGradeOverridden: {
+    id: 'progress.detailedGrades.overridden',
+    defaultMessage: 'Section grade has been overridden.',
   },
   score: {
     id: 'progress.score',
@@ -143,14 +155,7 @@ const messages = defineMessages({
     id: 'progress.weightedGradeSummary',
     defaultMessage: 'Your current weighted grade summary',
   },
-  noAccessToAssignmentType: {
-    id: 'progress.noAcessToAssignmentType',
-    defaultMessage: 'You do not have access to assignments of type {assignmentType}',
-  },
-  noAccessToSubsection: {
-    id: 'progress.noAcessToSubsection',
-    defaultMessage: 'You do not have access to subsection {displayName}',
-  },
+
 });
 
 export default messages;


### PR DESCRIPTION
- Progress page indicates if a grade has been overridden. This adds functionality that was in the legacy progress page but missing in the new Progress page.

![image](https://user-images.githubusercontent.com/3932645/145883818-0d090620-da7b-4b57-b188-427f93945086.png)

Ticket 
https://github.com/edx/edx-platform/pull/29585

Backend changes are in https://openedx.atlassian.net/browse/AA-1076

