### PR TITLE
feat: add Segment event for rendering Xpert and bump frontend-lib-learning-assistant version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@edx/frontend-component-footer": "12.0.0",
         "@edx/frontend-component-header": "4.0.0",
-        "@edx/frontend-lib-learning-assistant": "^1.9.4",
+        "@edx/frontend-lib-learning-assistant": "^1.11.1",
         "@edx/frontend-lib-special-exams": "2.20.1",
         "@edx/frontend-platform": "4.3.0",
         "@edx/paragon": "20.46.0",
@@ -3433,9 +3433,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-1.9.4.tgz",
-      "integrity": "sha512-dtupXZJdTxKyat9lWTNxQYzvBmS4ESewBhZd/sDiyBdHvNzGl3VHMeCzLz42Gk7B0oz7mrsd/xZHAu4FVU8qdA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-1.11.1.tgz",
+      "integrity": "sha512-vl93osyrEF5AxNwjNes643+AszUzpWGhVOm3ipGsvLyqgckIY6yQGD4WTwJnBLDBSTbStGjp5JLQvtlE0we/dQ==",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -3448,11 +3448,11 @@
         "react-markdown": "^8.0.5"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "4.3.0",
+        "@edx/frontend-platform": "^4.3.0",
         "@edx/paragon": "20.46.0",
         "@reduxjs/toolkit": "1.8.1",
-        "react": "16.14.0",
-        "react-dom": "16.14.0",
+        "react": "16.14.0 || ^17.0.0",
+        "react-dom": "16.14.0 || ^17.0.0",
         "react-redux": "7.2.9",
         "react-router": "5.2.1",
         "react-router-dom": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
     "@edx/frontend-component-footer": "12.0.0",
     "@edx/frontend-component-header": "4.0.0",
-    "@edx/frontend-lib-learning-assistant": "^1.9.4",
+    "@edx/frontend-lib-learning-assistant": "^1.11.1",
     "@edx/frontend-lib-special-exams": "2.20.1",
     "@edx/frontend-platform": "4.3.0",
     "@edx/paragon": "20.46.0",

--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Xpert } from '@edx/frontend-lib-learning-assistant';
 import { injectIntl } from '@edx/frontend-platform/i18n';
 
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+
 const Chat = ({
   enabled,
   enrollmentMode,
@@ -39,6 +41,14 @@ const Chat = ({
     enabled
     && (isEnrolled || isStaff) // display only to enrolled or staff
   );
+
+  // TODO: Remove this Segment alert. This has been added purely to diagnose whether
+  //       usage issues are as a result of the Xpert toggle button not appearing.
+  if (shouldDisplayChat) {
+    sendTrackEvent('edx.ui.lms.learning_assistant.render', {
+      course_id: courseId,
+    });
+  }
 
   return (
     <>


### PR DESCRIPTION
### Description

In order to diagnose low usage rates, we're temporarily adding Segment events for rendering the chat and for closing the call-to-action message. This will help us determine whether Xpert is being successfully rendered and whether Xpert is being ignored by tracking whether learners close the call-to-action message at a high rate.

At a minimum, we expect to remove the Segment event for rendering the Xpert, because this will be a very noisy Segment event. We plan to leave it in for a few days just to accumulate data. We will evaluate whether to keep the call-to-action dismissal Segment event based on the data.

This commit adds the Segment event for rendering the Xpert. This commit also installs version 1.11.1 of frontend-lib-learning-assistant, which introduces a Segment event for for closing the call-to-action message.

**Jira:** None