### PR TITLE
fix: remove launch tour from header

### DIFF
--- a/src/course-header/Header.jsx
+++ b/src/course-header/Header.jsx
@@ -7,7 +7,6 @@ import { AppContext } from '@edx/frontend-platform/react';
 
 import AnonymousUserMenu from './AnonymousUserMenu';
 import AuthenticatedUserDropdown from './AuthenticatedUserDropdown';
-import LaunchCourseHomeTourButton from '../product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton';
 
 import messages from './messages';
 
@@ -31,7 +30,7 @@ LinkedLogo.propTypes = {
 };
 
 function Header({
-  courseOrg, courseNumber, courseTitle, intl, metadataModel, showLaunchTourButton, showUserDropdown,
+  courseOrg, courseNumber, courseTitle, intl, showUserDropdown,
 }) {
   const { authenticatedUser } = useContext(AppContext);
 
@@ -62,7 +61,6 @@ function Header({
 
   return (
     <header className="course-header">
-      {showLaunchTourButton && (<LaunchCourseHomeTourButton metadataModel={metadataModel} srOnly />)}
       <a className="sr-only sr-only-focusable" href="#main-content">{intl.formatMessage(messages.skipNavLink)}</a>
       <div className="container-xl py-2 d-flex align-items-center">
         {headerLogo}
@@ -89,8 +87,6 @@ Header.propTypes = {
   courseNumber: PropTypes.string,
   courseTitle: PropTypes.string,
   intl: intlShape.isRequired,
-  metadataModel: PropTypes.string,
-  showLaunchTourButton: PropTypes.bool,
   showUserDropdown: PropTypes.bool,
 };
 
@@ -98,8 +94,6 @@ Header.defaultProps = {
   courseOrg: null,
   courseNumber: null,
   courseTitle: null,
-  metadataModel: 'courseHomeMeta',
-  showLaunchTourButton: false,
   showUserDropdown: true,
 };
 

--- a/src/product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton.jsx
+++ b/src/product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton.jsx
@@ -12,14 +12,14 @@ import { useModel } from '../../generic/model-store';
 import { launchCourseHomeTour } from '../data/slice';
 import messages from '../messages';
 
-function LaunchCourseHomeTourButton({ intl, metadataModel, srOnly }) {
+function LaunchCourseHomeTourButton({ intl, srOnly }) {
   const {
     courseId,
   } = useSelector(state => state.courseHome);
 
   const {
     org,
-  } = useModel(metadataModel, courseId);
+  } = useModel('courseHomeMeta', courseId);
 
   const {
     toursEnabled,
@@ -58,13 +58,11 @@ function LaunchCourseHomeTourButton({ intl, metadataModel, srOnly }) {
 }
 
 LaunchCourseHomeTourButton.defaultProps = {
-  metadataModel: 'courseHomeMeta',
   srOnly: false,
 };
 
 LaunchCourseHomeTourButton.propTypes = {
   intl: intlShape.isRequired,
-  metadataModel: PropTypes.string,
   srOnly: PropTypes.bool,
 };
 

--- a/src/tab-page/TabPage.jsx
+++ b/src/tab-page/TabPage.jsx
@@ -15,6 +15,7 @@ import genericMessages from '../generic/messages';
 import messages from './messages';
 import LoadedTabPage from './LoadedTabPage';
 import { setCallToActionToast } from '../course-home/data/slice';
+import LaunchCourseHomeTourButton from '../product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton';
 
 function TabPage({ intl, ...props }) {
   const {
@@ -73,12 +74,11 @@ function TabPage({ intl, ...props }) {
         >
           {toastHeader}
         </Toast>
+        {metadataModel === 'courseHomeMeta' && (<LaunchCourseHomeTourButton srOnly />)}
         <Header
           courseOrg={org}
           courseNumber={number}
           courseTitle={title}
-          metadataModel={metadataModel}
-          showLaunchTourLink
         />
         <LoadedTabPage {...props} />
         <Footer />


### PR DESCRIPTION
This header is being replaced by a shared library @edx/frontend-component-header. We're moving tour logic out so that it doesn't get wiped away in the transition