### PR TITLE
feat: add discussions tab [BD-38] [TNL-9743]

### DIFF
--- a/src/course-home/discussion-tab/DiscussionTab.jsx
+++ b/src/course-home/discussion-tab/DiscussionTab.jsx
@@ -1,15 +1,25 @@
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl } from '@edx/frontend-platform/i18n';
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useIFrameHeight } from '../../generic/hooks';
+import { generatePath, useHistory } from 'react-router';
+import { useParams } from 'react-router-dom';
+import { useIFrameHeight, useIFramePluginEvents } from '../../generic/hooks';
 
 function DiscussionTab() {
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useSelector(state => state.courseHome);
+  const { path } = useParams();
+  const [originalPath] = useState(path);
+  const history = useHistory();
+
   const [, iFrameHeight] = useIFrameHeight();
-  const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}`;
+  useIFramePluginEvents({
+    'discussions.navigate': (payload) => {
+      const basePath = generatePath('/course/:courseId/discussion', { courseId });
+      history.push(`${basePath}/${payload.path}`);
+    },
+  });
+  const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}/${originalPath}`;
   return (
     <iframe
       src={discussionsUrl}

--- a/src/course-home/discussion-tab/DiscussionTab.jsx
+++ b/src/course-home/discussion-tab/DiscussionTab.jsx
@@ -1,0 +1,26 @@
+import { getConfig } from '@edx/frontend-platform';
+import { injectIntl } from '@edx/frontend-platform/i18n';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useIFrameHeight } from '../../generic/hooks';
+
+function DiscussionTab() {
+  const {
+    courseId,
+  } = useSelector(state => state.courseHome);
+  const [, iFrameHeight] = useIFrameHeight();
+  const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}`;
+  return (
+    <iframe
+      src={discussionsUrl}
+      className="d-flex w-100 border-0"
+      height={iFrameHeight}
+      style={{ minHeight: '60rem' }}
+      title="discussion"
+    />
+  );
+}
+
+DiscussionTab.propTypes = {};
+
+export default injectIntl(DiscussionTab);

--- a/src/course-home/discussion-tab/DiscussionTab.test.jsx
+++ b/src/course-home/discussion-tab/DiscussionTab.test.jsx
@@ -1,0 +1,61 @@
+import { getConfig, history } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { AppProvider } from '@edx/frontend-platform/react';
+import { render } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import React from 'react';
+import { Route } from 'react-router';
+import { Factory } from 'rosie';
+import { UserMessagesProvider } from '../../generic/user-messages';
+import {
+  initializeMockApp, messageEvent, screen, waitFor,
+} from '../../setupTest';
+import initializeStore from '../../store';
+import { TabContainer } from '../../tab-page';
+import { appendBrowserTimezoneToUrl } from '../../utils';
+import { fetchDiscussionTab } from '../data/thunks';
+import DiscussionTab from './DiscussionTab';
+
+initializeMockApp();
+jest.mock('@edx/frontend-platform/analytics');
+
+describe('DiscussionTab', () => {
+  let axiosMock;
+  let store;
+  let component;
+
+  beforeEach(() => {
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    store = initializeStore();
+    component = (
+      <AppProvider store={store}>
+        <UserMessagesProvider>
+          <Route path="/course/:courseId/discussion">
+            <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
+              <DiscussionTab />
+            </TabContainer>
+          </Route>
+        </UserMessagesProvider>
+      </AppProvider>
+    );
+  });
+
+  const courseMetadata = Factory.build('courseHomeMetadata', { user_timezone: 'America/New_York' });
+  const { id: courseId } = courseMetadata;
+
+  let courseMetadataUrl = `${getConfig().LMS_BASE_URL}/api/course_home/course_metadata/${courseId}`;
+  courseMetadataUrl = appendBrowserTimezoneToUrl(courseMetadataUrl);
+
+  beforeEach(() => {
+    axiosMock.onGet(courseMetadataUrl).reply(200, courseMetadata);
+    history.push(`/course/${courseId}/discussion`); // so tab can pull course id from url
+
+    render(component);
+  });
+
+  it('resizes when it gets a size hint from iframe', async () => {
+    window.postMessage({ ...messageEvent, payload: { height: 1234 } }, '*');
+    await waitFor(() => expect(screen.getByTitle('discussion'))
+      .toHaveAttribute('height', String(1234)));
+  });
+});

--- a/src/courseware/course/sidebar/common/SidebarBase.jsx
+++ b/src/courseware/course/sidebar/common/SidebarBase.jsx
@@ -88,7 +88,7 @@ SidebarBase.propTypes = {
   title: PropTypes.string.isRequired,
   ariaLabel: PropTypes.string.isRequired,
   sidebarId: PropTypes.string.isRequired,
-  className: PropTypes.string.isRequired,
+  className: PropTypes.string,
   children: PropTypes.element.isRequired,
   showTitleBar: PropTypes.bool,
   width: PropTypes.string,
@@ -97,6 +97,7 @@ SidebarBase.propTypes = {
 SidebarBase.defaultProps = {
   width: '31rem',
   showTitleBar: true,
+  className: '',
 };
 
 export default injectIntl(SidebarBase);

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -16,7 +16,7 @@ function DiscussionsSidebar({ intl }) {
     courseId,
   } = useContext(SidebarContext);
   const topic = useModel('discussionTopics', unitId);
-  if (!topic) {
+  if (!topic?.id) {
     return null;
   }
   const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}/topics/${topic.id}`;
