### PR TITLE
fix: text in goal modal

### DIFF
--- a/src/courseware/course/celebration/WeeklyGoalCelebrationModal.jsx
+++ b/src/courseware/course/celebration/WeeklyGoalCelebrationModal.jsx
@@ -57,14 +57,16 @@ function WeeklyGoalCelebrationModal({
             className="mr-2"
             style={{ height: '21px', width: '22px' }}
           />
-          <FormattedMessage
-            id="learning.celebration.setGoal"
-            defaultMessage="Setting a goal can help you {strongText} in your course."
-            description="It explain the advantages of setting goal"
-            values={{
-              strongText: (<strong>achieve higher performance</strong>),
-            }}
-          />
+          <div>
+            <FormattedMessage
+              id="learning.celebration.setGoal"
+              defaultMessage="Setting a goal can help you {strongText} in your course."
+              description="It explain the advantages of setting goal"
+              values={{
+                strongText: (<strong>achieve higher performance</strong>),
+              }}
+            />
+          </div>
         </div>
       </>
     </StandardModal>


### PR DESCRIPTION
### Description:
This PR backports a fix from the master branch: "Fix text in the goal modal".
https://github.com/openedx/frontend-app-learning/pull/1020

### Before fix:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/17108583/211537131-b2e9c221-3ef1-4e4b-8ab7-5d3be116d2ac.png">

### After fix apply:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/17108583/211537209-a58500cf-01f5-4dd4-a9e6-ccdf4f965628.png">
