### PR TITLE
fix: logging an error when unit iframe fails to load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/frontend-component-footer": "12.0.0",
         "@edx/frontend-component-header": "4.0.0",
         "@edx/frontend-lib-special-exams": "2.16.2",
-        "@edx/frontend-platform": "4.2.0",
+        "@edx/frontend-platform": "^4.3.0",
         "@edx/paragon": "20.28.4",
         "@fortawesome/fontawesome-svg-core": "1.3.0",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -3449,9 +3449,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.2.0.tgz",
-      "integrity": "sha512-iDoFeccENQKBjqUgdjl5KSwBrjNEj8YW6Ual+6twcHHJUBg3yRoBEphwHIoRREcMgQjhdKVAdWj8eleh4JsEKA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.3.0.tgz",
+      "integrity": "sha512-8ySsSN8c8GHLDqhVwXE1yKm9717KaZ9AyTTnD8TQlBL81CQ0CaR/QCNaNmm3imYnGVkyU+XeReLILybyWiLSeQ==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -28717,9 +28717,9 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.2.0.tgz",
-      "integrity": "sha512-iDoFeccENQKBjqUgdjl5KSwBrjNEj8YW6Ual+6twcHHJUBg3yRoBEphwHIoRREcMgQjhdKVAdWj8eleh4JsEKA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.3.0.tgz",
+      "integrity": "sha512-8ySsSN8c8GHLDqhVwXE1yKm9717KaZ9AyTTnD8TQlBL81CQ0CaR/QCNaNmm3imYnGVkyU+XeReLILybyWiLSeQ==",
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@edx/frontend-component-footer": "12.0.0",
     "@edx/frontend-component-header": "4.0.0",
     "@edx/frontend-lib-special-exams": "2.16.2",
-    "@edx/frontend-platform": "4.2.0",
+    "@edx/frontend-platform": "4.3.0",
     "@edx/paragon": "20.28.4",
     "@fortawesome/fontawesome-svg-core": "1.3.0",
     "@fortawesome/free-brands-svg-icons": "5.15.4",

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -251,6 +251,9 @@ const Unit = ({
               // could have given us a 4xx or 5xx response.
               if (!hasLoaded) {
                 setShowError(true);
+                logError('Unit iframe failed to load. Server possibly returned 4xx or 5xx response.', {
+                  iframeUrl,
+                });
               }
 
               window.onmessage = (e) => {


### PR DESCRIPTION
Right now we log nothing to the logging service when a unit iframe fails to load.  The ErrorPage that’s shown isn’t using the ErrorBoundary, so we had no indication that something went wrong.  This solves the problem closer to the source where the error originates.

This PR also bumps frontend-platform to 4.3.0 to pick up the new feature that automatically logs the userId to the logging service whenever an error occurs.  