### PR TITLE
fix: copy link for discussion sidebar not working in chrome

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -34,6 +34,7 @@ const DiscussionsSidebar = ({ intl }) => {
         src={`${discussionsUrl}?inContextSidebar`}
         className="d-flex w-100 h-100 border-0"
         title={intl.formatMessage(messages.discussionsTitle)}
+        allow="clipboard-write"
       />
     </SidebarBase>
   );


### PR DESCRIPTION
Copy link was not working in chrome from discussion sidebar iframe. Allowed permission to write to clipboard for iframe