### PR TITLE
feat: Revert "Revert "feat: update special exams lib""

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "12.0.0",
         "@edx/frontend-component-header": "4.0.0",
-        "@edx/frontend-lib-special-exams": "2.19.1",
+        "@edx/frontend-lib-special-exams": "2.20.1",
         "@edx/frontend-platform": "4.3.0",
         "@edx/paragon": "20.46.0",
         "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.5.3",
@@ -3432,9 +3432,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.19.1.tgz",
-      "integrity": "sha512-J/mV4ca8dTXBZfMcSx520AhI4bvFTRh+leLUjYagN0Q+umhewFdI25e6cuSife6dIh4xnxMkdyMAs6Onb0CSzw==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.20.1.tgz",
+      "integrity": "sha512-AF0ubUIklG25hjuhFdtHpSruNfzV8azkAUw+47RP+3ffRdTlJq8JcNT0BWHOsZL0+DKKE2xtwwaVL5gY31R1vg==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",
@@ -3449,8 +3449,8 @@
         "@edx/paragon": "^19.4.1 || ^20.22.4",
         "@reduxjs/toolkit": "^1.5.1",
         "prop-types": "^15.7.2",
-        "react": "^16.14.0",
-        "react-dom": "^16.14.0",
+        "react": "^16.14.0 || ^17.0.0",
+        "react-dom": "^16.14.0 || ^17.0.0",
         "react-redux": "^7.1.3",
         "react-router": "^5.1.2",
         "react-router-dom": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "12.0.0",
     "@edx/frontend-component-header": "4.0.0",
-    "@edx/frontend-lib-special-exams": "2.19.1",
+    "@edx/frontend-lib-special-exams": "2.20.1",
     "@edx/frontend-platform": "4.3.0",
     "@edx/paragon": "20.46.0",
     "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.5.3",


### PR DESCRIPTION
Reverts openedx/frontend-app-learning#1154

This PR was originally reverted due to it's deploy coinciding with the app breaking. Turns out it was not the root cause.