### PR TITLE
fix: when LS is enabled, don't re-connect units and sequences

### DIFF
--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -98,11 +98,6 @@ function mergeLearningSequencesWithCourseBlocks(learningSequencesModels, courseB
       legacyWebUrl: blocksSequence.legacyWebUrl,
       unitIds: blocksSequence.unitIds,
     };
-
-    // Add back-references to this sequence for all child units.
-    blocksSequence.unitIds.forEach(childUnitId => {
-      mergedModels.units[childUnitId].sequenceId = sequenceId;
-    });
   });
 
   // List of Sections comes from Learning Sequences.


### PR DESCRIPTION
Learning Sequences (LS) don't need to edit unit blocks at all.
It's not their data and the stitching code didn't have all the
safety guards that the course block normalizer does in api.js.

This fixes an issue with degenerate course layouts (like problems
as direct children of sequences) when LS is enabled. It was trying
to stitch units and sequences together but failing to account for
unitIds that aren't actual units.

Which is technically still supported by the platform, though not
possible in Studio. We could try to do something smarter here, but
that's not LS's job - it should just trust that the unit data is
correctly normalized already. That unit loading code will
eventually move to the sequence metadata anyway (ideally) and LS
won't touch units at all.

[AA-1162](https://openedx.atlassian.net/browse/AA-1162)