### PR TITLE
fix: Update past expiration message URL in gated content

### DIFF
--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -65,6 +65,16 @@ function LockPaywall({
     });
   };
 
+  const logClickPastExpiration = () => {
+    sendTrackEvent('edx.bi.ecommerce.gated_content.past_expiration.link_clicked', {
+      ...eventProperties,
+      linkCategory: 'gated_content',
+      linkName: 'course_details',
+      linkType: 'link',
+      pageName: 'in_course',
+    });
+  };
+
   return (
     <Alert variant="light" aria-live="off" icon={Locked} className="lock-paywall-container">
       <div className="row">
@@ -75,7 +85,7 @@ function LockPaywall({
           {pastExpirationDeadline ? (
             <div className="mb-2 upgrade-intro">
               {intl.formatMessage(messages['learn.lockPaywall.content.pastExpiration'])}
-              <Hyperlink destination={marketingUrl} target="_blank">{intl.formatMessage(messages['learn.lockPaywall.courseDetails'])}</Hyperlink>
+              <Hyperlink destination={marketingUrl} onClick={logClickPastExpiration} target="_blank">{intl.formatMessage(messages['learn.lockPaywall.courseDetails'])}</Hyperlink>
             </div>
           ) : (
             <div className="mb-2 upgrade-intro">

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Alert, breakpoints, useWindowSize } from '@edx/paragon';
+import {
+  Alert, Hyperlink, breakpoints, useWindowSize,
+} from '@edx/paragon';
 import { Locked } from '@edx/paragon/icons';
 import messages from './messages';
 import certificateLocked from '../../../../generic/assets/edX_locked_certificate.png';
@@ -23,6 +25,8 @@ function LockPaywall({
 }) {
   const course = useModel('coursewareMeta', courseId);
   const {
+    accessExpiration,
+    marketingUrl,
     offer,
     org,
     verifiedMode,
@@ -38,6 +42,9 @@ function LockPaywall({
   const shouldDisplayGatedContentTwoColumnsHalf = useWindowSize().width <= breakpoints.large.minWidth
     && !notificationTrayVisible;
   const shouldWrapTextOnButton = useWindowSize().width > breakpoints.extraSmall.minWidth;
+
+  const accessExpirationDate = accessExpiration ? new Date(accessExpiration.expirationDate) : null;
+  const pastExpirationDeadline = accessExpiration ? new Date(Date.now()) > accessExpirationDate : false;
 
   if (!verifiedMode) {
     return null;
@@ -65,12 +72,18 @@ function LockPaywall({
           <h4 aria-level="3">
             <span>{intl.formatMessage(messages['learn.lockPaywall.title'])}</span>
           </h4>
+          {pastExpirationDeadline ? (
+            <div className="mb-2 upgrade-intro">
+              {intl.formatMessage(messages['learn.lockPaywall.content.pastExpiration'])}
+              <Hyperlink destination={marketingUrl} target="_blank">{intl.formatMessage(messages['learn.lockPaywall.courseDetails'])}</Hyperlink>
+            </div>
+          ) : (
+            <div className="mb-2 upgrade-intro">
+              {intl.formatMessage(messages['learn.lockPaywall.content'])}
+            </div>
+          )}
 
-          <div className="mb-2 upgrade-intro">
-            {intl.formatMessage(messages['learn.lockPaywall.content'])}
-          </div>
-
-          <div className={classNames('d-flex flex-row', { 'flex-wrap': notificationTrayVisible || shouldDisplayBulletPointsBelowCertificate })}>
+          <div className={classNames('d-inline-flex flex-row', { 'flex-wrap': notificationTrayVisible || shouldDisplayBulletPointsBelowCertificate })}>
             <div style={{ float: 'left' }} className="mr-3 mb-2">
               <img
                 alt={intl.formatMessage(messages['learn.lockPaywall.example.alt'])}
@@ -94,20 +107,24 @@ function LockPaywall({
           </div>
         </div>
 
-        <div
-          className={
-            classNames('d-md-flex align-items-md-center text-right', {
-              'col-md-5 mx-md-0': notificationTrayVisible, 'col-md-4 mx-md-3 justify-content-center': !notificationTrayVisible && !shouldDisplayGatedContentTwoColumnsHalf, 'col-md-11 justify-content-end': shouldDisplayGatedContentOneColumn && !shouldDisplayGatedContentTwoColumns, 'col-md-6 justify-content-center': shouldDisplayGatedContentTwoColumnsHalf,
-            })
-          }
-        >
-          <UpgradeButton
-            offer={offer}
-            onClick={logClick}
-            verifiedMode={verifiedMode}
-            style={{ whiteSpace: shouldWrapTextOnButton ? 'nowrap' : null }}
-          />
-        </div>
+        {pastExpirationDeadline
+          ? null
+          : (
+            <div
+              className={
+                classNames('d-md-flex align-items-md-center text-right', {
+                  'col-md-5 mx-md-0': notificationTrayVisible, 'col-md-4 mx-md-3 justify-content-center': !notificationTrayVisible && !shouldDisplayGatedContentTwoColumnsHalf, 'col-md-11 justify-content-end': shouldDisplayGatedContentOneColumn && !shouldDisplayGatedContentTwoColumns, 'col-md-6 justify-content-center': shouldDisplayGatedContentTwoColumnsHalf,
+                })
+              }
+            >
+              <UpgradeButton
+                offer={offer}
+                onClick={logClick}
+                verifiedMode={verifiedMode}
+                style={{ whiteSpace: shouldWrapTextOnButton ? 'nowrap' : null }}
+              />
+            </div>
+          )}
       </div>
     </Alert>
   );

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -69,7 +69,7 @@ function LockPaywall({
     sendTrackEvent('edx.bi.ecommerce.gated_content.past_expiration.link_clicked', {
       ...eventProperties,
       linkCategory: 'gated_content',
-      linkName: 'course_details',
+      linkName: 'search_courses',
       linkType: 'link',
       pageName: 'in_course',
     });

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
@@ -26,7 +27,6 @@ function LockPaywall({
   const course = useModel('coursewareMeta', courseId);
   const {
     accessExpiration,
-    marketingUrl,
     offer,
     org,
     verifiedMode,
@@ -85,7 +85,7 @@ function LockPaywall({
           {pastExpirationDeadline ? (
             <div className="mb-2 upgrade-intro">
               {intl.formatMessage(messages['learn.lockPaywall.content.pastExpiration'])}
-              <Hyperlink destination={marketingUrl} onClick={logClickPastExpiration} target="_blank">{intl.formatMessage(messages['learn.lockPaywall.courseDetails'])}</Hyperlink>
+              <Hyperlink destination={`${getConfig().MARKETING_SITE_BASE_URL}/search?tab=course`} onClick={logClickPastExpiration} target="_blank">{intl.formatMessage(messages['learn.lockPaywall.exploreAll'])}</Hyperlink>
             </div>
           ) : (
             <div className="mb-2 upgrade-intro">

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.scss
@@ -1,5 +1,6 @@
 .alert-content.lock-paywall-container {
     display: inline-flex;
+    width: 100%;
 }
 
 .lock-paywall-container svg {

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
@@ -94,4 +94,28 @@ describe('Lock Paywall', () => {
     expect(screen.getByText('View Course Details'))
       .toHaveAttribute('href', 'https://example.com/course-details');
   });
+
+  it('sends analytics event onClick of past expiration course details link', async () => {
+    sendTrackEvent.mockClear();
+    const courseMetadata = Factory.build('courseMetadata', {
+      access_expiration: {
+        expiration_date: '1995-02-22T05:00:00Z',
+      },
+      marketing_url: 'https://example.com/course-details',
+    });
+    const testStore = await initializeTestStore({ courseMetadata }, false);
+    render(<LockPaywall {...mockData} courseId={courseMetadata.id} />, { store: testStore });
+    const courseDetailsLink = await screen.getByText('View Course Details');
+    fireEvent.click(courseDetailsLink);
+
+    expect(sendTrackEvent).toHaveBeenCalledTimes(1);
+    expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.gated_content.past_expiration.link_clicked', {
+      org_key: 'edX',
+      courserun_key: mockData.courseId,
+      linkCategory: 'gated_content',
+      linkName: 'course_details',
+      linkType: 'link',
+      pageName: 'in_course',
+    });
+  });
 });

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
@@ -110,7 +110,7 @@ describe('Lock Paywall', () => {
       org_key: 'edX',
       courserun_key: mockData.courseId,
       linkCategory: 'gated_content',
-      linkName: 'course_details',
+      linkName: 'search_courses',
       linkType: 'link',
       pageName: 'in_course',
     });

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
@@ -86,13 +86,11 @@ describe('Lock Paywall', () => {
       access_expiration: {
         expiration_date: '1995-02-22T05:00:00Z',
       },
-      marketing_url: 'https://example.com/course-details',
     });
     const testStore = await initializeTestStore({ courseMetadata }, false);
     render(<LockPaywall {...mockData} courseId={courseMetadata.id} />, { store: testStore });
     expect(screen.getByText('The upgrade deadline for this course passed. To upgrade, enroll in the next available session.')).toBeInTheDocument();
-    expect(screen.getByText('View Course Details'))
-      .toHaveAttribute('href', 'https://example.com/course-details');
+    expect(screen.getByText('Explore all courses'));
   });
 
   it('sends analytics event onClick of past expiration course details link', async () => {
@@ -101,11 +99,10 @@ describe('Lock Paywall', () => {
       access_expiration: {
         expiration_date: '1995-02-22T05:00:00Z',
       },
-      marketing_url: 'https://example.com/course-details',
     });
     const testStore = await initializeTestStore({ courseMetadata }, false);
     render(<LockPaywall {...mockData} courseId={courseMetadata.id} />, { store: testStore });
-    const courseDetailsLink = await screen.getByText('View Course Details');
+    const courseDetailsLink = await screen.getByText('Explore all courses');
     fireEvent.click(courseDetailsLink);
 
     expect(sendTrackEvent).toHaveBeenCalledTimes(1);

--- a/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
+++ b/src/courseware/course/sequence/lock-paywall/LockPaywall.test.jsx
@@ -80,4 +80,18 @@ describe('Lock Paywall', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('displays past expiration message if expiration date has expired', async () => {
+    const courseMetadata = Factory.build('courseMetadata', {
+      access_expiration: {
+        expiration_date: '1995-02-22T05:00:00Z',
+      },
+      marketing_url: 'https://example.com/course-details',
+    });
+    const testStore = await initializeTestStore({ courseMetadata }, false);
+    render(<LockPaywall {...mockData} courseId={courseMetadata.id} />, { store: testStore });
+    expect(screen.getByText('The upgrade deadline for this course passed. To upgrade, enroll in the next available session.')).toBeInTheDocument();
+    expect(screen.getByText('View Course Details'))
+      .toHaveAttribute('href', 'https://example.com/course-details');
+  });
 });

--- a/src/courseware/course/sequence/lock-paywall/messages.js
+++ b/src/courseware/course/sequence/lock-paywall/messages.js
@@ -16,10 +16,10 @@ const messages = defineMessages({
     defaultMessage: 'The upgrade deadline for this course passed. To upgrade, enroll in the next available session. ',
     description: 'Message shown to indicate that a piece of content is unavailable to audit track users in a course where the expiration deadline has passed.',
   },
-  'learn.lockPaywall.courseDetails': {
-    id: 'learn.lockPaywall.courseDetails',
-    defaultMessage: 'View Course Details',
-    description: 'Link to the course details page for this course with a past expiration date.',
+  'learn.lockPaywall.exploreAll': {
+    id: 'learn.lockPaywall.exploreAll',
+    defaultMessage: 'Explore all courses',
+    description: 'Link to the search page if past access expiration date',
   },
   'learn.lockPaywall.example.alt': {
     id: 'learn.lockPaywall.example.alt',

--- a/src/courseware/course/sequence/lock-paywall/messages.js
+++ b/src/courseware/course/sequence/lock-paywall/messages.js
@@ -11,6 +11,16 @@ const messages = defineMessages({
     defaultMessage: 'Upgrade to gain access to locked features like this one and get the most out of your course.',
     description: 'Message shown to indicate that a piece of content is unavailable to audit track users.',
   },
+  'learn.lockPaywall.content.pastExpiration': {
+    id: 'learn.lockPaywall.content.pastExpiration',
+    defaultMessage: 'The upgrade deadline for this course passed. To upgrade, enroll in the next available session. ',
+    description: 'Message shown to indicate that a piece of content is unavailable to audit track users in a course where the expiration deadline has passed.',
+  },
+  'learn.lockPaywall.courseDetails': {
+    id: 'learn.lockPaywall.courseDetails',
+    defaultMessage: 'View Course Details',
+    description: 'Link to the course details page for this course with a past expiration date.',
+  },
   'learn.lockPaywall.example.alt': {
     id: 'learn.lockPaywall.example.alt',
     defaultMessage: 'Example Certificate',

--- a/src/courseware/data/__factories__/courseMetadata.factory.js
+++ b/src/courseware/data/__factories__/courseMetadata.factory.js
@@ -6,6 +6,9 @@ Factory.define('courseMetadata')
   .extend(courseMetadataBase)
   .option('host', '')
   .attrs({
+    access_expiration: {
+      expiration_date: '2032-02-22T05:00:00Z',
+    },
     content_type_gating_enabled: false,
     course_expired_message: null,
     course_goals: {


### PR DESCRIPTION
Back up for https://github.com/openedx/frontend-app-learning/pull/836/ if `marketingUrl` is not the URL we're looking for (course details).
This is part of [REV-2500](https://github.com/openedx/frontend-app-learning/pull/836/).