### PR TITLE
fix: deny proctored exam access to audit and honor enrollment tracks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3966,9 +3966,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.15.3.tgz",
-      "integrity": "sha512-rMAGDsj0O5m5cAnGyD+E70EUW/rWggrSsqfl1QzJDZAUG1x7Q+nwbV/01J3JqeJLzYnsxLWpP8rqnNUWPdg57w==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.15.5.tgz",
+      "integrity": "sha512-uH7mMVuGZd6LKHYoMBrm+lZgcfr87LwpKBoHWixTRxGbwmPQ/MOdtHZnrQ41JmkJ4fdZRJ7v/kBDLZU6TsppPA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-enterprise-utils": "1.1.1",
-    "@edx/frontend-lib-special-exams": "1.15.3",
+    "@edx/frontend-lib-special-exams": "1.15.5",
     "@edx/frontend-platform": "1.14.3",
     "@edx/paragon": "16.19.0",
     "@edx/frontend-component-header": "^2.4.2",

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -252,6 +252,7 @@ function Sequence({
           isStaff={course.isStaff}
           originalUserIsStaff={course.originalUserIsStaff}
           isIntegritySignatureEnabled={course.isIntegritySignatureEnabled}
+          canAccessProctoredExams={course.canAccessProctoredExams}
         >
           {defaultContent}
         </SequenceExamWrapper>

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -137,6 +137,7 @@ function normalizeMetadata(metadata) {
     isIntegritySignatureEnabled: data.is_integrity_signature_enabled,
     userNeedsIntegritySignature: data.user_needs_integrity_signature,
     isMasquerading: data.original_user_is_staff && !data.is_staff,
+    canAccessProctoredExams: data.can_access_proctored_exams,
   };
 }
 


### PR DESCRIPTION
### Description
[MST-1273](https://openedx.atlassian.net/browse/MST-1273)  
We need to allow both Timed exams and non-exam types content to be rendered

@openedx/masters-devs-cosmonauts Please review