### PR TITLE
fix: sync LMS_BASE_URL for bookmark API if changed

### DIFF
--- a/src/courseware/course/bookmark/BookmarkButton.test.jsx
+++ b/src/courseware/course/bookmark/BookmarkButton.test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { getConfig } from '@edx/frontend-platform';
 import { Factory } from 'rosie';
 import {
   render, screen, fireEvent, initializeTestStore, waitFor, authenticatedUser, logUnhandledRequests,
 } from '../../../setupTest';
 import { BookmarkButton } from './index';
+import { getBookmarksBaseUrl } from './data/api';
 
 describe('Bookmark Button', () => {
   let axiosMock;
@@ -32,7 +32,8 @@ describe('Bookmark Button', () => {
     mockData.unitId = nonBookmarkedUnitBlock.id;
 
     axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-    const bookmarkUrl = `${getConfig().LMS_BASE_URL}/api/bookmarks/v1/bookmarks/`;
+    const bookmarkUrl = getBookmarksBaseUrl();
+
     axiosMock.onPost(bookmarkUrl).reply(200, { });
 
     const bookmarkDeleteUrlRegExp = new RegExp(`${bookmarkUrl}*,*`);

--- a/src/courseware/course/bookmark/data/api.js
+++ b/src/courseware/course/bookmark/data/api.js
@@ -1,13 +1,13 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
-const bookmarksBaseUrl = `${getConfig().LMS_BASE_URL}/api/bookmarks/v1/bookmarks/`;
+export const getBookmarksBaseUrl = () => `${getConfig().LMS_BASE_URL}/api/bookmarks/v1/bookmarks/`;
 
 export async function createBookmark(usageId) {
-  return getAuthenticatedHttpClient().post(bookmarksBaseUrl, { usage_id: usageId });
+  return getAuthenticatedHttpClient().post(getBookmarksBaseUrl(), { usage_id: usageId });
 }
 
 export async function deleteBookmark(usageId) {
   const { username } = getAuthenticatedUser();
-  return getAuthenticatedHttpClient().delete(`${bookmarksBaseUrl}${username},${usageId}/`);
+  return getAuthenticatedHttpClient().delete(`${getBookmarksBaseUrl()}${username},${usageId}/`);
 }


### PR DESCRIPTION
  This change makes it possible to use the latest  LMS_BASE_API
  if it was changed because of dynamic config API, which is the
  default case of tutor.

  This changes closes
  -  openedx/wg-build-test-release/issues/270

   Fixes that are simlar to this
  - gradebook openedx/frontend-app-gradebook/pull/290
  - course authoring openedx/frontend-app-course-authoring/pull/389
  
  ## Testing 
  
  ### Tutor 
  - Create a plugin tutor file `nano "$(tutor plugins printroot)/learning.py"`
  ```python
  from tutor import hooks
from tutormfe.plugin import MFE_APPS

@MFE_APPS.add()
def _add_my_mfe(mfes):
    mfes["learning"] = {
        "repository": "https://github.com/ghassanmas/frontend-app-learning",
        "port": 2000,
        "version": "fix-btr-270", # optional, will default to the Open edX current tag.
    }
    return mfes
  ```
  
  ```bash
tutor plugins enable leanring
tutor images buile mfe
tutor local start mfe -d 
  ```
  
  ### Devstack
   - It should still be working as expected assuming config api is enabled and LMS_BASE url is fetched only through the dynamic config api
   
   
   ## Last step 
   
   - Try reproduce the bug by following the test report @ openedx/wg-build-test-release/issues/270
  
  ## Todos 
   - [x] Test thse changes on tutor local latest plam branch 
   - [x] Ensure the test don't fail locally 
   - [x] Ensure the test don't fail on CI