### PR TITLE
fix: prevent content tools from displaying over chat sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "12.0.0",
         "@edx/frontend-component-header": "4.0.0",
-        "@edx/frontend-lib-learning-assistant": "^1.9.3",
+        "@edx/frontend-lib-learning-assistant": "^1.9.4",
         "@edx/frontend-lib-special-exams": "2.20.1",
         "@edx/frontend-platform": "4.3.0",
         "@edx/paragon": "20.46.0",
@@ -3433,9 +3433,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-1.9.3.tgz",
-      "integrity": "sha512-kk8cbdWm94/oph4i/6TidVPTqPStoge/qS8Kr53gx1hH7u9cKU8fLM8KWQAG00KL3sYTWRJ0D3C6SqwgNCpSiA==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-1.9.4.tgz",
+      "integrity": "sha512-dtupXZJdTxKyat9lWTNxQYzvBmS4ESewBhZd/sDiyBdHvNzGl3VHMeCzLz42Gk7B0oz7mrsd/xZHAu4FVU8qdA==",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "12.0.0",
     "@edx/frontend-component-header": "4.0.0",
-    "@edx/frontend-lib-learning-assistant": "^1.9.3",
+    "@edx/frontend-lib-learning-assistant": "^1.9.4",
     "@edx/frontend-lib-special-exams": "2.20.1",
     "@edx/frontend-platform": "4.3.0",
     "@edx/paragon": "20.46.0",

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -98,6 +98,7 @@ const Course = ({
               enrollmentMode={course.enrollmentMode}
               isStaff={isStaff}
               courseId={courseId}
+              contentToolsEnabled={course.showCalculator || course.notes.enabled}
             />
             <SidebarTriggers />
           </>

--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -9,6 +9,7 @@ const Chat = ({
   enrollmentMode,
   isStaff,
   courseId,
+  contentToolsEnabled,
 }) => {
   const VERIFIED_MODES = [
     'professional',
@@ -34,7 +35,7 @@ const Chat = ({
     <>
       {/* Use a portal to ensure that component overlay does not compete with learning MFE styles. */}
       {shouldDisplayChat && (createPortal(
-        <Xpert courseId={courseId} />,
+        <Xpert courseId={courseId} contentToolsEnabled={contentToolsEnabled} />,
         document.body,
       ))}
     </>
@@ -46,6 +47,7 @@ Chat.propTypes = {
   enabled: PropTypes.bool.isRequired,
   enrollmentMode: PropTypes.string,
   courseId: PropTypes.string.isRequired,
+  contentToolsEnabled: PropTypes.bool.isRequired,
 };
 
 Chat.defaultProps = {

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -42,6 +42,7 @@ describe('Chat', () => {
               isStaff={false}
               enabled
               courseId={courseId}
+              contentToolsEnabled={false}
             />
           </BrowserRouter>,
           { store },
@@ -74,6 +75,7 @@ describe('Chat', () => {
             isStaff
             enabled
             courseId={courseId}
+            contentToolsEnabled={false}
           />
         </BrowserRouter>,
         { store },
@@ -134,6 +136,7 @@ describe('Chat', () => {
               isStaff={test.isStaff}
               enabled={test.enabled}
               courseId={courseId}
+              contentToolsEnabled={false}
             />
           </BrowserRouter>,
           { store },

--- a/src/courseware/course/content-tools/ContentTools.jsx
+++ b/src/courseware/course/content-tools/ContentTools.jsx
@@ -1,23 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 
 import Calculator from './calculator';
 import NotesVisibility from './notes-visibility';
 
 const ContentTools = ({
   course,
-}) => (
-  <div className="content-tools">
-    <div className="d-flex justify-content-end align-items-end m-0">
-      {course.showCalculator && (
-      <Calculator />
-      )}
-      {course.notes.enabled && (
-      <NotesVisibility course={course} />
-      )}
-    </div>
-  </div>
-);
+}) => {
+  const {
+    sidebarIsOpen,
+  } = useSelector(state => state.learningAssistant);
+
+  return (
+    !sidebarIsOpen && (
+      <div className="content-tools">
+        <div className="d-flex justify-content-end align-items-end m-0">
+          {course.showCalculator && (
+            <Calculator />
+          )}
+          {course.notes.enabled && (
+            <NotesVisibility course={course} />
+          )}
+        </div>
+      </div>
+    )
+  );
+};
 
 ContentTools.propTypes = {
   course: PropTypes.shape({


### PR DESCRIPTION
## [MST-2015](https://2u-internal.atlassian.net/browse/MST-2105)

This PR fixes a UI bug when both the learning assistant and content tools are enabled for a course.

When content tools are enabled, they display over the learning assistant toggle: 

![Screenshot 2023-08-31 at 8 44 37 AM](https://github.com/openedx/frontend-app-learning/assets/46360176/f19cec0b-a74b-43b9-8809-e6e0f7570ecb)

If the learning sidebar is open, the content tools are similarly displayed over the chat sidebar: 

![Screenshot 2023-08-31 at 11 36 17 AM](https://github.com/openedx/frontend-app-learning/assets/46360176/e7a3073f-8d92-4dea-bf3e-cc27c5137934)

The content tools should be conditionally displayed, depending on whether or not the chat sidebar is open:

![Screenshot 2023-08-31 at 11 38 53 AM](https://github.com/openedx/frontend-app-learning/assets/46360176/dd8891e8-addb-4c2b-8901-fd39fcc4202d)

![Screenshot 2023-08-31 at 11 39 12 AM](https://github.com/openedx/frontend-app-learning/assets/46360176/c08b2d61-e7cd-44a1-aadd-079885a32015)
