### PR TITLE
fix: hide discussions sidebar and trigger icon when unit does not exist or enableInContext is false.

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -16,10 +16,12 @@ function DiscussionsSidebar({ intl }) {
     courseId,
   } = useContext(SidebarContext);
   const topic = useModel('discussionTopics', unitId);
-  if (!topic?.id) {
+  const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}/category/${unitId}`;
+
+  if (!topic?.id || !topic?.enabledInContext) {
     return null;
   }
-  const discussionsUrl = `${getConfig().DISCUSSIONS_MFE_BASE_URL}/${courseId}/category/${unitId}`;
+
   return (
     <SidebarBase
       title={intl.formatMessage(messages.discussionsTitle)}

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsTrigger.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsTrigger.jsx
@@ -32,9 +32,11 @@ function DiscussionsTrigger({
       dispatch(getCourseDiscussionTopics(courseId));
     }
   }, [courseId, baseUrl]);
-  if (!topic.id) {
+
+  if (!topic?.id || !topic?.enabledInContext) {
     return null;
   }
+
   return (
     <SidebarTriggerBase onClick={onClick} ariaLabel={intl.formatMessage(messages.openDiscussionsTrigger)}>
       <Icon src={QuestionAnswer} className="m-0 m-auto" />

--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -242,7 +242,7 @@ export function getCourseDiscussionTopics(courseId) {
         const topics = await getCourseTopics(courseId);
         dispatch(updateModels({
           modelType: 'discussionTopics',
-          models: topics,
+          models: topics.filter(topic => topic.usageKey),
           idField: 'usageKey',
         }));
       }


### PR DESCRIPTION
### [INF-713](https://2u-internal.atlassian.net/browse/INF-713)

1. Removed nonCourseware/courseWide topics from courseware units API response.
2. Hide the inContext discussions sidebar and trigger icon when the unit does not exist or `enableInContext` is false.

**When enableInContext is false**
<img width="1440" alt="Screenshot 2023-01-06 at 3 22 15 PM" src="https://user-images.githubusercontent.com/79941147/210987981-fb29b3be-e044-407f-b684-64ac23ea1b3b.png">

**When the unit is deleted from the studio, The Unit, and discussion sidebar will not be visible in LMS**
<img width="508" alt="Screenshot 2023-01-06 at 3 31 11 PM" src="https://user-images.githubusercontent.com/79941147/210989590-33871a6d-5071-4cbf-b1bf-1608ceca9911.png">
<img width="1440" alt="Screenshot 2023-01-06 at 3 22 15 PM" src="https://user-images.githubusercontent.com/79941147/210989648-0aee15c4-d904-43e7-b31d-8927d266bdb6.png">

