### PR TITLE
fix: show date on home page

### DIFF
--- a/src/alerts/course-start-alert/CourseStartAlert.jsx
+++ b/src/alerts/course-start-alert/CourseStartAlert.jsx
@@ -11,7 +11,9 @@ import { Info } from '@edx/paragon/icons';
 
 import { useModel } from '../../generic/model-store';
 
-const DAY_MS = 24 * 60 * 60 * 1000; // in ms
+const DAY_SEC = 24 * 60 * 60; // in seconds
+const DAY_MS = DAY_SEC * 1000; // in ms
+const YEAR_SEC = 365 * DAY_SEC; // in seconds
 
 function CourseStartAlert({ payload }) {
   const {
@@ -25,15 +27,18 @@ function CourseStartAlert({ payload }) {
 
   const timezoneFormatArgs = userTimezone ? { timeZone: userTimezone } : {};
 
+  const delta = new Date(startDate) - new Date();
   const timeRemaining = (
     <FormattedRelativeTime
       key="timeRemaining"
-      value={startDate}
+      value={delta / 1000}
+      numeric="auto"
+      // 1 year interval to help auto format. It won't format without updateIntervalInSeconds.
+      updateIntervalInSeconds={YEAR_SEC}
       {...timezoneFormatArgs}
     />
   );
 
-  const delta = new Date(startDate) - new Date();
   if (delta < DAY_MS) {
     return (
       <Alert variant="info" icon={Info}>


### PR DESCRIPTION
Correct display of the number of days before the start of the course into the Course Home.

## Description
Now the course home page has this course start date format:
![image2](https://user-images.githubusercontent.com/98233552/214084425-200217ab-2104-41e9-aa4d-7748141e2172.png)

In Olive, the library @edx/frontend-platform: 2.5.1 is used in MFE Frontend-app-learning. When using this version of this library in `FormattedRelativeTime` (now has parameters like in [nutmeg-master](https://github.com/openedx/frontend-app-learning/blob/open-release/nutmeg.master/src/alerts/course-start-alert/CourseStartAlert.jsx#:~:text=%3CFormattedRelative,/%3E) where earlier version of @edx/frontend-platform was used), you must use parameters such as in branch [master](https://github.com/openedx/frontend-app-learning/blob/master/src/alerts/course-start-alert/CourseStartAlert.jsx#:~:text=%3CFormattedRelativeTime,/%3E).
Changes from master branch work correctly.

![Screen_23](https://user-images.githubusercontent.com/98233552/218574886-b713f312-d6fb-43b1-b8b0-794342b37bce.png)