### PR TITLE
RTL: fix position of grade rectangles in GradeBar

### DIFF
--- a/src/course-home/progress-tab/grades/course-grade/GradeBar.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/GradeBar.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import {
+  getLocale, injectIntl, intlShape, isRtl,
+} from '@edx/frontend-platform/i18n';
 import { useModel } from '../../../../generic/model-store';
 import CurrentGradeTooltip from './CurrentGradeTooltip';
 import PassingGradeTooltip from './PassingGradeTooltip';
@@ -26,14 +28,16 @@ function GradeBar({ intl, passingGrade }) {
 
   const lockedTooltipClassName = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
 
+  const adjustedRtlStyle = (percentOffest) => (isRtl(getLocale()) ? { transform: `translateX(${100 - percentOffest}%)` } : {});
+
   return (
     <div className="col-12 col-sm-6 align-self-center p-0">
       <div className="sr-only">{intl.formatMessage(messages.courseGradeBarAltText, { currentGrade, passingGrade })}</div>
       <svg width="100%" height="100px" className="grade-bar" aria-hidden="true">
         <g style={{ transform: 'translateY(2.61em)' }}>
           <rect className="grade-bar__base" width="100%" />
-          <rect className="grade-bar--passing" width={`${passingGrade}%`} />
-          <rect className={`grade-bar--current-${isPassing ? 'passing' : 'non-passing'}`} width={`${currentGrade}%`} />
+          <rect className="grade-bar--passing" width={`${passingGrade}%`} style={adjustedRtlStyle(passingGrade)} />
+          <rect className={`grade-bar--current-${isPassing ? 'passing' : 'non-passing'}`} width={`${currentGrade}%`} style={adjustedRtlStyle(currentGrade)} />
 
           {/* Start divider */}
           <rect className="grade-bar__divider" />


### PR DESCRIPTION
**TL;DR -** fixes the position of current and passing grade rectangles to appear on the right when in RTL.

**What changed?**
- We use 2 frontend-platform functions `isRtl` and `getLocale` to apply the fix only if the current user language is right-to-left.
- We apply translateX CSS transformation in the GradeBar components only for RTL.
- The GradeBar appears in RTL mirrored compared to LTR

**Screenshots**
Reference LTR layout (in English)
![Screenshot from 2022-09-15 19-26-06](https://user-images.githubusercontent.com/10594967/190487053-da458008-6708-40cd-9667-e394ee1dd0c3.png)
Fixed RTL layout (after) 
![Screenshot from 2022-09-15 19-25-38](https://user-images.githubusercontent.com/10594967/190487350-7ea8aa35-a1f4-44c0-9316-a4da538c8dfc.png)
Broken RTL layout (before)
![image](https://user-images.githubusercontent.com/10594967/190487209-e7acf832-b8ad-406f-82dc-9a9f1ebc1550.png)