### PR TITLE
fix: toggle notes visibility button state correctly

### DIFF
--- a/src/courseware/course/content-tools/notes-visibility/NotesVisibility.jsx
+++ b/src/courseware/course/content-tools/notes-visibility/NotesVisibility.jsx
@@ -25,7 +25,7 @@ class NotesVisibility extends Component {
   }
 
   handleClick = () => {
-    const data = { visibility: this.state.visible };
+    const data = { visibility: !this.state.visible };
     getAuthenticatedHttpClient().put(
       this.visibilityUrl,
       data,

--- a/src/courseware/course/content-tools/notes-visibility/NotesVisibility.test.jsx
+++ b/src/courseware/course/content-tools/notes-visibility/NotesVisibility.test.jsx
@@ -85,7 +85,7 @@ describe('Notes Visibility', () => {
 
     expect(axiosMock.history.put).toHaveLength(1);
     expect(axiosMock.history.put[0].url).toEqual(visibilityUrl);
-    expect(axiosMock.history.put[0].data).toEqual(`{"visibility":${mockData.course.notes.visible}}`);
+    expect(axiosMock.history.put[0].data).toEqual(`{"visibility":${!mockData.course.notes.visible}}`);
 
     expect(screen.getByRole('switch', { name: 'Hide Notes' })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Description

The "Show/Hide Notes" button saves the opposite of its selected state with the `/courses/<course_id>/edxnotes/visibility/` API. This fixes that.

## Testing instructions

1. Enable Notes in a Course Advanced settings
2. Open a Course unit as a Student
3. Use the button
3.1. If the button shows as "Show Notes", click (so it toggles to "Hide Notes"), check that the value sent to `PUT /courses/<course_id>/edxnotes/visibility/` is `{visibility: true}`
3.2. If the button shows as "Hide Notes", click (so it toggles to "Show Notes"), check that the value sent to `PUT /courses/<course_id>/edxnotes/visibility/` is `{visibility: false}`

This independent of the effective visibility of the notes, which might not always correspond to the state in the MFE upon page load due to openedx/wg-build-test-release#227 / openedx/frontend-app-learning#1005.