### PR TITLE
[BACKPORT (OLIVE)] fix: make links clickable behind content tools

### DIFF
--- a/src/courseware/course/content-tools/contentTools.scss
+++ b/src/courseware/course/content-tools/contentTools.scss
@@ -1,6 +1,5 @@
 .content-tools {
   position: fixed;
-  left: 0;
   right: 0;
   bottom: 0;
   z-index: 100;


### PR DESCRIPTION
Backport of https://github.com/openedx/frontend-app-learning/pull/1096