### PR TITLE
fix: [MICROBA-1769] Cert status before course end

### DIFF
--- a/src/course-home/data/__factories__/courseHomeMetadata.factory.js
+++ b/src/course-home/data/__factories__/courseHomeMetadata.factory.js
@@ -10,6 +10,7 @@ Factory.define('courseHomeMetadata')
     is_enrolled: false,
     is_staff: false,
     can_load_courseware: true,
+    can_view_certificate: true,
     celebrations: null,
     course_access: {
       additional_context_user_message: null,

--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -22,6 +22,7 @@ Object {
     "courseHomeMeta": Object {
       "course-v1:edX+DemoX+Demo_Course": Object {
         "canLoadCourseware": true,
+        "canViewCertificate": true,
         "celebrations": null,
         "courseAccess": Object {
           "additionalContextUserMessage": null,
@@ -340,6 +341,7 @@ Object {
     "courseHomeMeta": Object {
       "course-v1:edX+DemoX+Demo_Course": Object {
         "canLoadCourseware": true,
+        "canViewCertificate": true,
         "celebrations": null,
         "courseAccess": Object {
           "additionalContextUserMessage": null,
@@ -538,6 +540,7 @@ Object {
     "courseHomeMeta": Object {
       "course-v1:edX+DemoX+Demo_Course": Object {
         "canLoadCourseware": true,
+        "canViewCertificate": true,
         "celebrations": null,
         "courseAccess": Object {
           "additionalContextUserMessage": null,

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -22,6 +22,8 @@ function CertificateStatus({ intl }) {
   const {
     isEnrolled,
     org,
+    canViewCertificate,
+    isSelfPaced,
   } = useModel('courseHomeMeta', courseId);
 
   const {
@@ -45,6 +47,8 @@ function CertificateStatus({ intl }) {
     hasScheduledContent,
     isEnrolled,
     userHasPassingGrade,
+    null, // CourseExitPageIsActive
+    canViewCertificate || isSelfPaced,
   );
 
   const eventProperties = {
@@ -156,7 +160,7 @@ function CertificateStatus({ intl }) {
         certAvailabilityDate = <FormattedDate value={certificateAvailableDate} day="numeric" month="long" year="numeric" />;
         body = (
           <FormattedMessage
-            id="courseCelebration.certificateBody.notAvailable.endDate"
+            id="courseCelebration.certificateBody.notAvailable.certificateAvailableDate"
             defaultMessage="This course ends on {endDate}. Final grades and any earned certificates are
             scheduled to be available after {certAvailabilityDate}."
             description="This shown for leaner when they are eligible for certifcate but it't not available yet, it could because leaners just finished the course quickly!"
@@ -178,10 +182,22 @@ function CertificateStatus({ intl }) {
         }
         break;
 
-      // This code shouldn't be hit but coding defensively since switch expects a default statement
       default:
-        certCase = null;
-        certEventName = 'no_certificate_status';
+        // if user completes a course before certificates are available, treat it as notAvailable
+        // regardless of passing or nonpassing status
+        if (!canViewCertificate && !isSelfPaced) {
+          certCase = 'notAvailable';
+          endDate = intl.formatDate(end, {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          });
+          body = intl.formatMessage(messages.notAvailableEndDateBody, { endDate });
+        } else {
+          // This code shouldn't be hit but coding defensively since switch expects a default statement
+          certCase = null;
+          certEventName = 'no_certificate_status';
+        }
         break;
     }
   }

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -23,6 +23,7 @@ function CertificateStatus({ intl }) {
     isEnrolled,
     org,
     canViewCertificate,
+    userTimezone,
   } = useModel('courseHomeMeta', courseId);
 
   const {
@@ -61,6 +62,7 @@ function CertificateStatus({ intl }) {
   let certStatus;
   let certWebViewUrl;
   let downloadUrl;
+  const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
 
   if (certificateData) {
     certStatus = certificateData.certStatus;
@@ -190,6 +192,8 @@ function CertificateStatus({ intl }) {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
+          }, {
+            ...timezoneFormatArgs,
           });
           body = intl.formatMessage(messages.notAvailableEndDateBody, { endDate });
         }

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -192,7 +192,6 @@ function CertificateStatus({ intl }) {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
-          }, {
             ...timezoneFormatArgs,
           });
           body = intl.formatMessage(messages.notAvailableEndDateBody, { endDate });

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -195,6 +195,9 @@ function CertificateStatus({ intl }) {
             ...timezoneFormatArgs,
           });
           body = intl.formatMessage(messages.notAvailableEndDateBody, { endDate });
+        } else {
+          certCase = null;
+          certEventName = 'no_certificate_status';
         }
         break;
     }

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -23,7 +23,6 @@ function CertificateStatus({ intl }) {
     isEnrolled,
     org,
     canViewCertificate,
-    isSelfPaced,
   } = useModel('courseHomeMeta', courseId);
 
   const {
@@ -48,7 +47,7 @@ function CertificateStatus({ intl }) {
     isEnrolled,
     userHasPassingGrade,
     null, // CourseExitPageIsActive
-    canViewCertificate || isSelfPaced,
+    canViewCertificate,
   );
 
   const eventProperties = {
@@ -160,7 +159,7 @@ function CertificateStatus({ intl }) {
         certAvailabilityDate = <FormattedDate value={certificateAvailableDate} day="numeric" month="long" year="numeric" />;
         body = (
           <FormattedMessage
-            id="courseCelebration.certificateBody.notAvailable.certificateAvailableDate"
+            id="courseCelebration.certificateBody.notAvailable.endDate"
             defaultMessage="This course ends on {endDate}. Final grades and any earned certificates are
             scheduled to be available after {certAvailabilityDate}."
             description="This shown for leaner when they are eligible for certifcate but it't not available yet, it could because leaners just finished the course quickly!"
@@ -185,7 +184,7 @@ function CertificateStatus({ intl }) {
       default:
         // if user completes a course before certificates are available, treat it as notAvailable
         // regardless of passing or nonpassing status
-        if (!canViewCertificate && !isSelfPaced) {
+        if (!canViewCertificate) {
           certCase = 'notAvailable';
           endDate = intl.formatDate(end, {
             year: 'numeric',
@@ -193,10 +192,6 @@ function CertificateStatus({ intl }) {
             day: 'numeric',
           });
           body = intl.formatMessage(messages.notAvailableEndDateBody, { endDate });
-        } else {
-          // This code shouldn't be hit but coding defensively since switch expects a default statement
-          certCase = null;
-          certEventName = 'no_certificate_status';
         }
         break;
     }

--- a/src/course-home/progress-tab/certificate-status/messages.js
+++ b/src/course-home/progress-tab/certificate-status/messages.js
@@ -77,7 +77,7 @@ const messages = defineMessages({
     description: 'Header text when the certifcate is not available',
   },
   notAvailableEndDateBody: {
-    id: 'courseCelebration.certificateBody.notAvailable.endDate',
+    id: 'progress.certificateBody.notAvailable.endDate',
     defaultMessage: 'Final grades and any earned certificates are scheduled to be available after {endDate}.',
     description: 'Shown for learners who have finished a course before grades and certificates are available.',
   },

--- a/src/course-home/progress-tab/certificate-status/messages.js
+++ b/src/course-home/progress-tab/certificate-status/messages.js
@@ -76,6 +76,11 @@ const messages = defineMessages({
     defaultMessage: 'Certificate status',
     description: 'Header text when the certifcate is not available',
   },
+  notAvailableEndDateBody: {
+    id: 'courseCelebration.certificateBody.notAvailable.endDate',
+    defaultMessage: 'Final grades and any earned certificates are scheduled to be available after {endDate}.',
+    description: 'Shown for learners who have finished a course before grades and certificates are available.',
+  },
   upgradeHeader: {
     id: 'progress.certificateStatus.upgradeHeader',
     defaultMessage: 'Earn a certificate',

--- a/src/courseware/course/course-exit/CourseCelebration.jsx
+++ b/src/courseware/course/course-exit/CourseCelebration.jsx
@@ -133,7 +133,7 @@ function CourseCelebration({ intl }) {
         <>
           <p>
             <FormattedMessage
-              id="courseCelebration.certificateBody.notAvailable.certificateAvailableDate"
+              id="courseCelebration.certificateBody.notAvailable.endDate.v2"
               defaultMessage="This course ends on {endDate}. Final grades and any earned certificates are
               scheduled to be available after {certAvailableDate}."
               values={{ endDate, certAvailableDate }}
@@ -261,7 +261,6 @@ function CourseCelebration({ intl }) {
           year: 'numeric',
           month: 'long',
           day: 'numeric',
-        }, {
           ...timezoneFormatArgs,
         });
         message = (

--- a/src/courseware/course/course-exit/CourseCelebration.jsx
+++ b/src/courseware/course/course-exit/CourseCelebration.jsx
@@ -56,7 +56,7 @@ function CourseCelebration({ intl }) {
     org,
     verifiedMode,
     canViewCertificate,
-    isSelfPaced,
+    userTimezone,
   } = useModel('courseHomeMeta', courseId);
 
   const {
@@ -71,6 +71,7 @@ function CourseCelebration({ intl }) {
   const dashboardLink = <DashboardLink />;
   const idVerificationSupportLink = <IdVerificationSupportLink />;
   const profileLink = <ProfileLink />;
+  const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
 
   let buttonPrefix = null;
   let buttonLocation;
@@ -250,7 +251,7 @@ function CourseCelebration({ intl }) {
       }
       break;
     default:
-      if (!canViewCertificate && !isSelfPaced) {
+      if (!canViewCertificate) {
         //  We reuse the cert event here. Since this default state is so
         //  Similar to the earned_not_available state, this event name should be fine
         //  to cover the same cases.
@@ -260,6 +261,8 @@ function CourseCelebration({ intl }) {
           year: 'numeric',
           month: 'long',
           day: 'numeric',
+        }, {
+          ...timezoneFormatArgs,
         });
         message = (
           <>

--- a/src/courseware/course/course-exit/CourseCelebration.jsx
+++ b/src/courseware/course/course-exit/CourseCelebration.jsx
@@ -55,6 +55,8 @@ function CourseCelebration({ intl }) {
   const {
     org,
     verifiedMode,
+    canViewCertificate,
+    isSelfPaced,
   } = useModel('courseHomeMeta', courseId);
 
   const {
@@ -130,7 +132,7 @@ function CourseCelebration({ intl }) {
         <>
           <p>
             <FormattedMessage
-              id="courseCelebration.certificateBody.notAvailable.endDate.v2"
+              id="courseCelebration.certificateBody.notAvailable.certificateAvailableDate"
               defaultMessage="This course ends on {endDate}. Final grades and any earned certificates are
               scheduled to be available after {certAvailableDate}."
               values={{ endDate, certAvailableDate }}
@@ -248,6 +250,28 @@ function CourseCelebration({ intl }) {
       }
       break;
     default:
+      if (!canViewCertificate && !isSelfPaced) {
+        //  We reuse the cert event here. Since this default state is so
+        //  Similar to the earned_not_available state, this event name should be fine
+        //  to cover the same cases.
+        visitEvent = 'celebration_with_unavailable_cert';
+        certHeader = intl.formatMessage(messages.certificateHeaderNotAvailable);
+        const endDate = intl.formatDate(end, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        });
+        message = (
+          <>
+            <p>
+              {intl.formatMessage(messages.certificateNotAvailableEndDateBody, { endDate })}
+            </p>
+            <p>
+              {intl.formatMessage(messages.certificateNotAvailableBodyAccessCert)}
+            </p>
+          </>
+        );
+      }
       break;
   }
 

--- a/src/courseware/course/course-exit/CourseExit.jsx
+++ b/src/courseware/course/course-exit/CourseExit.jsx
@@ -27,7 +27,11 @@ function CourseExit({ intl }) {
     userHasPassingGrade,
   } = useModel('coursewareMeta', courseId);
 
-  const { isMasquerading } = useModel('courseHomeMeta', courseId);
+  const {
+    isMasquerading,
+    canViewCertificate,
+    isSelfPaced,
+  } = useModel('courseHomeMeta', courseId);
 
   const mode = getCourseExitMode(
     certificateData,
@@ -35,6 +39,7 @@ function CourseExit({ intl }) {
     isEnrolled,
     userHasPassingGrade,
     courseExitPageIsActive,
+    canViewCertificate || isSelfPaced,
   );
 
   // Audit users cannot fully complete a course, so we will

--- a/src/courseware/course/course-exit/CourseExit.jsx
+++ b/src/courseware/course/course-exit/CourseExit.jsx
@@ -30,7 +30,6 @@ function CourseExit({ intl }) {
   const {
     isMasquerading,
     canViewCertificate,
-    isSelfPaced,
   } = useModel('courseHomeMeta', courseId);
 
   const mode = getCourseExitMode(
@@ -39,7 +38,7 @@ function CourseExit({ intl }) {
     isEnrolled,
     userHasPassingGrade,
     courseExitPageIsActive,
-    canViewCertificate || isSelfPaced,
+    canViewCertificate,
   );
 
   // Audit users cannot fully complete a course, so we will

--- a/src/courseware/course/course-exit/messages.js
+++ b/src/courseware/course/course-exit/messages.js
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: 'If you have earned a passing grade, your certificate will be automatically issued.',
     description: 'Text displayed when course certificate is not yet available to be viewed',
   },
+  certificateNotAvailableEndDateBody: {
+    id: 'courseCelebration.certificateBody.notAvailable.endDate',
+    defaultMessage: 'Final grades and any earned certificates are scheduled to be available after {endDate}.',
+    description: 'Shown for learners who have finished a course before grades and certificates are available.',
+  },
   certificateHeaderUnverified: {
     id: 'courseCelebration.certificateHeader.unverified',
     defaultMessage: 'You must complete verification to receive your certificate.',

--- a/src/courseware/course/course-exit/utils.js
+++ b/src/courseware/course/course-exit/utils.js
@@ -74,14 +74,14 @@ function getCourseExitNavigation(courseId, intl) {
     userHasPassingGrade,
     courseExitPageIsActive,
   } = useModel('coursewareMeta', courseId);
-  const { canViewCertificate, isSelfPaced } = useModel('courseHomeMeta', courseId);
+  const { canViewCertificate } = useModel('courseHomeMeta', courseId);
   const exitMode = getCourseExitMode(
     certificateData,
     hasScheduledContent,
     isEnrolled,
     userHasPassingGrade,
     courseExitPageIsActive,
-    canViewCertificate || !isSelfPaced,
+    canViewCertificate,
   );
   const exitActive = exitMode !== COURSE_EXIT_MODES.disabled;
 

--- a/src/courseware/course/course-exit/utils.js
+++ b/src/courseware/course/course-exit/utils.js
@@ -31,6 +31,7 @@ function getCourseExitMode(
   isEnrolled,
   userHasPassingGrade,
   courseExitPageIsActive = null,
+  canImmediatelyViewCertificate = false,
 ) {
   const authenticatedUser = getAuthenticatedUser();
 
@@ -55,7 +56,7 @@ function getCourseExitMode(
   if (hasScheduledContent && !userHasPassingGrade) {
     return COURSE_EXIT_MODES.inProgress;
   }
-  if (isEligibleForCertificate && !userHasPassingGrade) {
+  if (isEligibleForCertificate && !userHasPassingGrade && canImmediatelyViewCertificate) {
     return COURSE_EXIT_MODES.nonPassing;
   }
   if (isCelebratoryStatus) {
@@ -73,12 +74,14 @@ function getCourseExitNavigation(courseId, intl) {
     userHasPassingGrade,
     courseExitPageIsActive,
   } = useModel('coursewareMeta', courseId);
+  const { canViewCertificate, isSelfPaced } = useModel('courseHomeMeta', courseId);
   const exitMode = getCourseExitMode(
     certificateData,
     hasScheduledContent,
     isEnrolled,
     userHasPassingGrade,
     courseExitPageIsActive,
+    canViewCertificate || !isSelfPaced,
   );
   const exitActive = exitMode !== COURSE_EXIT_MODES.disabled;
 


### PR DESCRIPTION
Right now, learners who are nonpassing are able to view information
about thier certificates early at the course end screen and progress
pages. This is because we show messaging around the nonpassing state in
some cases before a course ends and certificates are available. This can
also lead to cases where grades are not finalized and students who may
be passing see a scary nonpassing message instead.

This change makes it so during the course exit, a student who finishes a
course before the course is over will see the celebration screen
regardless of passing status. Once the course is over (or if
certificates are available immediately), and they are
still not passing, they will see the nonpassing messaging. The same
change was made for the certificate status alert in the progress tab.