### PR TITLE
fix: modifies sidebar state such that it remains open

### DIFF
--- a/src/courseware/course/sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.jsx
@@ -40,7 +40,7 @@ const SidebarProvider = ({
       setCurrentSidebar(initialSidebar);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialSidebar, verifiedMode]);
+  }, [initialSidebar, verifiedMode, unitId]);
 
   const onNotificationSeen = useCallback(() => {
     setNotificationStatus('inactive');
@@ -49,11 +49,6 @@ const SidebarProvider = ({
 
   const toggleSidebar = useCallback((sidebarId) => {
     // Switch to new sidebar or hide the current sidebar
-    if (currentSidebar === SIDEBARS.DISCUSSIONS.ID) {
-      localStorage.setItem('showDiscussionSidebar', false);
-    } else if (sidebarId === SIDEBARS.DISCUSSIONS.ID) {
-      localStorage.setItem('showDiscussionSidebar', true);
-    }
     setCurrentSidebar(sidebarId === currentSidebar ? null : sidebarId);
   }, [currentSidebar]);
 

--- a/src/courseware/course/sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.jsx
@@ -5,7 +5,6 @@ import React, {
 } from 'react';
 
 import { getLocalStorage, setLocalStorage } from '../../../data/localStorage';
-import { getSessionStorage } from '../../../data/sessionStorage';
 import { useModel } from '../../../generic/model-store';
 import SidebarContext from './SidebarContext';
 import { SIDEBARS } from './sidebars';
@@ -18,29 +17,21 @@ const SidebarProvider = ({
   const { verifiedMode } = useModel('courseHomeMeta', courseId);
   const shouldDisplayFullScreen = useWindowSize().width < breakpoints.large.minWidth;
   const shouldDisplaySidebarOpen = useWindowSize().width > breakpoints.medium.minWidth;
-  const showNotificationsOnLoad = getSessionStorage(`notificationTrayStatus.${courseId}`) !== 'closed';
   const query = new URLSearchParams(window.location.search);
-  if (query.get('sidebar') === 'true') {
-    localStorage.setItem('showDiscussionSidebar', true);
-  }
-  const showDiscussionSidebar = localStorage.getItem('showDiscussionSidebar') !== 'false';
-  const showNotificationSidebar = (verifiedMode && shouldDisplaySidebarOpen && showNotificationsOnLoad)
-    ? SIDEBARS.NOTIFICATIONS.ID
-    : null;
-  const initialSidebar = showDiscussionSidebar
+  const initialSidebar = ((verifiedMode && shouldDisplaySidebarOpen) || query.get('sidebar') === 'true')
     ? SIDEBARS.DISCUSSIONS.ID
-    : showNotificationSidebar;
+    : null;
   const [currentSidebar, setCurrentSidebar] = useState(initialSidebar);
   const [notificationStatus, setNotificationStatus] = useState(getLocalStorage(`notificationStatus.${courseId}`));
   const [upgradeNotificationCurrentState, setUpgradeNotificationCurrentState] = useState(getLocalStorage(`upgradeNotificationCurrentState.${courseId}`));
 
   useEffect(() => {
     // As a one-off set initial sidebar if the verified mode data has just loaded
-    if (verifiedMode && currentSidebar === null && initialSidebar) {
-      setCurrentSidebar(initialSidebar);
+    if (verifiedMode) {
+      setCurrentSidebar(SIDEBARS.DISCUSSIONS.ID);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialSidebar, verifiedMode, unitId]);
+  }, [verifiedMode, unitId]);
 
   const onNotificationSeen = useCallback(() => {
     setNotificationStatus('inactive');


### PR DESCRIPTION
[INF-915](https://2u-internal.atlassian.net/browse/INF-915)

- Removed state tracking and such that the sidebar always opens when a user navigates to a unit.
- The close button should still allow users to close the sidebar, but it should re-open when user reloads the page or navigates to another unit that has discussions enabled.