### PR TITLE
feat: add rtl support 

### DIFF
--- a/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape, isRtl } from '@edx/frontend-platform/i18n';
 import { OverlayTrigger, Popover } from '@edx/paragon';
 
 import { useModel } from '../../../../generic/model-store';
@@ -23,6 +23,12 @@ function CurrentGradeTooltip({ intl, tooltipClassName }) {
 
   const currentGrade = Number((visiblePercent * 100).toFixed(0));
 
+  let currentGradeDirection = currentGrade < 50 ? '' : '-';
+
+  if (isRtl) {
+    currentGradeDirection = currentGrade < 50 ? '-' : '';
+  }
+
   return (
     <>
       <OverlayTrigger
@@ -37,16 +43,16 @@ function CurrentGradeTooltip({ intl, tooltipClassName }) {
         )}
       >
         <g>
-          <circle cx={`${Math.min(...[currentGrade, 100])}%`} cy="50%" r="8.5" fill="transparent" />
-          <rect className="grade-bar__divider" x={`${Math.min(...[currentGrade, 100])}%`} style={{ transform: 'translateY(2.61em)' }} />
+          <circle cx={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`} cy="50%" r="8.5" fill="transparent" />
+          <rect className="grade-bar__divider" x={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`} style={{ transform: 'translateY(2.61em)' }} />
         </g>
       </OverlayTrigger>
       <text
         className="x-small"
         textAnchor={currentGrade < 50 ? 'start' : 'end'}
-        x={`${Math.min(...[currentGrade, 100])}%`}
+        x={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`}
         y="20px"
-        style={{ transform: `translateX(${currentGrade < 50 ? '' : '-'}3.4em)` }}
+        style={{ transform: `translateX(${currentGradeDirection}3.4em)` }}
       >
         {intl.formatMessage(messages.currentGradeLabel)}
       </text>

--- a/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape, isRtl } from '@edx/frontend-platform/i18n';
 import { OverlayTrigger, Popover } from '@edx/paragon';
 
 import messages from '../messages';
 
 function PassingGradeTooltip({ intl, passingGrade, tooltipClassName }) {
+  let passingGradeDirection = passingGrade < 50 ? '' : '-';
+
+  if (isRtl) {
+    passingGradeDirection = passingGrade < 50 ? '-' : '';
+  }
+
   return (
     <>
       <OverlayTrigger
@@ -21,17 +27,17 @@ function PassingGradeTooltip({ intl, passingGrade, tooltipClassName }) {
         )}
       >
         <g>
-          <circle cx={`${passingGrade}%`} cy="50%" r="8.5" fill="transparent" />
-          <circle className="grade-bar--passing" cx={`${passingGrade}%`} cy="50%" r="4.5" />
+          <circle cx={`${isRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="8.5" fill="transparent" />
+          <circle className="grade-bar--passing" cx={`${isRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="4.5" />
         </g>
       </OverlayTrigger>
 
       <text
         className="x-small"
         textAnchor={passingGrade < 50 ? 'start' : 'end'}
-        x={`${passingGrade}%`}
+        x={`${isRtl ? 100 - passingGrade : passingGrade}%`}
         y="90px"
-        style={{ transform: `translateX(${passingGrade < 50 ? '' : '-'}3.4em)` }}
+        style={{ transform: `translateX(${passingGradeDirection}3.4em)` }}
       >
         {intl.formatMessage(messages.passingGradeLabel)}
       </text>

--- a/src/generic/PageLoading.jsx
+++ b/src/generic/PageLoading.jsx
@@ -18,7 +18,7 @@ export default class PageLoading extends Component {
 
   render() {
     return (
-      <main>
+      <div>
         <div
           className="d-flex justify-content-center align-items-center flex-column"
           style={{
@@ -29,7 +29,7 @@ export default class PageLoading extends Component {
             {this.renderSrMessage()}
           </Spinner>
         </div>
-      </main>
+      </div>
     );
   }
 }

--- a/src/generic/PageLoading.jsx
+++ b/src/generic/PageLoading.jsx
@@ -18,7 +18,7 @@ export default class PageLoading extends Component {
 
   render() {
     return (
-      <div>
+      <main>
         <div
           className="d-flex justify-content-center align-items-center flex-column"
           style={{
@@ -29,7 +29,7 @@ export default class PageLoading extends Component {
             {this.renderSrMessage()}
           </Spinner>
         </div>
-      </div>
+      </main>
     );
   }
 }


### PR DESCRIPTION
1) Add RTL support for the chart on the progress tab.

**Description:** When the user uses the Arabic language, which requires adaptation of the site for RTL, the progress graph does not adapt and is static for the RTL & LTR versions.

**Screen after adding changes:**
![image](https://user-images.githubusercontent.com/17108583/146935923-851802b0-3f3d-48c4-a890-3ae9e301014b.png)


2. Change the `div` tag to a more semantic `main` tag.

**Description:** Main site content should be covered in the `main` tag to increase semantic weight.