### PR TITLE
chore: fix fo format relative time

### DIFF
--- a/src/alerts/course-start-alert/CourseStartAlert.jsx
+++ b/src/alerts/course-start-alert/CourseStartAlert.jsx
@@ -11,7 +11,9 @@ import { Info } from '@edx/paragon/icons';
 
 import { useModel } from '../../generic/model-store';
 
-const DAY_MS = 24 * 60 * 60 * 1000; // in ms
+const DAY_SEC = 24 * 60 * 60; // in seconds
+const DAY_MS = DAY_SEC * 1000; // in ms
+const YEAR_SEC = 365 * DAY_SEC; // in seconds
 
 function CourseStartAlert({ payload }) {
   const {
@@ -25,15 +27,17 @@ function CourseStartAlert({ payload }) {
 
   const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
 
+  const delta = new Date(startDate) - new Date();
   const timeRemaining = (
     <FormattedRelativeTime
       key="timeRemaining"
-      value={startDate}
+      value={delta / 1000}
+      numeric="auto"
+      // 1 year interval to help auto format. It won't format without updateIntervalInSeconds.
+      updateIntervalInSeconds={YEAR_SEC}
       {...timezoneFormatArgs}
     />
   );
-
-  const delta = new Date(startDate) - new Date();
   if (delta < DAY_MS) {
     return (
       <Alert variant="info" icon={Info}>

--- a/src/course-home/outline-tab/alerts/course-end-alert/CourseEndAlert.jsx
+++ b/src/course-home/outline-tab/alerts/course-end-alert/CourseEndAlert.jsx
@@ -9,7 +9,9 @@ import {
 import { Alert } from '@edx/paragon';
 import { Info } from '@edx/paragon/icons';
 
-const DAY_MS = 24 * 60 * 60 * 1000; // in ms
+const DAY_SEC = 24 * 60 * 60; // in seconds
+const DAY_MS = DAY_SEC * 1000; // in ms
+const YEAR_SEC = 365 * DAY_SEC; // in seconds
 
 function CourseEndAlert({ payload }) {
   const {
@@ -20,16 +22,19 @@ function CourseEndAlert({ payload }) {
 
   const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
 
+  let msg;
+  const delta = new Date(endDate) - new Date();
   const timeRemaining = (
     <FormattedRelativeTime
       key="timeRemaining"
-      value={endDate}
+      value={delta / 1000}
+      numeric="auto"
+      // 1 year interval to help auto format. It won't format without updateIntervalInSeconds.
+      updateIntervalInSeconds={YEAR_SEC}
       {...timezoneFormatArgs}
     />
   );
 
-  let msg;
-  const delta = new Date(endDate) - new Date();
   if (delta < DAY_MS) {
     const courseEndTime = (
       <FormattedTime


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/AU-954

TLDR; format relative suppose to use delta to see the different of relative time and I need to add `updateIntervalInSeconds` to make `FormattedRelativeTime` auto format the text. For more info: https://formatjs.io/docs/react-intl/components/#formattedrelativetime

<img width="1037" alt="Screen Shot 2022-12-16 at 10 55 42 AM" src="https://user-images.githubusercontent.com/83240113/208138588-f05ae82c-e5bf-411b-a349-bdccd88fd8aa.png">
<img width="1025" alt="Screen Shot 2022-12-16 at 10 51 09 AM" src="https://user-images.githubusercontent.com/83240113/208138589-4ba9f69c-fc93-4d44-90f9-89c9866fdca4.png">
<img width="1045" alt="Screen Shot 2022-12-16 at 10 50 00 AM" src="https://user-images.githubusercontent.com/83240113/208138591-7c5ab676-7ab2-4766-b2df-3133aab25b4c.png">
<img width="1033" alt="Screen Shot 2022-12-16 at 10 49 21 AM" src="https://user-images.githubusercontent.com/83240113/208138593-57330ec1-9af6-49ad-ac5d-0dafddb360de.png">
