### PR TITLE
feat: update discussion sidebar url to allow grouping by subsection [BD-38]

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -19,7 +19,7 @@ function DiscussionsSidebar({ intl }) {
   if (!topic?.id) {
     return null;
   }
-  const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}/topics/${topic.id}`;
+  const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}/category/${unitId}`;
   return (
     <SidebarBase
       title={intl.formatMessage(messages.discussionsTitle)}

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.test.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.test.jsx
@@ -59,7 +59,7 @@ describe('Discussions Trigger', () => {
     renderWithProvider();
     expect(screen.queryByTitle('Discussions')).toBeInTheDocument();
     expect(screen.queryByTitle('Discussions'))
-      .toHaveAttribute('src', `http://localhost:2002/${courseId}/topics/topic-1?inContext`);
+      .toHaveAttribute('src', `http://localhost:2002/${courseId}/category/${unitId}?inContext`);
   });
 
   it('should show nothing if unit has no discussions associated with it', async () => {


### PR DESCRIPTION
To enable grouping by subsection in the discussions MFE, this PR updates
the embed URL to the one that supports grouping.

ref: https://github.com/openedx/frontend-app-discussions/pull/281
