### PR TITLE
fix: make links clickable behind content tools

### DIFF
--- a/src/courseware/course/content-tools/contentTools.scss
+++ b/src/courseware/course/content-tools/contentTools.scss
@@ -1,6 +1,5 @@
 .content-tools {
   position: fixed;
-  left: 0;
   right: 0;
   bottom: 0;
   z-index: 100;


### PR DESCRIPTION
Description:
Links parallel to the content tool buttons are not clickable.

Issue:
https://github.com/mitodl/mitxpro/issues/2604

As you can see from the screen recording when links are parallel to the content tools, the links are not clickable.

https://user-images.githubusercontent.com/52656433/230077023-7defd227-b1cb-4e54-b74c-3e0fef4c5f34.mov

