### PR TITLE
[BD-46] feat: added Paragon translations

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,5 +1,6 @@
 import { messages as footerMessages } from '@edx/frontend-component-footer';
 import { messages as headerMessages } from '@edx/frontend-component-header';
+import { messages as paragonMessages } from '@edx/paragon';
 
 import arMessages from './messages/ar.json';
 import frMessages from './messages/fr.json';
@@ -37,6 +38,7 @@ const appMessages = {
 };
 
 export default [
+  paragonMessages,
   appMessages,
   footerMessages,
   headerMessages,


### PR DESCRIPTION
- Ensure paragonMessages gets passed to the initialization so the hardcoded English strings throughout Paragon components use translations instead.

Issue: https://github.com/openedx/frontend-app-gradebook/issues/340