### PR TITLE
fix: should not fetch courseTopics for lti provider

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsTrigger.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsTrigger.jsx
@@ -3,7 +3,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Icon } from '@edx/paragon';
 import { QuestionAnswer } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useModel } from '../../../../../generic/model-store';
 import { getCourseDiscussionTopics } from '../../../../data/thunks';
@@ -23,12 +23,17 @@ const DiscussionsTrigger = ({
     courseId,
   } = useContext(SidebarContext);
   const dispatch = useDispatch();
+  const { tabs } = useModel('courseHomeMeta', courseId);
   const topic = useModel('discussionTopics', unitId);
   const baseUrl = getConfig().DISCUSSIONS_MFE_BASE_URL;
+  const ltiProvider = useMemo(
+    () => tabs?.find(tab => tab.slug === 'lti_discussion'),
+    [tabs],
+  );
 
   useEffect(() => {
     // Only fetch the topic data if the MFE is configured.
-    if (baseUrl) {
+    if (baseUrl && !ltiProvider) {
       dispatch(getCourseDiscussionTopics(courseId));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsTrigger.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsTrigger.jsx
@@ -26,14 +26,13 @@ const DiscussionsTrigger = ({
   const { tabs } = useModel('courseHomeMeta', courseId);
   const topic = useModel('discussionTopics', unitId);
   const baseUrl = getConfig().DISCUSSIONS_MFE_BASE_URL;
-  const ltiProvider = useMemo(
-    () => tabs?.find(tab => tab.slug === 'lti_discussion'),
+  const edxProvider = useMemo(
+    () => tabs?.find(tab => tab.slug === 'discussion'),
     [tabs],
   );
 
   useEffect(() => {
-    // Only fetch the topic data if the MFE is configured.
-    if (baseUrl && !ltiProvider) {
+    if (baseUrl && edxProvider) {
       dispatch(getCourseDiscussionTopics(courseId));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### [INF-1024](https://2u-internal.atlassian.net/browse/INF-1024)

- [course-topics](api/discussion/v1/courses/course-id) This API call raises an error when the discussion provider is set to LTI. e.g Yellowdig. This API call should only call when the discussion provider is edx.
- Error - "Discussion is disabled for the course."