### PR TITLE
RTL: use backslash to write fractions (grades)

### DIFF
--- a/src/course-home/progress-tab/grades/detailed-grades/DetailedGradesTable.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/DetailedGradesTable.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import {
+  getLocale, injectIntl, intlShape, isRtl,
+} from '@edx/frontend-platform/i18n';
 import { DataTable } from '@edx/paragon';
 
 import { useModel } from '../../../../generic/model-store';
@@ -17,6 +19,7 @@ function DetailedGradesTable({ intl }) {
     sectionScores,
   } = useModel('progress', courseId);
 
+  const isLocaleRtl = isRtl(getLocale());
   return (
     sectionScores.map((chapter) => {
       const subsectionScores = chapter.subsections.filter(
@@ -32,7 +35,7 @@ function DetailedGradesTable({ intl }) {
 
       const detailedGradesData = subsectionScores.map((subsection) => ({
         subsectionTitle: <SubsectionTitleCell subsection={subsection} />,
-        score: <span className={subsection.learnerHasAccess ? '' : 'greyed-out'}>{subsection.numPointsEarned}/{subsection.numPointsPossible}</span>,
+        score: <span className={subsection.learnerHasAccess ? '' : 'greyed-out'}>{subsection.numPointsEarned}{isLocaleRtl ? '\\' : '/'}{subsection.numPointsPossible}</span>,
       }));
 
       return (

--- a/src/course-home/progress-tab/grades/detailed-grades/ProblemScoreDrawer.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/ProblemScoreDrawer.jsx
@@ -2,18 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import {
+  getLocale, injectIntl, intlShape, isRtl,
+} from '@edx/frontend-platform/i18n';
 
 import messages from '../messages';
 
 function ProblemScoreDrawer({ intl, problemScores, subsection }) {
+  const isLocaleRtl = isRtl(getLocale());
   return (
     <span className="row w-100 m-0 x-small ml-4 pt-2 pl-1 text-gray-700 flex-nowrap">
       <span id="problem-score-label" className="col-auto p-0">{intl.formatMessage(messages.problemScoreLabel)}</span>
       <div className={classNames('col', 'p-0', { 'greyed-out': !subsection.learnerHasAccess })}>
         <ul className="list-unstyled row w-100 m-0" aria-labelledby="problem-score-label">
           {problemScores.map(problemScore => (
-            <li className="ml-3">{problemScore.earned}/{problemScore.possible}</li>
+            <li className="ml-3">{problemScore.earned}{isLocaleRtl ? '\\' : '/'}{problemScore.possible}</li>
           ))}
         </ul>
       </div>


### PR DESCRIPTION
**TL;DR -** This commit replaces the slash `/` for RTL languages with a backslash `\` when it is used to write fractions for such as `2/5` (grades)

**Background**
- In fractions, the direction of the slash determines which number comes on top (numerator) and which is on the bottom (denominator). For example: 3 / 2 means "2 over 3,  "2 divided by 3" or "2 out of 3"
- In RTL text, some characters are mirrored to match the writing direction, such as parentheses `( )` and comparison signs `< >`
- However, `/` is not mirrored in RTL, which introduces visual confusion when used to write fractions. For Example, **2 / 3** in English still shows as **2 / 3** in Arabic, while it should look **3 \ 2**

**What changed?**
- We use 2 frontend-platform functions `isRtl` and `getLocale` to apply the fix only if the current user language is right-to-left.
- we replace `/` with `\` for RTL languages in places where absolute grades are shown.
- The change is applied to each grade displayed in the progress tab's detailed grade table.

**Screenshots** (look at the grades)
The screenshots show the detailed grades table in the Arabic language for the DemoX course.

| Before | After |
|---|----|
| ![Screenshot from 2022-09-15 17-56-52](https://user-images.githubusercontent.com/10594967/190466703-f3312327-0baa-42ca-89dd-3a9f30122f98.png) | ![Screenshot from 2022-09-15 17-57-10](https://user-images.githubusercontent.com/10594967/190466965-9d30ead3-26e6-4394-9a94-436deead14a8.png) |
