### PR TITLE
fix: error when navigating exam units

### DIFF
--- a/src/courseware/course/sequence/Unit/hooks/useExamAccess.js
+++ b/src/courseware/course/sequence/Unit/hooks/useExamAccess.js
@@ -16,7 +16,7 @@ const useExamAccess = ({
   const [blockAccess, setBlockAccess] = useKeyedState(stateKeys.blockAccess, isExam());
   React.useEffect(() => {
     if (isExam()) {
-      return fetchExamAccess()
+      fetchExamAccess()
         .finally(() => {
           const examAccess = getExamAccess();
           setAccessToken(examAccess);
@@ -26,7 +26,6 @@ const useExamAccess = ({
           logError(error);
         });
     }
-    return undefined;
   }, [id]);
 
   return {

--- a/src/courseware/course/sequence/Unit/hooks/useExamAccess.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useExamAccess.test.js
@@ -4,6 +4,7 @@ import { mockUseKeyedState } from '@edx/react-unit-test-utils';
 import { getExamAccess, fetchExamAccess, isExam } from '@edx/frontend-lib-special-exams';
 import { isEqual } from 'lodash';
 
+import { waitFor } from '../../../../../setupTest';
 import useExamAccess, { stateKeys } from './useExamAccess';
 
 const getEffect = (prereqs) => {
@@ -54,19 +55,20 @@ describe('useExamAccess hook', () => {
       useExamAccess({ id });
       state.expectInitializedWith(stateKeys.blockAccess, true);
     });
-    describe('effects - on id change', () => {
-      let cb;
+    describe.only('effects - on id change', () => {
+      let useEffectCb;
       beforeEach(() => {
         useExamAccess({ id });
-        cb = getEffect([id], React);
+        useEffectCb = getEffect([id], React);
       });
       it('does not call fetchExamAccess if not an exam', () => {
-        cb();
+        useEffectCb();
         expect(fetchExamAccess).not.toHaveBeenCalled();
       });
       it('fetches and sets exam access if isExam', async () => {
         isExam.mockReturnValueOnce(true);
-        await cb();
+        useEffectCb();
+        await waitFor(() => expect(fetchExamAccess).toHaveBeenCalled());
         state.expectSetStateCalledWith(stateKeys.accessToken, testAccessToken);
         state.expectSetStateCalledWith(stateKeys.blockAccess, false);
       });
@@ -74,7 +76,8 @@ describe('useExamAccess hook', () => {
       it('logs error if fetchExamAccess fails', async () => {
         isExam.mockReturnValueOnce(true);
         fetchExamAccess.mockReturnValueOnce(Promise.reject(testError));
-        await cb();
+        useEffectCb();
+        await waitFor(() => expect(fetchExamAccess).toHaveBeenCalled());
         expect(logError).toHaveBeenCalledWith(testError);
       });
     });

--- a/src/courseware/course/sequence/Unit/hooks/useExamAccess.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useExamAccess.test.js
@@ -55,7 +55,7 @@ describe('useExamAccess hook', () => {
       useExamAccess({ id });
       state.expectInitializedWith(stateKeys.blockAccess, true);
     });
-    describe.only('effects - on id change', () => {
+    describe('effects - on id change', () => {
       let useEffectCb;
       beforeEach(() => {
         useExamAccess({ id });


### PR DESCRIPTION
### [MST-2029](https://2u-internal.atlassian.net/browse/MST-2029?atlOrigin=eyJpIjoiYjM4N2Y2MjY3YjA4NDA3Nzg0OWY2ZWFiYTMyNjJlMmYiLCJwIjoiaiJ9)

This useEffect hook would occasionally cause React to choke. By returning a value here we're telling react to callback that function on cleanup, except we're returning a Promise not a function so it blows up. There's no need to return anything here.

There may be another issue or change that caused this problem to surface but this fixed the error for me locally.