### PR TITLE
feat: add config value for chat response url

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -137,6 +137,7 @@ initialize({
         EXAMS_BASE_URL: process.env.EXAMS_BASE_URL || null,
         PROCTORED_EXAM_FAQ_URL: process.env.PROCTORED_EXAM_FAQ_URL || null,
         PROCTORED_EXAM_RULES_URL: process.env.PROCTORED_EXAM_RULES_URL || null,
+        CHAT_RESPONSE_URL: process.env.CHAT_RESPONSE_URL || null,
       }, 'LearnerAppConfig');
     },
   },


### PR DESCRIPTION
## [MST-2041](https://2u-internal.atlassian.net/browse/MST-2041)

Expose config value so that it can be consumed by `frontend-lib-learning-assistant`, which will be installed in the learning MFE.