### PR TITLE
chore: bump frontend-lib-special-exams to 1.15.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4060,9 +4060,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.15.2.tgz",
-      "integrity": "sha512-44s7cuyQbUjTq39GvvfJhvjkBLoPFnwfQ+Z431spbRLrAbsBCEh96qoNnSAyTGB68khJqbplpmEwwHGA9EyOUg==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.15.3.tgz",
+      "integrity": "sha512-rMAGDsj0O5m5cAnGyD+E70EUW/rWggrSsqfl1QzJDZAUG1x7Q+nwbV/01J3JqeJLzYnsxLWpP8rqnNUWPdg57w==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-enterprise-utils": "1.1.1",
-    "@edx/frontend-lib-special-exams": "1.15.2",
+    "@edx/frontend-lib-special-exams": "1.15.3",
     "@edx/frontend-platform": "1.14.3",
     "@edx/paragon": "16.19.0",
     "@edx/frontend-component-header": "^2.4.2",


### PR DESCRIPTION
Update for more user-friendly errors: https://github.com/edx/frontend-lib-special-exams/pull/58