### PR TITLE
fix: guard access to a react ref before using it

### DIFF
--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -28,7 +28,9 @@ export default function LmsHtmlFragment({
 
   const iframe = useRef(null);
   function resetIframeHeight() {
-    iframe.current.height = iframe.current.contentWindow.document.body.scrollHeight;
+    if (iframe.current) {
+      iframe.current.height = iframe.current.contentWindow.document.body.scrollHeight;
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
This was causing some errors ever since we started using the ref in an event handler - I'm not entirely sure why the ref stops being valid, unless it's a lifecycle thing. But anyway, this seems to stop the error in testing.