### PR TITLE
fix: fix alignment in the streak celebration modal

### DIFF
--- a/src/shared/streak-celebration/StreakCelebrationModal.jsx
+++ b/src/shared/streak-celebration/StreakCelebrationModal.jsx
@@ -160,8 +160,8 @@ function StreakModal({
         </ModalDialog.Title>
       </ModalDialog.Header>
       <ModalDialog.Body className="modal-body">
-        <p>{intl.formatMessage(messages.streakBody)}</p>
-        <p className="modal-image">
+        <p className="text-center">{intl.formatMessage(messages.streakBody)}</p>
+        <p className="modal-image text-center">
           {!wideScreen && <img src={StreakMobileImage} alt="" className="img-fluid" />}
           {wideScreen && <img src={StreakDesktopImage} alt="" className="img-fluid" />}
         </p>

--- a/src/shared/streak-celebration/StreakCelebrationModal.scss
+++ b/src/shared/streak-celebration/StreakCelebrationModal.scss
@@ -26,6 +26,10 @@
   .modal-body {
     padding-top: .5rem;
     font-size: 1.2rem;
+
+    .pgn__modal-body-content {
+      text-align: center;
+    }
   }
 
   .modal-footer {


### PR DESCRIPTION
**Description:**
Fix alignment in the streak celebration modal. The reason for the error is the upgrade of the paragon library from version 16.14.9 to 19.14.1

**Related to:** [pull request into nutmeg](https://github.com/openedx/frontend-app-learning/pull/974) and [master branch](https://github.com/openedx/frontend-app-learning/pull/975)

**Current behaviour:**
<img width="524" alt="189695000-b5bc94d6-23f1-4b82-be39-6c9a83a3ee95" src="https://user-images.githubusercontent.com/19806032/214091448-eef9461a-d300-45ef-b00f-27efc39fdd74.png">

**Fixed behaviour:**
<img width="526" alt="189694438-aff56165-d1fe-4e34-a6bb-0119170122e1" src="https://user-images.githubusercontent.com/19806032/214091526-b1c89c8c-9470-4344-a8d0-5be8fb5abe93.png">
