### PR TITLE
fix: remove minHeight from in-context discussion sidebar

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -30,8 +30,7 @@ function DiscussionsSidebar({ intl }) {
     >
       <iframe
         src={`${discussionsUrl}?inContext`}
-        className="d-flex w-100 border-0"
-        style={{ minHeight: '60rem' }}
+        className="d-flex w-100 h-100 border-0"
         title={intl.formatMessage(messages.discussionsTitle)}
       />
     </SidebarBase>


### PR DESCRIPTION
### [INF-480](https://2u-internal.atlassian.net/browse/INF-480)

- Remove the minHeight from the discussions sidebar because of unnecessary scroll