@@ -31,8 +31,6 @@ function DiscussionsSidebar({ intl }) {
       <iframe
         src={`${discussionsUrl}?inContext`}
         className="d-flex w-100 border-0"
-        // Need to set minHeight so there is enough space for the add post UI
-        // TODO: Use postMessage API to dynamically update iframe size.
         style={{ minHeight: '60rem' }}
         title={intl.formatMessage(messages.discussionsTitle)}
       />

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.test.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.test.jsx
@@ -1,0 +1,69 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import MockAdapter from 'axios-mock-adapter';
+import React from 'react';
+import {
+  initializeMockApp, initializeTestStore, render, screen,
+} from '../../../../../setupTest';
+import { executeThunk } from '../../../../../utils';
+import { buildTopicsFromUnits } from '../../../../data/__factories__/discussionTopics.factory';
+import { getCourseDiscussionTopics } from '../../../../data/thunks';
+import SidebarContext from '../../SidebarContext';
+import DiscussionsSidebar from './DiscussionsSidebar';
+
+initializeMockApp();
+
+describe('Discussions Trigger', () => {
+  let axiosMock;
+  let mockData;
+  let courseId;
+  let unitId;
+
+  beforeEach(async () => {
+    const store = await initializeTestStore({
+      excludeFetchCourse: false,
+      excludeFetchSequence: false,
+    });
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    const state = store.getState();
+    courseId = state.courseware.courseId;
+    [unitId] = Object.keys(state.models.units);
+
+    mockData = {
+      courseId,
+      unitId,
+      currentSidebar: 'DISCUSSIONS',
+    };
+
+    axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/discussion/v1/courses/${courseId}`).reply(
+      200,
+      {
+        provider: 'openedx',
+      },
+    );
+    axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/discussion/v2/course_topics/${courseId}`)
+      .reply(200, buildTopicsFromUnits(state.models.units));
+    await executeThunk(getCourseDiscussionTopics(courseId), store.dispatch);
+  });
+
+  function renderWithProvider(testData = {}) {
+    const { container } = render(
+      <SidebarContext.Provider value={{ ...mockData, ...testData }}>
+        <DiscussionsSidebar />
+      </SidebarContext.Provider>,
+    );
+    return container;
+  }
+
+  it('should show up if unit discussions associated with it', async () => {
+    renderWithProvider();
+    expect(screen.queryByTitle('Discussions')).toBeInTheDocument();
+    expect(screen.queryByTitle('Discussions'))
+      .toHaveAttribute('src', `http://localhost:2002/${courseId}/topics/topic-1?inContext`);
+  });
+
+  it('should show nothing if unit has no discussions associated with it', async () => {
+    renderWithProvider({ unitId: 'no-discussion' });
+    expect(screen.queryByTitle('Discussions')).not.toBeInTheDocument();
+  });
+});

