### PR TITLE
fix: make iframe wrapper take all vieport width

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -82,14 +82,9 @@
   flex-direction: column;
   flex-grow: 1;
   margin-bottom: 4rem;
-
-  // On mobile, the unit container will be responsible
-  // for container padding.
-  @media (min-width: map-get($grid-breakpoints, "sm")) {
-    width: 100%;
-    margin-right: auto;
-    margin-left: auto;
-  }
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
 }
 
 .sequence {
@@ -268,10 +263,16 @@
 }
 
 .unit-container {
-  padding: 0 $grid-gutter-width 2rem;
+  padding-top: 0;
+  padding-bottom: 2rem;
   max-width: 1024px;
   margin-left: auto;
   margin-right: auto;
+
+  @media (min-width: map-get($grid-breakpoints, "sm")) {
+    padding-left: $grid-gutter-width;
+    padding-right: $grid-gutter-width;
+  }
 
   @media (min-width: 830px) {
     padding-left: 40px;
@@ -280,7 +281,18 @@
 }
 
 .unit-iframe-wrapper {
-  margin: 0 -20px 2rem;
+  margin-top: 0;
+
+  // Some XBlocks (such as xblock-drag-and-drop-v2) rely on the viewport width
+  // to determine their layout on mobile. This is problematic because the
+  // viewport width may not be the same as the width of the iframe. To fix this,
+  // here we compensate for the padding of the parent div with "container-xl"
+  // class to ensure that the viewport width is the same as the width of the
+  // iframe.
+  margin-left: -$grid-gutter-width * .5;
+  margin-right: -$grid-gutter-width * .5;
+
+  margin-bottom: 2rem;
 
   @media (min-width: 830px) {
     margin: 0 -40px 2rem;


### PR DESCRIPTION
## Description

Resolves openedx/xblock-drag-and-drop-v2#312. Probably it was introduced in https://github.com/openedx/frontend-app-learning/pull/27.

Consider how the block interface behaves in the legacy courseware (Lilac):

https://user-images.githubusercontent.com/18251194/229360280-a705d79f-01c2-4148-a011-3c1f2f784e99.mp4

On the video you can see that when the viewport reaches 480px, the block resets content width and makes it scrollable. This was implemented this way intentionally in this PR: https://github.com/openedx/xblock-drag-and-drop-v2/pull/135.


Here is how it behaves in this MFE:

https://user-images.githubusercontent.com/18251194/229360306-7cd81313-51d9-4b3f-a7f6-bd1eccb254bf.mp4

Something weird happens when the viewport width reaches 574px. The iframe shrinks, making XBlock very hard to use.

With changes from this PR:

https://user-images.githubusercontent.com/18251194/229360318-02121d34-84f8-4c3e-837f-d4ff5de7ef69.mp4

It basically removes / compensates padding from the iframe's parent containers and sets 100% width for the iframe container itself. You can see that the block now behaves as in the legacy courseware.

## Testing instructions

1. Switch `$(DEVSTACK_ROOT)/frontend-app-learning` to this branch.
2. Verify that `xblock-drag-and-drop-v2`'s content behaves exactly as on the third video in different browsers.

## Misc notes

You may notice that this icon is shifted, when it's supposed to stay next to the navigation:
![image](https://user-images.githubusercontent.com/18251194/229362310-33cf07b0-b0cb-4843-a570-19b80e3a68e7.png)

It's not related to this PR's changes, and probably has been introduced here: https://github.com/openedx/frontend-app-learning/pull/414 

Also see [this comment](https://github.com/openedx/platform-roadmap/issues/268#issuecomment-1611291912) with a diagram where this icon should be.

[private-ref](https://tasks.opencraft.com/browse/BB-7211)