### PR TITLE
feat: upgrade special exams version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "11.6.3",
         "@edx/frontend-component-header": "3.6.4",
-        "@edx/frontend-lib-special-exams": "2.10.0",
+        "@edx/frontend-lib-special-exams": "2.12.0",
         "@edx/frontend-platform": "3.4.1",
         "@edx/paragon": "20.28.4",
         "@fortawesome/fontawesome-svg-core": "1.3.0",
@@ -3272,9 +3272,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.10.0.tgz",
-      "integrity": "sha512-YHTYlmHIVM6KRTklbM3ERHmu1adRoMIpYTWwn/KhEQ/a6YQfRM8SJt8uawj4ceSRftJ7E9QWMGy/21KfnIYOxg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.12.0.tgz",
+      "integrity": "sha512-VltUW9bZ+Ha9Gw4xplEJjfZi4zjUJJWsAFOVeX8n+ZJLko4qDU46tL7EOLAJyMaiAtjvHent8MNIfcGBbqgcFQ==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",
@@ -28482,9 +28482,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.10.0.tgz",
-      "integrity": "sha512-YHTYlmHIVM6KRTklbM3ERHmu1adRoMIpYTWwn/KhEQ/a6YQfRM8SJt8uawj4ceSRftJ7E9QWMGy/21KfnIYOxg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.12.0.tgz",
+      "integrity": "sha512-VltUW9bZ+Ha9Gw4xplEJjfZi4zjUJJWsAFOVeX8n+ZJLko4qDU46tL7EOLAJyMaiAtjvHent8MNIfcGBbqgcFQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "11.6.3",
     "@edx/frontend-component-header": "3.6.4",
-    "@edx/frontend-lib-special-exams": "2.10.0",
+    "@edx/frontend-lib-special-exams": "2.12.0",
     "@edx/frontend-platform": "3.4.1",
     "@edx/paragon": "20.28.4",
     "@fortawesome/fontawesome-svg-core": "1.3.0",


### PR DESCRIPTION
Upgrade to the latest version of the special exams lib, which includes these changes: [openedx/frontend-lib-special-exams@feb32dd...a37b9fa](https://github.com/openedx/frontend-lib-special-exams/compare/v2.10.0...v2.12.0)