--- a/src/generic/hooks.js
+++ b/src/generic/hooks.js
@@ -24,7 +24,7 @@ export function useEventListener(type, handler) {
 
 /**
  * Hooks up post messages to callbacks
- * @param {string:function} events A mapping of message type to callback
+ * @param {Object.<string, function>} events A mapping of message type to callback
  */
 export function useIFramePluginEvents(events) {
   const receiveMessage = useCallback(({ data }) => {
@@ -44,7 +44,7 @@ export function useIFramePluginEvents(events) {
  * @param onIframeLoaded A callback for when the frame is loaded
  * @returns {[boolean, number]}
  */
-export function useIFrameHeight(onIframeLoaded) {
+export function useIFrameHeight(onIframeLoaded = null) {
   const [iframeHeight, setIframeHeight] = useState(null);
   const [hasLoaded, setHasLoaded] = useState(false);
   const receiveResizeMessage = useCallback(({ height }) => {

--- a/src/generic/hooks.test.jsx
+++ b/src/generic/hooks.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { useEventListener, useIFrameHeight } from './hooks';
+
+describe('Hooks', () => {
+  test('useEventListener', async () => {
+    const handler = jest.fn();
+    const TestComponent = () => {
+      useEventListener('message', handler);
+      return (<div data-testid="testid" />);
+    };
+    render(<TestComponent />);
+
+    await screen.findByTestId('testid');
+    window.postMessage({ test: 'test' }, '*');
+    await waitFor(() => expect(handler).toHaveBeenCalled());
+  });
+  test('useIFrameHeight', async () => {
+    const onLoaded = jest.fn();
+    const TestComponent = () => {
+      const [hasLoaded, height] = useIFrameHeight(onLoaded);
+      return (
+        <div data-testid="testid">
+          <span data-testid="loaded">
+            {String(hasLoaded)}
+          </span>
+          <span data-testid="height">
+            {String(height)}
+          </span>
+        </div>
+      );
+    };
+    render(<TestComponent />);
+
+    await screen.findByTestId('testid');
+    expect(screen.getByTestId('loaded')).toHaveTextContent('false');
+    expect(screen.getByTestId('height')).toHaveTextContent('null');
+    window.postMessage({
+      type: 'plugin.resize',
+      payload: { height: 1234 },
+    }, '*');
+    await waitFor(() => expect(onLoaded).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId('loaded')).toHaveTextContent('true'));
+    expect(screen.getByTestId('height')).toHaveTextContent('1234');
+  });
+});

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -53,7 +53,7 @@ subscribe(APP_READY, () => {
                   <DatesTab />
                 </TabContainer>
               </PageRoute>
-              <PageRoute path="/course/:courseId/discussion">
+              <PageRoute path="/course/:courseId/discussion/:path*">
                 <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
                   <DiscussionTab />
                 </TabContainer>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,6 +12,8 @@ import { Switch } from 'react-router-dom';
 
 import { messages as footerMessages } from '@edx/frontend-component-footer';
 import { messages as headerMessages } from '@edx/frontend-component-header';
+import { fetchDiscussionTab } from './course-home/data/thunks';
+import DiscussionTab from './course-home/discussion-tab/DiscussionTab';
 
 import appMessages from './i18n';
 import { UserMessagesProvider } from './generic/user-messages';
@@ -49,6 +51,11 @@ subscribe(APP_READY, () => {
               <PageRoute path="/course/:courseId/dates">
                 <TabContainer tab="dates" fetch={fetchDatesTab} slice="courseHome">
                   <DatesTab />
+                </TabContainer>
+              </PageRoute>
+              <PageRoute path="/course/:courseId/discussion">
+                <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
+                  <DiscussionTab />
                 </TabContainer>
               </PageRoute>
               <PageRoute


### PR DESCRIPTION
Adds code for the discussions tab, making it dynamically resize based on contents using a postMessage API.

**Test instructions**:
- [Optional] check out https://github.com/openedx/edx-platform/pull/30109 and enable the flag for new discussion structure.
- Visit http://localhost:2000/course/<course-id>/discussion
- It should load the discussions MFE in an iframe
- Checkout this PR of the discussions MFE: https://github.com/openedx/frontend-app-discussions/pull/100
- The iframe should now dynamically resize based on the content. 


https://user-images.githubusercontent.com/118837/160090506-c31f5e35-4d27-451f-af89-f02419b5126d.mp4


