### PR TITLE
fix: save scroll position on exit from video xblock fullscreen mode

### DIFF
--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -131,6 +131,21 @@ describe('Unit', () => {
     expect(window.scrollY === testMessageWithOffset.offset);
   });
 
+  it('scrolls page on MessageEvent when receiving videoFullScreen state', async () => {
+    // Set message to contain video full screen data.
+    const defaultTopOffset = 800;
+    const testMessageWithOtherHeight = { ...messageEvent, payload: { height: 500 } };
+    const testMessageWithFullscreenState = (isShow) => ({ type: 'plugin.videoFullScreen', payload: { show: isShow } });
+    render(<Unit {...mockData} />);
+    Object.defineProperty(window, 'scrollY', { value: defaultTopOffset, writable: true });
+    window.postMessage(testMessageWithFullscreenState(true), '*');
+    window.postMessage(testMessageWithFullscreenState(false), '*');
+    window.postMessage(testMessageWithOtherHeight, '*');
+
+    await expect(waitFor(() => expect(window.scrollTo()).toHaveBeenCalledTimes(1)));
+    expect(window.scrollY === defaultTopOffset);
+  });
+
   it('ignores MessageEvent with unhandled type', async () => {
     // Clone message and set different type.
     const testMessageWithUnhandledType = { ...messageEvent, type: 'wrong type' };

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -135,7 +135,7 @@ describe('Unit', () => {
     // Set message to contain video full screen data.
     const defaultTopOffset = 800;
     const testMessageWithOtherHeight = { ...messageEvent, payload: { height: 500 } };
-    const testMessageWithFullscreenState = (isShow) => ({ type: 'plugin.videoFullScreen', payload: { show: isShow } });
+    const testMessageWithFullscreenState = (isOpen) => ({ type: 'plugin.videoFullScreen', payload: { open: isOpen } });
     render(<Unit {...mockData} />);
     Object.defineProperty(window, 'scrollY', { value: defaultTopOffset, writable: true });
     window.postMessage(testMessageWithFullscreenState(true), '*');


### PR DESCRIPTION
This merge request contains a fix for toggling video xblock full-screen mode and saving the previous window top offset position on exit from the full-screen state.

A related bug was found here https://bugs.chromium.org/p/chromium/issues/detail?id=142427 but it still reproduces.

Realised solution: Save the scroll position before the turn on the fullscreen mode and scroll to the previous position on turn off the fullscreen mode.

Dependent PR to MFE Learning:
This MR https://github.com/openedx/edx-platform/pull/31871 must be merged with this MR.

All general discussion and addition information there: https://github.com/openedx/platform-roadmap/issues/229