### PR TITLE
Revert "Revert "fix: remove minHeight from in-context discussion sidebar""

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -30,8 +30,7 @@ function DiscussionsSidebar({ intl }) {
     >
       <iframe
         src={`${discussionsUrl}?inContext`}
-        className="d-flex w-100 border-0"
-        style={{ minHeight: '60rem' }}
+        className="d-flex w-100 h-100 border-0"
         title={intl.formatMessage(messages.discussionsTitle)}
       />
     </SidebarBase>


### PR DESCRIPTION
Reverts openedx/frontend-app-learning#1003

- Learning MFE pipeline is unblocked. So apply my styling in-context styling change.