### PR TITLE
feat: fetch exam access token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "11.6.3",
         "@edx/frontend-component-header": "3.6.4",
-        "@edx/frontend-lib-special-exams": "2.10.0",
+        "@edx/frontend-lib-special-exams": "2.12.0",
         "@edx/frontend-platform": "3.4.1",
         "@edx/paragon": "20.28.4",
         "@fortawesome/fontawesome-svg-core": "1.3.0",
@@ -3272,9 +3272,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.10.0.tgz",
-      "integrity": "sha512-YHTYlmHIVM6KRTklbM3ERHmu1adRoMIpYTWwn/KhEQ/a6YQfRM8SJt8uawj4ceSRftJ7E9QWMGy/21KfnIYOxg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.12.0.tgz",
+      "integrity": "sha512-VltUW9bZ+Ha9Gw4xplEJjfZi4zjUJJWsAFOVeX8n+ZJLko4qDU46tL7EOLAJyMaiAtjvHent8MNIfcGBbqgcFQ==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",
@@ -28482,9 +28482,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.10.0.tgz",
-      "integrity": "sha512-YHTYlmHIVM6KRTklbM3ERHmu1adRoMIpYTWwn/KhEQ/a6YQfRM8SJt8uawj4ceSRftJ7E9QWMGy/21KfnIYOxg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.12.0.tgz",
+      "integrity": "sha512-VltUW9bZ+Ha9Gw4xplEJjfZi4zjUJJWsAFOVeX8n+ZJLko4qDU46tL7EOLAJyMaiAtjvHent8MNIfcGBbqgcFQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "11.6.3",
     "@edx/frontend-component-header": "3.6.4",
-    "@edx/frontend-lib-special-exams": "2.10.0",
+    "@edx/frontend-lib-special-exams": "2.12.0",
     "@edx/frontend-platform": "3.4.1",
     "@edx/paragon": "20.28.4",
     "@fortawesome/fontawesome-svg-core": "1.3.0",

--- a/src/courseware/course/sequence/Unit.test.jsx
+++ b/src/courseware/course/sequence/Unit.test.jsx
@@ -1,9 +1,24 @@
 import React from 'react';
 import { Factory } from 'rosie';
+import { fetchExamAccess, getExamAccess, isExam } from '@edx/frontend-lib-special-exams';
 import {
   initializeTestStore, loadUnit, messageEvent, render, screen, waitFor,
 } from '../../../setupTest';
 import Unit, { sendUrlHashToFrame } from './Unit';
+
+const originalIsExam = jest.requireActual('@edx/frontend-lib-special-exams').isExam();
+const originalFetchExamAccess = jest.requireActual('@edx/frontend-lib-special-exams').fetchExamAccess();
+const originalGetExamAccess = jest.requireActual('@edx/frontend-lib-special-exams').getExamAccess();
+jest.mock('@edx/frontend-lib-special-exams', () => ({
+  ...jest.requireActual('@edx/frontend-lib-special-exams'),
+  isExam: jest.fn(),
+  fetchExamAccess: jest.fn(),
+  getExamAccess: jest.fn(),
+}));
+isExam.mockImplementation(() => originalIsExam).mockReturnValue(false);
+fetchExamAccess.mockImplementation(() => originalFetchExamAccess).mockResolvedValue();
+const examAccessToken = 'EXAMACCESSTOKEN';
+getExamAccess.mockImplementation(() => originalGetExamAccess).mockReturnValue(examAccessToken);
 
 describe('Unit', () => {
   let mockData;
@@ -173,5 +188,32 @@ describe('Unit', () => {
     render(<Unit {...mockData} />);
     expect(React.useEffect).toHaveBeenCalled();
     expect(mockHashCheck).toHaveBeenCalled();
+  });
+
+  it('updates url if exam and exam access granted', async () => {
+    isExam.mockReturnValue(true);
+
+    render(<Unit {...mockData} />);
+    expect(isExam).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByTitle(unit.display_name)).toHaveAttribute('src', `http://localhost:18000/xblock/${mockData.id}?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view&format=${mockData.format}&exam_access=${examAccessToken}`));
+  });
+
+  it('does not update url if exam and exam access not granted', async () => {
+    isExam.mockReturnValue(true);
+    fetchExamAccess.mockRejectedValue();
+    getExamAccess.mockReturnValue('');
+
+    render(<Unit {...mockData} />);
+    expect(isExam).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByTitle(unit.display_name)).toHaveAttribute('src', `http://localhost:18000/xblock/${mockData.id}?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view&format=${mockData.format}`));
+  });
+
+  it('does not update url if not exam', async () => {
+    isExam.mockReturnValue(false);
+
+    render(<Unit {...mockData} />);
+    expect(isExam).toHaveBeenCalled();
+    const renderedUnit = screen.getByTitle(unit.display_name);
+    expect(renderedUnit).toHaveAttribute('src', `http://localhost:18000/xblock/${mockData.id}?show_title=0&show_bookmark_button=0&recheck_access=1&view=student_view&format=${mockData.format}`);
   });
 });


### PR DESCRIPTION
When required (if Unit is an exam and if using the exams IDA), this code fetches the exam access token. If the exam access token is not granted the iframe does not load. The exam access token is added to the iframe url.

Here are the associated tickets:
[MST-1599](https://2u-internal.atlassian.net/browse/MST-1599)
[MST-1781](https://2u-internal.atlassian.net/browse/MST-1781)