### PR TITLE
chore: upgrade special exams lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3946,9 +3946,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.15.5.tgz",
-      "integrity": "sha512-uH7mMVuGZd6LKHYoMBrm+lZgcfr87LwpKBoHWixTRxGbwmPQ/MOdtHZnrQ41JmkJ4fdZRJ7v/kBDLZU6TsppPA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-1.16.0.tgz",
+      "integrity": "sha512-P7+RJbgSA2JPmYYDiMZcXpLD0N27D9/Fh++wszYO6p+rUxxwPSzjLAHbBJhumdymItJ51MvZ6xhb/ArZh9IrDw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.2.2",
     "@edx/frontend-component-header": "2.4.5",
-    "@edx/frontend-lib-special-exams": "1.15.5",
+    "@edx/frontend-lib-special-exams": "1.16.0",
     "@edx/frontend-platform": "1.15.6",
     "@edx/paragon": "19.13.6",
     "@fortawesome/fontawesome-svg-core": "1.3.0",

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -221,7 +221,6 @@ function Sequence({
           courseId={courseId}
           isStaff={isStaff}
           originalUserIsStaff={originalUserIsStaff}
-          isIntegritySignatureEnabled={course.isIntegritySignatureEnabled}
           canAccessProctoredExams={course.canAccessProctoredExams}
         >
           {defaultContent}

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -122,7 +122,6 @@ function normalizeMetadata(metadata) {
     verificationStatus: data.verification_status,
     linkedinAddToProfileUrl: data.linkedin_add_to_profile_url,
     relatedPrograms: camelCaseObject(data.related_programs),
-    isIntegritySignatureEnabled: data.is_integrity_signature_enabled,
     userNeedsIntegritySignature: data.user_needs_integrity_signature,
     canAccessProctoredExams: data.can_access_proctored_exams,
   };


### PR DESCRIPTION
Upgrade to the latest version of the special exams lib, which removes IDV as a prerequisite to proctored exams.