### PR TITLE
fix: sidebar length is fixed

### DIFF
--- a/src/courseware/course/sidebar/common/SidebarBase.jsx
+++ b/src/courseware/course/sidebar/common/SidebarBase.jsx
@@ -37,6 +37,7 @@ function SidebarBase({
     <section
       className={classNames('ml-0 ml-lg-4 border border-light-400 rounded-sm h-auto align-top', {
         'bg-white m-0 border-0 fixed-top vh-100 rounded-0': shouldDisplayFullScreen,
+        'min-vh-100': !shouldDisplayFullScreen,
       }, className)}
       style={{ width: shouldDisplayFullScreen ? '100%' : width }}
       aria-label={ariaLabel}


### PR DESCRIPTION
after fix:

sidebar extends the full length of the browser
<img width="1615" alt="Screen Shot 2022-12-22 at 7 08 19 PM" src="https://user-images.githubusercontent.com/67791278/209152022-4eba8269-8a98-4ecf-a790-07756e9cf974.png">

before fix:
sidebar takes up only space as the content on the left hand

<img width="1644" alt="Screen Shot 2022-12-22 at 7 08 49 PM" src="https://user-images.githubusercontent.com/67791278/209152039-4b6fc0a0-2a85-4321-9f45-6a792cbcd2be.png">


Scroll View

https://user-images.githubusercontent.com/67791278/209167143-56cbf1a9-5f9e-4c62-806b-d327806a8fc5.mov


