### PR TITLE
fix: revert "fix: deny proctored exam access to audit and honor enrollment tracks (#828)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3966,9 +3966,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.15.4.tgz",
-      "integrity": "sha512-00klUabOLrulyHMfrvVm+2HsnDe3uwUjH80mJV+Yg+7+kVwz0LraUM5PHPuLR0zHFsajK49kttabJfZEOEBdtA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.15.3.tgz",
+      "integrity": "sha512-rMAGDsj0O5m5cAnGyD+E70EUW/rWggrSsqfl1QzJDZAUG1x7Q+nwbV/01J3JqeJLzYnsxLWpP8rqnNUWPdg57w==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-enterprise-utils": "1.1.1",
-    "@edx/frontend-lib-special-exams": "1.15.4",
+    "@edx/frontend-lib-special-exams": "1.15.3",
     "@edx/frontend-platform": "1.14.3",
     "@edx/paragon": "16.19.0",
     "@edx/frontend-component-header": "^2.4.2",

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -252,7 +252,6 @@ function Sequence({
           isStaff={course.isStaff}
           originalUserIsStaff={course.originalUserIsStaff}
           isIntegritySignatureEnabled={course.isIntegritySignatureEnabled}
-          canAccessProctoredExams={course.canAccessProctoredExams}
         >
           {defaultContent}
         </SequenceExamWrapper>

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -137,7 +137,6 @@ function normalizeMetadata(metadata) {
     isIntegritySignatureEnabled: data.is_integrity_signature_enabled,
     userNeedsIntegritySignature: data.user_needs_integrity_signature,
     isMasquerading: data.original_user_is_staff && !data.is_staff,
-    canAccessProctoredExams: data.can_access_proctored_exams,
   };
 }
 


### PR DESCRIPTION
### Description
This reverts commit 45d5141769bfa57ead8f9ce147cc51ee434d4141.

Found a bug in [the PR](https://github.com/openedx/frontend-app-learning/pull/828). This PR reverts that change.

@openedx/masters-devs-cosmonauts Please review quickly.

The bug was that, the [code at frontend-lib-special-exam](https://github.com/edx/frontend-lib-special-exams/blob/main/src/exam/Exam.jsx#L61), which is part of the version 1.15.4, is excluding too much. When the content type is not of an exam type, the variable examType has the value `""`. I need to only check against an array of proctored exam types.