### PR TITLE
chore: upgrade frontend-lib-special-exams version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "11.6.3",
         "@edx/frontend-component-header": "3.6.4",
-        "@edx/frontend-lib-special-exams": "2.15.0",
+        "@edx/frontend-lib-special-exams": "2.16.0",
         "@edx/frontend-platform": "3.4.1",
         "@edx/paragon": "20.28.4",
         "@fortawesome/fontawesome-svg-core": "1.3.0",
@@ -3272,9 +3272,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.15.0.tgz",
-      "integrity": "sha512-hRKv+88s0fQ1wDhoGx3kJtmR+1LtLmHx/fTtZYMCV4ze90NHhR7oc6i5+dcysbZLIQbtTnfVd+n0Q1L2qnYJYg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.16.0.tgz",
+      "integrity": "sha512-jCix80D9XM9PwbqtyURhTh126RT6Bcyca2DT7FwiiBWNTlzYZ9rtjHjGaS6Oddl5lXAyj2K60kuosgQ7V3shfg==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",
@@ -28482,9 +28482,9 @@
       }
     },
     "@edx/frontend-lib-special-exams": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.15.0.tgz",
-      "integrity": "sha512-hRKv+88s0fQ1wDhoGx3kJtmR+1LtLmHx/fTtZYMCV4ze90NHhR7oc6i5+dcysbZLIQbtTnfVd+n0Q1L2qnYJYg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.16.0.tgz",
+      "integrity": "sha512-jCix80D9XM9PwbqtyURhTh126RT6Bcyca2DT7FwiiBWNTlzYZ9rtjHjGaS6Oddl5lXAyj2K60kuosgQ7V3shfg==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "11.6.3",
     "@edx/frontend-component-header": "3.6.4",
-    "@edx/frontend-lib-special-exams": "2.15.0",
+    "@edx/frontend-lib-special-exams": "2.16.0",
     "@edx/frontend-platform": "3.4.1",
     "@edx/paragon": "20.28.4",
     "@fortawesome/fontawesome-svg-core": "1.3.0",


### PR DESCRIPTION
## [MST-1883](https://2u-internal.atlassian.net/browse/MST-1883)

The latest version of `frontend-lib-special-exams` bumps the peer dependency version for `frontend-platform`.