### PR TITLE
fix: don't log errors when we ask for sequence metadata for units (#790)

### DIFF
--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -237,7 +237,13 @@ export function fetchSequence(sequenceId) {
         dispatch(fetchSequenceSuccess({ sequenceId }));
       }
     } catch (error) {
-      logError(error);
+      // Some errors are expected - for example, CoursewareContainer may request sequence metadata for a unit and rely
+      // on the request failing to notice that it actually does have a unit (mostly so it doesn't have to know anything
+      // about the opaque key structure). In such cases, the backend gives us a 422.
+      const isExpected = error.response && error.response.status === 422;
+      if (!isExpected) {
+        logError(error);
+      }
       dispatch(fetchSequenceFailure({ sequenceId }));
     }
   };


### PR DESCRIPTION
Fixes: https://github.com/openedx/build-test-release-wg/issues/129

After running Maple in production for a couple weeks, we began seeing errors link this in our logs:

```
Internal Server Error: /api/courseware/sequence/block-v1:MITx+18.031r_7+2022_IAP+type@vertical+block@rec2-tab1

AttributeError at /api/courseware/sequence/block-v1:MITx+18.031r_7+2022_IAP+type@vertical+block@rec2-tab1
'VerticalBlockWithMixins' object has no attribute 'get_metadata'
```

It seems to be associated with students experiencing timeouts when clicking the middle item in the Learner MFE breadcrumbs (the sequential).

[Demo: 'VerticalBlockWithMixins' object has no attribute 'get_metadata'](https://watch.screencastify.com/v/dpxV1PeOnIty1u8i8AwF)

After discussing in the [#frontend-working-group](https://openedx.slack.com/archives/C02BMP2RD5Y/p1641565532010500?thread_ts=1641565313.009300&cid=C02BMP2RD5Y) in Slack, it seems like it's been fixed in master by these two commits, one to the Learner MFE and one to edx-platform:

[edx/edx-platform@7123807](https://github.com/edx/edx-platform/commit/712380713b8fc3f46bcef1360fdbcf8c3b468208)
[openedx/frontend-app-learning@907892e](https://github.com/openedx/frontend-app-learning/commit/907892e7bb1263d6b9b56d8acc7fe57abd34cbdd)

We should backport these changes to maple.