### PR TITLE
fix: update translations for instructor toolbar and masquarade widget

### DIFF
--- a/src/instructor-toolbar/InstructorToolbar.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import { ALERT_TYPES, AlertList } from '../generic/user-messages';
 import Alert from '../generic/user-messages/Alert';
@@ -74,17 +75,35 @@ export default function InstructorToolbar(props) {
           {(urlStudio || urlInsights) && (
             <>
               <hr className="border-light" />
-              <span className="mr-2 mt-1 col-form-label">View course in:</span>
+              <span className="mr-2 mt-1 col-form-label">
+                <FormattedMessage
+                  id="instructorToolbar.view.label"
+                  description="Label on the instructor toolbar."
+                  defaultMessage="View course in:"
+                />
+              </span>
             </>
           )}
           {urlStudio && (
             <span className="mx-1 my-1">
-              <a className="btn btn-inverse-outline-primary" href={urlStudio}>Studio</a>
+              <a className="btn btn-inverse-outline-primary" href={urlStudio}>
+                <FormattedMessage
+                  id="instructorToolbar.view.mode.label.1"
+                  description="Label view mode for studio."
+                  defaultMessage="Studio"
+                />
+              </a>
             </span>
           )}
           {urlInsights && (
             <span className="mx-1 my-1">
-              <a className="btn btn-inverse-outline-primary" href={urlInsights}>Insights</a>
+              <a className="btn btn-inverse-outline-primary" href={urlInsights}>
+                <FormattedMessage
+                  id="instructorToolbar.view.mode.label.2"
+                  description="Label view mode for insights."
+                  defaultMessage="Insights"
+                />
+              </a>
             </span>
           )}
         </div>

--- a/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
+++ b/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
@@ -117,10 +117,11 @@ class MasqueradeWidget extends Component {
       masqueradeUsername,
     } = this.state;
     const specificLearnerInputText = this.props.intl.formatMessage(messages.placeholder);
+    const viewCourseAsTextLabel = this.props.intl.formatMessage(messages.viewCourseAs);
     return (
       <div className="flex-grow-1">
         <div className="row">
-          <span className="col-auto col-form-label pl-3">View this course as:</span>
+          <span className="col-auto col-form-label pl-3">{viewCourseAsTextLabel}</span>
           <Dropdown className="flex-shrink-1 mx-1">
             <Dropdown.Toggle variant="inverse-outline-primary">
               {masquerade}

--- a/src/instructor-toolbar/masquerade-widget/messages.js
+++ b/src/instructor-toolbar/masquerade-widget/messages.js
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Masquerade as this user',
     description: 'Label for the masquerade user input',
   },
+  viewCourseAs: {
+    id: 'masquerade-widget.viewCourseAs.text.label',
+    defaultMessage: 'View this course as:',
+    description: 'Label for the view this course as',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
Issue: https://github.com/openedx/frontend-app-learning/issues/917

Description: Update translations for instructor toolbar and masquarade widget. I'm contributing on behalf of Raccoon Gang

Screen after adding changes(fr locale):
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/68189005/184208408-43925407-5f28-4700-b6b4-bc5552cb09cc.png">

