### PR TITLE
chore: pin frontend lib special exams version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "11.6.3",
         "@edx/frontend-component-header": "3.6.4",
-        "@edx/frontend-lib-special-exams": "2.4.0",
+        "@edx/frontend-lib-special-exams": "~2.4.0",
         "@edx/frontend-platform": "3.4.1",
         "@edx/paragon": "20.28.4",
         "@fortawesome/fontawesome-svg-core": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "11.6.3",
     "@edx/frontend-component-header": "3.6.4",
-    "@edx/frontend-lib-special-exams": "2.4.0",
+    "@edx/frontend-lib-special-exams": "~2.4.0",
     "@edx/frontend-platform": "3.4.1",
     "@edx/paragon": "20.28.4",
     "@fortawesome/fontawesome-svg-core": "1.3.0",


### PR DESCRIPTION
To avoid any hiccups with our work on supporting edx-exams and current proctored exams happening, we should avoid any major or minor upgrades. `frontend-lib-special-exams` currently has no patched version between 2.4.0, and 2.5.0: https://github.com/openedx/frontend-lib-special-exams/releases