### PR TITLE
fix: make launch tour smaller to fit surrounding icons

### DIFF
--- a/src/product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton.jsx
+++ b/src/product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton.jsx
@@ -47,7 +47,7 @@ function LaunchCourseHomeTourButton({ intl, srOnly }) {
             <Icon
               src={Compass}
               className="mr-2"
-              style={{ height: '18px', width: '18px' }}
+              style={{ height: '12px', width: '12px' }}
             />
           )}
           {intl.formatMessage(messages.launchTour)}


### PR DESCRIPTION
**BEFORE:**

![Screenshot from 2022-01-06 09-56-26](https://user-images.githubusercontent.com/1196901/148404531-f1640763-c70b-4669-a2be-4c7673ad1a25.png)

**AFTER:**

![Screenshot from 2022-01-06 09-55-16](https://user-images.githubusercontent.com/1196901/148404550-c2684d3b-e560-4d34-886c-34b033e71633.png)
