### PR TITLE
feat: allow override of plugin.modal height

### DIFF
--- a/src/courseware/course/sequence/Unit/ContentIFrame.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.jsx
@@ -74,7 +74,7 @@ const ContentIFrame = ({
           <iframe title={title} {...contentIFrameProps} data-testid={testIDs.contentIFrame} />
         </div>
       )}
-      {modalOptions.open && (
+      {modalOptions.isOpen && (
         <Modal
           body={modalOptions.body
             ? <div className="unit-modal">{ modalOptions.body }</div>
@@ -84,7 +84,7 @@ const ContentIFrame = ({
                 allow={IFRAME_FEATURE_POLICY}
                 frameBorder="0"
                 src={modalOptions.url}
-                style={{ width: '100%', height: '100vh' }}
+                style={{ width: '100%', height: modalOptions.height }}
               />
             )}
           dialogClassName="modal-lti"

--- a/src/courseware/course/sequence/Unit/ContentIFrame.test.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.test.jsx
@@ -29,16 +29,17 @@ const iframeBehavior = {
 
 const modalOptions = {
   closed: {
-    open: false,
+    isOpen: false,
   },
   withBody: {
     body: 'test-body',
-    open: true,
+    isOpen: true,
   },
   withUrl: {
-    open: true,
+    isOpen: true,
     title: 'test-modal-title',
     url: 'test-modal-url',
+    height: 'test-height',
   },
 };
 
@@ -83,7 +84,7 @@ describe('ContentIFrame Component', () => {
   });
   describe('output', () => {
     let component;
-    describe('shouldShowContent', () => {
+    describe('if shouldShowContent', () => {
       describe('if not hasLoaded', () => {
         it('displays errorPage if showError', () => {
           hooks.useIFrameBehavior.mockReturnValueOnce({ ...iframeBehavior, showError: true });
@@ -121,7 +122,7 @@ describe('ContentIFrame Component', () => {
         });
       });
     });
-    describe('not shouldShowContent', () => {
+    describe('if not shouldShowContent', () => {
       it('does not show PageLoading, ErrorPage, or unit-iframe-wrapper', () => {
         el = shallow(<ContentIFrame {...{ ...props, shouldShowContent: false }} />);
         expect(el.instance.findByType(PageLoading).length).toEqual(0);
@@ -129,13 +130,13 @@ describe('ContentIFrame Component', () => {
         expect(el.instance.findByTestId(testIDs.contentIFrame).length).toEqual(0);
       });
     });
-    it('does not display modal if modalOptions returns open: false', () => {
+    it('does not display modal if modalOptions returns isOpen: false', () => {
       el = shallow(<ContentIFrame {...props} />);
       expect(el.instance.findByType(Modal).length).toEqual(0);
     });
-    describe('if modalOptions.open', () => {
+    describe('if modalOptions.isOpen', () => {
       const testModalOpenAndHandleClose = () => {
-        test('Modal component is open, with handleModalClose from hook', () => {
+        test('Modal component isOpen, with handleModalClose from hook', () => {
           expect(component.props.onClose).toEqual(modalIFrameData.handleModalClose);
         });
       };
@@ -164,7 +165,7 @@ describe('ContentIFrame Component', () => {
               allow={IFRAME_FEATURE_POLICY}
               frameBorder="0"
               src={modalOptions.withUrl.url}
-              style={{ width: '100%', height: '100vh' }}
+              style={{ width: '100%', height: modalOptions.withUrl.height }}
             />,
           );
         });

--- a/src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
+++ b/src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
@@ -5,28 +5,32 @@ import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils/dist';
 import { useEventListener } from '../../../../../generic/hooks';
 
 export const stateKeys = StrictDict({
-  modalOptions: 'modalOptions',
+  isOpen: 'isOpen',
+  options: 'options',
 });
 
+export const DEFAULT_HEIGHT = '100vh';
+
 const useModalIFrameBehavior = () => {
-  const [modalOptions, setModalOptions] = useKeyedState(stateKeys.modalOptions, ({ open: false }));
+  const [isOpen, setIsOpen] = useKeyedState(stateKeys.isOpen, false);
+  const [options, setOptions] = useKeyedState(stateKeys.options, { height: DEFAULT_HEIGHT });
 
   const receiveMessage = React.useCallback(({ data }) => {
     const { type, payload } = data;
     if (type === 'plugin.modal') {
-      payload.open = true;
-      setModalOptions(payload);
+      setOptions((current) => ({ ...current, ...payload }));
+      setIsOpen(true);
     }
   }, []);
   useEventListener('message', receiveMessage);
 
   const handleModalClose = () => {
-    setModalOptions({ open: false });
+    setIsOpen(false);
   };
 
   return {
     handleModalClose,
-    modalOptions,
+    modalOptions: { isOpen, ...options },
   };
 };
 


### PR DESCRIPTION
The height of the modal in `modal.plugin` call from the Unit defaults to 100vh, which can lead to visual issues with consumed interfaces.  This allows the consumer to pass a height field (preferrably still in vh) that will be respected when creating the modal.

Without overridden height:
![image](https://github.com/openedx/frontend-app-learning/assets/5533134/f209c5fe-dead-453c-9368-8b02f3f96e70)
![image](https://github.com/openedx/frontend-app-learning/assets/5533134/fc489660-b528-4ce6-8b93-dfc2998c5669)


With overridden height:
![image](https://github.com/openedx/frontend-app-learning/assets/5533134/fba011bd-a573-4825-a65e-ca9f3b7a346b)
