### PR TITLE
feat: send from_email event property on course start event [VAN-1060]

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -154,6 +154,21 @@ describe('Outline Tab', () => {
       const sequenceLink = screen.getByText('Title of Sequence');
       expect(sequenceLink.getAttribute('href')).toContain(`/course/${courseId}`);
     });
+
+    it('set event property fromEmail true in case of from_email query param', async () => {
+      await fetchAndRender('http://localhost/?from_email=true');
+
+      const startCourseButton = screen.getByRole('link', { name: messages.start.defaultMessage });
+      fireEvent.click(startCourseButton);
+
+      expect(sendTrackingLogEvent).toHaveBeenCalledWith('edx.course.home.resume_course.clicked', {
+        org_key: 'edX',
+        courserun_key: courseId,
+        event_type: 'start',
+        from_email: true,
+        url: `${getConfig().LMS_BASE_URL}/courses/${courseId}/jump_to/block-v1:edX+Test+Block@12345abcde`,
+      });
+    });
   });
 
   describe('Suggested schedule alerts', () => {

--- a/src/course-home/outline-tab/widgets/StartOrResumeCourseCard.jsx
+++ b/src/course-home/outline-tab/widgets/StartOrResumeCourseCard.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { history } from '@edx/frontend-platform';
 import { Button, Card } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
@@ -15,6 +17,9 @@ function StartOrResumeCourseCard({ intl }) {
   const {
     org,
   } = useModel('courseHomeMeta', courseId);
+
+  const [fromEmail, setFromEmail] = useState(false);
+  const location = useLocation();
 
   const eventProperties = {
     org_key: org,
@@ -37,8 +42,24 @@ function StartOrResumeCourseCard({ intl }) {
       ...eventProperties,
       event_type: hasVisitedCourse ? 'resume' : 'start',
       url: resumeCourseUrl,
+      from_email: fromEmail,
     });
   };
+
+  useEffect(() => {
+    const currentParams = new URLSearchParams(location.search);
+    const fromEmailQueryParam = Boolean(currentParams.get('from_email'));
+    if (fromEmailQueryParam) {
+      setFromEmail(true);
+
+      // Deleting the from_email query param as it only needs to be set once
+      // whenever passed in query params.
+      currentParams.delete('from_email');
+      history.replace({
+        search: currentParams.toString(),
+      });
+    }
+  }, [location.search]);
 
   return (
     <Card className="mb-3 raised-card" data-testid="start-resume-card">


### PR DESCRIPTION
We need to track if the user is starting a course after coming from the email, therefore we are sending the `from_email` query param from the email `Start course` button and then sending the `from_email` true in event property if the query param is available.

[VAN-1060](https://2u-internal.atlassian.net/browse/VAN-1060)