### PR TITLE
fix: Improve Guard for Iframe resize

### DIFF
--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -28,7 +28,7 @@ export default function LmsHtmlFragment({
 
   const iframe = useRef(null);
   function resetIframeHeight() {
-    if (iframe.current) {
+    if (iframe?.current?.contentWindow?.document?.body) {
       iframe.current.height = iframe.current.contentWindow.document.body.scrollHeight;
     }
   }


### PR DESCRIPTION
Fix line that was causing JS errors when it was called in a context without a valid document