### PR TITLE
fix: gracefully handle 403 responses in tab loading

### DIFF
--- a/src/course-home/data/__factories__/outlineTabData.factory.js
+++ b/src/course-home/data/__factories__/outlineTabData.factory.js
@@ -28,6 +28,7 @@ Factory.define('outlineTabData')
     upgrade_url: `${host}/dashboard`,
   }))
   .attrs({
+    course_access_redirect: false,
     has_scheduled_content: null,
     access_expiration: null,
     can_show_upgrade_sock: false,


### PR DESCRIPTION
From https://github.com/openedx/edx-platform/pull/32210 :
> The issue:
>
> When a learner navigates to a Learning MFE course overview page, we hit (the course outline) API.(the course outline) API uses get_course_with_access to check whether or not the learner can access this course. If not, get_course_with_access raises a CourseAccessError, which causes the request to return a 302 and a URL to redirect to.
>
> This is useful in cases where the user is requesting a web page - they will be automatically redirected to another page depending on their state. However, this is being requested as an API request. When the error is raised, we then attempt to make an API request to various other sites. In this case, it's the learner home, which then requests the auth service, and causes the CORS. The CORS is an error, but it's not really the issue here. We shouldn't be making an ajax request to the redirect URL at all. We should be redirecting the user's web browser to the redirect URL.

The above PR is the change to the outline API to prevent the auto redirect and to instead return a 403.

There is an existing mechanism in the TabPage component to handle this redirect. Redirect information is passed via the  course metadata endpoint, and all we need to do is not raise an exception when loading the outline. We have the same behavior in the progress and outline views as well, so I also made this change there, to expect and ignore the 403. 

Testing instructions in the edx-platform PR