### PR TITLE
fix: [AA-1219] Crash when locked content rendered without unit ID

### DIFF
--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
@@ -69,8 +69,13 @@ UnitButton.defaultProps = {
   showCompletion: true,
 };
 
-const mapStateToProps = (state, props) => ({
-  ...state.models.units[props.unitId],
-});
+const mapStateToProps = (state, props) => {
+  if (props.unitId) {
+    return {
+      ...state.models.units[props.unitId],
+    };
+  }
+  return {};
+};
 
 export default connect(mapStateToProps)(UnitButton);


### PR DESCRIPTION
Allows SequenceNavigation to complete rendering even if unitId is not provided.

Currently, the page crashes when trying to show that a page is locked content. This change aligns with other work to allow the UnitButton to render even if it does not have a unitId.