### PR TITLE
feat: add experimental atlas to pull_translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export TRANSIFEX_RESOURCE=frontend-app-learning
 transifex_langs = "ar,fr,es_419,zh_CN,pt,it,de,uk,ru,hi,fa_IR,fr_CA,it_IT,pt_PT,de_DE"
 
+intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
@@ -42,9 +43,23 @@ push_translations:
 	# Pushing comments to Transifex...
 	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
+ifeq ($(OPENEDX_ATLAS_PULL),)
 # Pulls translations from Transifex.
 pull_translations:
 	tx pull -f --mode reviewed --languages=$(transifex_langs)
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	rm -rf src/i18n/messages
+	mkdir src/i18n/messages
+	cd src/i18n/messages \
+      && atlas pull --filter=$(transifex_langs) \
+               translations/frontend-component-header/src/i18n/messages:frontend-component-header \
+               translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+               translations/frontend-app-learning/src/i18n/messages:frontend-app-learning
+
+	$(intl_imports) frontend-component-header frontend-component-footer frontend-app-learning
+endif
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,3 +1,6 @@
+import { messages as footerMessages } from '@edx/frontend-component-footer';
+import { messages as headerMessages } from '@edx/frontend-component-header';
+
 import arMessages from './messages/ar.json';
 import frMessages from './messages/fr.json';
 import es419Messages from './messages/es_419.json';
@@ -15,7 +18,7 @@ import ititCAMessages from './messages/it_IT.json';
 import ptptCAMessages from './messages/pt_PT.json';
 // no need to import en messages-- they are in the defaultMessage field
 
-const messages = {
+const appMessages = {
   ar: arMessages,
   'es-419': es419Messages,
   fr: frMessages,
@@ -33,4 +36,8 @@ const messages = {
   'pt-pt': ptptCAMessages,
 };
 
-export default messages;
+export default [
+  appMessages,
+  footerMessages,
+  headerMessages,
+];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,13 +11,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Switch } from 'react-router-dom';
 
-import { messages as footerMessages } from '@edx/frontend-component-footer';
-import { messages as headerMessages } from '@edx/frontend-component-header';
 import { Helmet } from 'react-helmet';
 import { fetchDiscussionTab, fetchLiveTab } from './course-home/data/thunks';
 import DiscussionTab from './course-home/discussion-tab/DiscussionTab';
 
-import appMessages from './i18n';
+import messages from './i18n';
 import { UserMessagesProvider } from './generic/user-messages';
 
 import './index.scss';
@@ -142,9 +140,5 @@ initialize({
       }, 'LearnerAppConfig');
     },
   },
-  messages: [
-    appMessages,
-    footerMessages,
-    headerMessages,
-  ],
+  messages,
 });

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -19,7 +19,7 @@ import { reducer as coursewareReducer } from './courseware/data/slice';
 import { reducer as modelsReducer } from './generic/model-store';
 import { UserMessagesProvider } from './generic/user-messages';
 
-import appMessages from './i18n';
+import messages from './i18n';
 import { fetchCourse, fetchSequence } from './courseware/data';
 import { appendBrowserTimezoneToUrl, executeThunk } from './utils';
 import buildSimpleCourseAndSequenceMetadata from './courseware/data/__factories__/sequenceMetadata.factory';
@@ -78,7 +78,7 @@ export function initializeMockApp() {
   configureI18n({
     config: getConfig(),
     loggingService,
-    messages: [appMessages],
+    messages,
   });
 
   return { loggingService, authService };


### PR DESCRIPTION
### Description

This is an experimental off-by-defualt feature for moving the translation files ouside the repos.

Run `OPENEDX_ATLAS_PULL=true make translations` to use `atlas` to pull translations instead of `transifex`.

### Changes

 - Centralize i18n messages import in `src/i18n/index.js`
 - Add new `pull_translations` implementation via `atlas`
 - Use the new `i18n-imports.js` script from https://github.com/openedx/frontend-platform/pull/463

### Reviewers
 - [x] Get initial feedback (done by Brian)
 - [x] Get the dependencies bumped to bring up `intl-imports.js` script:
    - https://github.com/openedx/frontend-component-footer/pull/286
    - https://github.com/openedx/frontend-component-header/pull/329
    - https://github.com/openedx/frontend-platform/pull/463 
 - [x] Upgrade `frontend-platform@3.x.x` in exams library (blocker): https://github.com/openedx/frontend-lib-special-exams/pull/89
 - [x] Quick QA: <details><summary>Screenshot</summary>![image](https://user-images.githubusercontent.com/645156/234812969-47536d86-9605-40ff-9600-0b98fbbedee4.png)</details> 
 - [x] Fix tests


### Sample expected outcome

The file tree after running the new `pull_translations` will look like the following:

All messages will be pulled fresh, without depending on any messages from the MFE or its depedencies.

```
frontend-app-learning $ tree src/i18n/
src/i18n/
├── index.js
└── messages
    ├── frontend-app-learning
    │   ├── ar.json
    │   ├── de.json
    │   ├── es_419.json
    │   ├── fr_CA.json
    │   ├── index.js
    │   ├── ru.json
    │   ├── uk.json
    │   └── zh_CN.json
    ├── frontend-component-footer
    │   ├── ar.json
    │   ├── de_DE.json
    │   ├── de.json
    │   ├── es_419.json
    │   ├── fr_CA.json
    │   ├── fr.json
    │   ├── hi.json
    │   ├── it_IT.json
    │   ├── it.json
    │   ├── pt.json
    │   ├── pt_PT.json
    │   ├── ru.json
    │   ├── uk.json
    │   └── zh_CN.json
    └── frontend-component-header
```

### Sample package `index.js` file

For each directory/package an `index.js` file will be generated if and only if there are messages in the files:

```js
// This file is generated by the Open edX generate-mfe-i18n-imports.
// Refer to docs yada yada ...
//

import messages0ar from './ar.json';
import messages1de from './de.json';
import messages2es_419 from './es_419.json';
import messages3fr_CA from './fr_CA.json';
import messages4ru from './ru.json';
import messages5uk from './uk.json';
import messages6zh_CN from './zh_CN.json';
const messages = {
  'ar': messages0ar,
  'zh-cn': messages6zh_CN,
  'uk': messages5uk,
  'ru': messages4ru,
  'fr-ca': messages3fr_CA,
  'es-419': messages2es_419,
  'de': messages1de,
};
export default messages;
```

### Sample MFE `src/i18n/index.js` file

A new `index.js` is going to be generated containing only downloaded languages.

```js
// This file is generated by the Open edX frontend-platform's i18n-imports commands.
//

import messages1frontendcomponentheader from './messages/frontend-component-header';
// footer is omitted due to not having translations
import messages2frontendapplearning from './messages/frontend-app-learning';

export default [
  messages1frontendcomponentheader,
  messages2frontendapplearning,
];
```


References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes