### PR TITLE
Reverting back to anchor tag as Link causing an error

### DIFF
--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -6,7 +6,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
 import { SelectMenu } from '@edx/paragon';
-import { Link } from 'react-router-dom';
 import { useModel, useModels } from '../../generic/model-store';
 /** [MM-P2P] Experiment */
 import { MMP2PFlyoverTrigger } from '../../experiments/mm-p2p';
@@ -31,12 +30,12 @@ function CourseBreadcrumb({
       >
         { getConfig().ENABLE_JUMPNAV !== 'true' || content.length < 2 || !isStaff
           ? (
-            <Link
+            <a
               className="text-primary-500"
-              to={`/course/${courseId}/${defaultContent.id}`}
+              href={`${getConfig().PUBLIC_PATH}course/${courseId}/${defaultContent.id}`}
             >
               {defaultContent.label}
-            </Link>
+            </a>
           )
           : (
             <SelectMenu isLink defaultMessage={defaultContent.label}>
@@ -129,9 +128,9 @@ export default function CourseBreadcrumbs({
     <nav aria-label="breadcrumb" className="my-4 d-inline-block col-sm-10">
       <ol className="list-unstyled d-flex  flex-nowrap align-items-center m-0">
         <li className="list-unstyled col-auto m-0 p-0">
-          <Link
+          <a
+            href={`${getConfig().PUBLIC_PATH}course/${courseId}/home`}
             className="flex-shrink-0 text-primary"
-            to={`/course/${courseId}/home`}
           >
             <FontAwesomeIcon icon={faHome} className="mr-2" />
             <FormattedMessage
@@ -139,7 +138,7 @@ export default function CourseBreadcrumbs({
               description="The course home link in breadcrumbs nav"
               defaultMessage="Course"
             />
-          </Link>
+          </a>
         </li>
         {links.map(content => (
           <CourseBreadcrumb

--- a/src/courseware/course/CourseBreadcrumbs.test.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
-import { BrowserRouter } from 'react-router-dom';
 import { useModel, useModels } from '../../generic/model-store';
 import CourseBreadcrumbs from './CourseBreadcrumbs';
 
@@ -106,14 +105,12 @@ describe('CourseBreadcrumbs', () => {
     ],
   ]);
   render(
-    <BrowserRouter>
-      <CourseBreadcrumbs
-        courseId="course-v1:edX+DemoX+Demo_Course"
-        sectionId="block-v1:edX+DemoX+Demo_Course+type@chapter+block@interactive_demonstrations"
-        sequenceId="block-v1:edX+DemoX+Demo_Course+type@sequential+block@basic_questions"
-        isStaff
-      />
-    </BrowserRouter>,
+    <CourseBreadcrumbs
+      courseId="course-v1:edX+DemoX+Demo_Course"
+      sectionId="block-v1:edX+DemoX+Demo_Course+type@chapter+block@interactive_demonstrations"
+      sequenceId="block-v1:edX+DemoX+Demo_Course+type@sequential+block@basic_questions"
+      isStaff
+    />,
   );
   it('renders course breadcrumbs as expected', async () => {
     expect(screen.queryAllByRole('link')).toHaveLength(1);


### PR DESCRIPTION
fixes: https://github.com/mitodl/edx-platform/issues/285


### Description:

It makes sense to use the `<Link>` tag but in React the problem this creates is say you are on `/blah`, while clicking on your Link will go to `/page`, clicking on the `<a href='page' />` will take you to `/blah/page`

Reverting the the changes in the [PR](https://github.com/openedx/frontend-app-learning/commit/de49e8b2717023f12a29a08dda77bd4a66c5bb69) that had merged for `Link from router to fix path based routing` issue. With the `<Link>` tag react routes mapping has changed so when the call goes fetch sequences data then the [sequenceId here](https://github.com/openedx/frontend-app-learning/blob/master/src/courseware/CoursewareContainer.jsx#L88-L92) points to `vertical+block` (bit odd behaviour) and call failed to OpenEdx that is expecting a `sequential:usage+key` instead of a `vertical:usage+key`.

### Error Trace:

```
Internal Server Error: /api/courseware/sequence/block-v1:MITx+18.031r_7+2022_IAP+type@vertical+block@rec2-tab1
AttributeError at /api/courseware/sequence/block-v1:MITx+18.031r_7+2022_IAP+type@vertical+block@rec2-tab1
'VerticalBlockWithMixins' object has no attribute 'get_metadata'

Traceback (most recent call last):
 File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
   response = get_response(request)
 File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
   response = wrapped_callback(request, *callback_args, **callback_kwargs)
 File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/sentry_sdk/integrations/django/views.py", line 67, in sentry_wrapped_callback
   return callback(request, *args, **kwargs)
 File "/usr/lib/python3.8/contextlib.py", line 75, in inner
   return func(*args, **kwds)
 File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
   return view_func(*args, **kwargs)
 File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
   return self.dispatch(request, *args, **kwargs)
 File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
   response = self.handle_exception(exc)
 File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
   response = handler(request, *args, **kwargs)
 File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/courseware_api/views.py", line 591, in get
   return Response(sequence.get_metadata(view=view, context=context))

```
