### PR TITLE
feat: add rtl support

### DIFF
--- a/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape, isRtl } from '@edx/frontend-platform/i18n';
 import { OverlayTrigger, Popover } from '@edx/paragon';
 
 import { useModel } from '../../../../generic/model-store';
@@ -23,6 +23,12 @@ function CurrentGradeTooltip({ intl, tooltipClassName }) {
 
   const currentGrade = Number((visiblePercent * 100).toFixed(0));
 
+  let currentGradeDirection = currentGrade < 50 ? '' : '-';
+
+  if (isRtl) {
+    currentGradeDirection = currentGrade < 50 ? '-' : '';
+  }
+
   return (
     <>
       <OverlayTrigger
@@ -37,16 +43,16 @@ function CurrentGradeTooltip({ intl, tooltipClassName }) {
         )}
       >
         <g>
-          <circle cx={`${Math.min(...[currentGrade, 100])}%`} cy="50%" r="8.5" fill="transparent" />
-          <rect className="grade-bar__divider" x={`${Math.min(...[currentGrade, 100])}%`} style={{ transform: 'translateY(2.61em)' }} />
+          <circle cx={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`} cy="50%" r="8.5" fill="transparent" />
+          <rect className="grade-bar__divider" x={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`} style={{ transform: 'translateY(2.61em)' }} />
         </g>
       </OverlayTrigger>
       <text
         className="x-small"
         textAnchor={currentGrade < 50 ? 'start' : 'end'}
-        x={`${Math.min(...[currentGrade, 100])}%`}
+        x={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`}
         y="20px"
-        style={{ transform: `translateX(${currentGrade < 50 ? '' : '-'}3.4em)` }}
+        style={{ transform: `translateX(${currentGradeDirection}3.4em)` }}
       >
         {intl.formatMessage(messages.currentGradeLabel)}
       </text>

--- a/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
-import { injectIntl, intlShape, isRtl } from '@edx/frontend-platform/i18n';
+import {
+  getLocale, injectIntl, intlShape, isRtl,
+} from '@edx/frontend-platform/i18n';
 import { OverlayTrigger, Popover } from '@edx/paragon';
 
 import { useModel } from '../../../../generic/model-store';
@@ -25,7 +27,9 @@ function CurrentGradeTooltip({ intl, tooltipClassName }) {
 
   let currentGradeDirection = currentGrade < 50 ? '' : '-';
 
-  if (isRtl) {
+  const isLocaleRtl = isRtl(getLocale());
+
+  if (isLocaleRtl) {
     currentGradeDirection = currentGrade < 50 ? '-' : '';
   }
 
@@ -43,14 +47,14 @@ function CurrentGradeTooltip({ intl, tooltipClassName }) {
         )}
       >
         <g>
-          <circle cx={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`} cy="50%" r="8.5" fill="transparent" />
-          <rect className="grade-bar__divider" x={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`} style={{ transform: 'translateY(2.61em)' }} />
+          <circle cx={`${Math.min(...[isLocaleRtl ? 100 - currentGrade : currentGrade, 100])}%`} cy="50%" r="8.5" fill="transparent" />
+          <rect className="grade-bar__divider" x={`${Math.min(...[isLocaleRtl ? 100 - currentGrade : currentGrade, 100])}%`} style={{ transform: 'translateY(2.61em)' }} />
         </g>
       </OverlayTrigger>
       <text
         className="x-small"
         textAnchor={currentGrade < 50 ? 'start' : 'end'}
-        x={`${Math.min(...[isRtl ? 100 - currentGrade : currentGrade, 100])}%`}
+        x={`${Math.min(...[isLocaleRtl ? 100 - currentGrade : currentGrade, 100])}%`}
         y="20px"
         style={{ transform: `translateX(${currentGradeDirection}3.4em)` }}
       >

--- a/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape, isRtl } from '@edx/frontend-platform/i18n';
 import { OverlayTrigger, Popover } from '@edx/paragon';
 
 import messages from '../messages';
 
 function PassingGradeTooltip({ intl, passingGrade, tooltipClassName }) {
+  let passingGradeDirection = passingGrade < 50 ? '' : '-';
+
+  if (isRtl) {
+    passingGradeDirection = passingGrade < 50 ? '-' : '';
+  }
+
   return (
     <>
       <OverlayTrigger
@@ -21,17 +27,17 @@ function PassingGradeTooltip({ intl, passingGrade, tooltipClassName }) {
         )}
       >
         <g>
-          <circle cx={`${passingGrade}%`} cy="50%" r="8.5" fill="transparent" />
-          <circle className="grade-bar--passing" cx={`${passingGrade}%`} cy="50%" r="4.5" />
+          <circle cx={`${isRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="8.5" fill="transparent" />
+          <circle className="grade-bar--passing" cx={`${isRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="4.5" />
         </g>
       </OverlayTrigger>
 
       <text
         className="x-small"
         textAnchor={passingGrade < 50 ? 'start' : 'end'}
-        x={`${passingGrade}%`}
+        x={`${isRtl ? 100 - passingGrade : passingGrade}%`}
         y="90px"
-        style={{ transform: `translateX(${passingGrade < 50 ? '' : '-'}3.4em)` }}
+        style={{ transform: `translateX(${passingGradeDirection}3.4em)` }}
       >
         {intl.formatMessage(messages.passingGradeLabel)}
       </text>

--- a/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/PassingGradeTooltip.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape, isRtl } from '@edx/frontend-platform/i18n';
+import {
+  getLocale, injectIntl, intlShape, isRtl,
+} from '@edx/frontend-platform/i18n';
 import { OverlayTrigger, Popover } from '@edx/paragon';
 
 import messages from '../messages';
 
 function PassingGradeTooltip({ intl, passingGrade, tooltipClassName }) {
+  const isLocaleRtl = isRtl(getLocale());
+
   let passingGradeDirection = passingGrade < 50 ? '' : '-';
 
-  if (isRtl) {
+  if (isLocaleRtl) {
     passingGradeDirection = passingGrade < 50 ? '-' : '';
   }
 
@@ -27,15 +31,15 @@ function PassingGradeTooltip({ intl, passingGrade, tooltipClassName }) {
         )}
       >
         <g>
-          <circle cx={`${isRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="8.5" fill="transparent" />
-          <circle className="grade-bar--passing" cx={`${isRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="4.5" />
+          <circle cx={`${isLocaleRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="8.5" fill="transparent" />
+          <circle className="grade-bar--passing" cx={`${isLocaleRtl ? 100 - passingGrade : passingGrade}%`} cy="50%" r="4.5" />
         </g>
       </OverlayTrigger>
 
       <text
         className="x-small"
         textAnchor={passingGrade < 50 ? 'start' : 'end'}
-        x={`${isRtl ? 100 - passingGrade : passingGrade}%`}
+        x={`${isLocaleRtl ? 100 - passingGrade : passingGrade}%`}
         y="90px"
         style={{ transform: `translateX(${passingGradeDirection}3.4em)` }}
       >


### PR DESCRIPTION
Backport PR https://github.com/openedx/frontend-app-learning/pull/783 and https://github.com/openedx/frontend-app-learning/pull/804 to `open-release/maple.master`.

- Add RTL support for the chart on the progress tab.
Description: When the user uses the Arabic language, which requires adaptation of the site for RTL, the progress graph does not adapt and is static for the RTL & LTR versions.
- fix: RTL bug on progress tab
![image](https://user-images.githubusercontent.com/17108583/149752380-ae3ca4a0-a0cf-4d96-b22a-ef3991a1b414.png)
