### PR TITLE
fix: AA-1194: Update the breadcrumb link

### DIFF
--- a/src/courseware/course/CourseBreadcrumbs.jsx
+++ b/src/courseware/course/CourseBreadcrumbs.jsx
@@ -15,8 +15,7 @@ import JumpNavMenuItem from './JumpNavMenuItem';
 function CourseBreadcrumb({
   content, withSeparator, courseId, sequenceId, unitId, isStaff,
 }) {
-  const defaultContent = content.filter(destination => destination.default)[0] || { id: courseId, label: '' };
-
+  const defaultContent = content.filter(destination => destination.default)[0] || { id: courseId, label: '', sequences: [] };
   return (
     <>
       {withSeparator && (
@@ -33,7 +32,9 @@ function CourseBreadcrumb({
           ? (
             <Link
               className="text-primary-500"
-              to={`/course/${courseId}/${defaultContent.id}`}
+              to={defaultContent.sequences.length
+                ? `/course/${courseId}/${defaultContent.sequences[0].id}`
+                : `/course/${courseId}/${defaultContent.id}`}
             >
               {defaultContent.label}
             </Link>


### PR DESCRIPTION
Before, for sections, it would link you to the chapter which would
cause a JS error since the sequence endpoint expects sequentials.
This updates to now link to the first subsection within a section when
you hit the section breadcrumb