### PR TITLE
chore: update transifex scripts to api v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
-transifex_resource = frontend-app-learning
+export TRANSIFEX_RESOURCE=frontend-app-learning
 transifex_langs = "ar,fr,es_419,zh_CN"
 
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
-tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/translation/en/strings/
-tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/source/
 
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
@@ -38,11 +36,11 @@ push_translations:
 	# Pushing strings to Transifex...
 	tx push -s
 	# Fetching hashes from Transifex...
-	./node_modules/reactifex/bash_scripts/get_hashed_strings.sh $(tx_url1)
+	./node_modules/@edx/reactifex/bash_scripts/get_hashed_strings_v3.sh
 	# Writing out comments to file...
-	$(transifex_utils) $(transifex_temp) --comments
+	$(transifex_utils) $(transifex_temp) --comments --v3-scripts-path
 	# Pushing comments to Transifex...
-	./node_modules/reactifex/bash_scripts/put_comments.sh $(tx_url2)
+	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
 # Pulls translations from Transifex.
 pull_translations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4114,6 +4114,59 @@
         }
       }
     },
+    "@edx/reactifex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-1.0.3.tgz",
+      "integrity": "sha512-zJjD3ym4KOQ2sa+lwR08jgospMyiRTSRqK6Mxi1VMQ+sqxZxWFCGymV+mqLRPHPAJ/z+qhblsVuWeb0N9qI5ww==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "yargs": "^17.1.1"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "yargs": {
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "dev": true
+        }
+      }
+    },
     "@formatjs/ecma402-abstract": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz",
@@ -21193,12 +21246,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
-    },
-    "reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@edx/frontend-build": "9.0.6",
+    "@edx/reactifex": "1.0.3",
     "@pact-foundation/pact": "9.17.0",
     "@testing-library/dom": "7.16.3",
     "@testing-library/jest-dom": "5.16.2",
@@ -79,7 +80,6 @@
     "husky": "7.0.4",
     "jest": "27.5.1",
     "jest-chain": "1.1.5",
-    "reactifex": "1.1.1",
     "rosie": "2.1.0"
   }
 }


### PR DESCRIPTION
Transifex is sunsetting anything below v3 later this year. Let's get ahead of our scripts unexpectedly failing.

- Switch 'reactifex' dev dep to our maintained fork at   '@edx/reactifex' (it has an older released version number, but it's still maintained unlike the original)
- Update Makefile commands for new v3 transifex API

See https://github.com/openedx/frontend-app-support-tools/commit/4510b63dcecc711e347596e27f06f1ed4bec89b0 for a similar conversion - support-tools is only other repo using this version of the scripts.

The new script requires `TRANSIFEX_AUTH_TOKEN`, whereas the old scripts required `SECRET_USER` and `SECRET_PWD` to be set. I can't see where we set either in our edx.org scripting, so I'll assume that both versions are set somewhere, because support-tools is working fine. But this is the sort of thing that can only really be tested live, since I don't have an auth token locally to test this change with.