### PR TITLE
Fix [RTL]: mirror new user tour modal background

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -376,6 +376,7 @@
 @import "course-home/progress-tab/course-completion/CompletionDonutChart.scss";
 @import "course-home/progress-tab/grades/course-grade/GradeBar.scss";
 @import "courseware/course/course-exit/CourseRecommendations";
+@import "product-tours/newUserCourseHomeTour/NewUserCourseHomeTourModal.scss";
 
 /** [MM-P2P] Experiment */
 @import "experiments/mm-p2p/index.scss";

--- a/src/product-tours/newUserCourseHomeTour/NewUserCourseHomeTourModal.jsx
+++ b/src/product-tours/newUserCourseHomeTour/NewUserCourseHomeTourModal.jsx
@@ -19,6 +19,7 @@ function NewUserCourseHomeTourModal({
     <MarketingModal
       isOpen={isOpen}
       title="New user course home prompt"
+      className="new-user-tour-dialog"
       heroIsDark
       hasCloseButton={false}
       heroNode={(

--- a/src/product-tours/newUserCourseHomeTour/NewUserCourseHomeTourModal.scss
+++ b/src/product-tours/newUserCourseHomeTour/NewUserCourseHomeTourModal.scss
@@ -1,0 +1,3 @@
+[dir="rtl"] .new-user-tour-dialog .pgn__modal-hero .pgn__modal-hero-bg {
+    transform: scaleX(-1);
+}


### PR DESCRIPTION
**TL;DR -** When in RTL, it mirrors the background image used in the new user tour modal as it obstructs the readability of the modal title.

**Screenshots**

| LTR for reference | ![Screenshot from 2022-10-03 13-20-57](https://user-images.githubusercontent.com/10594967/193577859-f7c23586-a953-4916-a48a-7d4acd9efb7e.png) |
| ---- | ---- |
| RTL before fix | ![Screenshot from 2022-10-03 13-22-47](https://user-images.githubusercontent.com/10594967/193578172-6c21da2c-7f9c-4bc3-9eef-fe02d49ac0a0.png) |
| RTL after fix | ![Screenshot from 2022-10-03 13-21-27](https://user-images.githubusercontent.com/10594967/193578225-0ccc8359-c23e-49c7-97ea-de3534e22a1d.png) |


**Testing instructions**

- It should be your first time as a user to access a course home, otherwise either create and enroll a new user or edit your account's UserTour object from LMS Django admin.
- Switch to your user language preference to an RTL language of your choice (e.g. Arabic).
- Go to your course home. The "Welcome to your platform course" modal should appear.
