### PR TITLE
Revert "fix: remove minHeight from in-context discussion sidebar"

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -30,7 +30,8 @@ function DiscussionsSidebar({ intl }) {
     >
       <iframe
         src={`${discussionsUrl}?inContext`}
-        className="d-flex w-100 h-100 border-0"
+        className="d-flex w-100 border-0"
+        style={{ minHeight: '60rem' }}
         title={intl.formatMessage(messages.discussionsTitle)}
       />
     </SidebarBase>


### PR DESCRIPTION
Reverts openedx/frontend-app-learning#1002

frontend-app-learning build is failing. The SRE team thinks it is failing because of this PR. So, I'm reverting it to check that build will fail or not.