### PR TITLE
feat: Add border for active tab in course navigation at Live page

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -57,7 +57,7 @@ subscribe(APP_READY, () => {
                 </TabContainer>
               </PageRoute>
               <PageRoute path="/course/:courseId/live">
-                <TabContainer tab="live" fetch={fetchLiveTab} slice="courseHome">
+                <TabContainer tab="lti_live" fetch={fetchLiveTab} slice="courseHome">
                   <LiveTab />
                 </TabContainer>
               </PageRoute>


### PR DESCRIPTION
### Description

When Live tab is selected - it doesn't have an active class and therefore doesn't have bottom border.

<img width="1678" alt="image-2" src="https://user-images.githubusercontent.com/19806032/221383977-17175ce3-5b73-4d31-aac7-8aa3533a3565.png">

After investigation we found that active class is adding if slug === activeTabSlug and activeTabSlug was taken from `tab="live"` in `src/index.js`

```
<TabContainer tab="live" fetch={fetchLiveTab} slice="courseHome">
  <LiveTab />
</TabContainer>
```

After changing `live` to `lti_live` problem was fixed