### PR TITLE
fix:Update broken link to course outline in Progress tab

### DIFF
--- a/src/course-home/progress-tab/grades/detailed-grades/DetailedGrades.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/DetailedGrades.jsx
@@ -40,7 +40,7 @@ function DetailedGrades({ intl }) {
     <Hyperlink
       variant="muted"
       isInline
-      destination={`/course/${courseId}/home`}
+      destination={`/learning/course/${courseId}/home`}
       onClick={logOutlineLinkClick}
       tabIndex={gradesFeatureIsFullyLocked ? '-1' : '0'}
     >


### PR DESCRIPTION
At the bottom of the Progress page, there is a legend "For progress on ungraded aspects of the course, view your Course Outline. The url linked to _Course Outline_ points to `/course/${courseId}/home`, and should point to `/learning/course/${courseId}/home`