### PR TITLE
chore: simplify setup-node gh action use

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,11 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Setup Nodejs Env
-      run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - uses: actions/setup-node@v3
       with:
-        node-version: ${{ env.NODE_VER }}
+        node-version-file: '.nvmrc'
     - run: make validate.ci
     - name: Upload coverage
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
`NODE_VER` doesn't seem to be used anywhere else in the repo, so I figure it makes sense to utilize the [`setup-node`](https://github.com/actions/setup-node) action's built in `node-version-file` functionality

excerpt from CI on this PR
```
Run actions/setup-node@v3
  
Resolved .nvmrc as 18
Found in cache @ /opt/hostedtoolcache/node/18.1[7](https://github.com/openedx/frontend-app-learning/actions/runs/6188199250/job/16799694086?pr=1185#step:3:7).1/x64
```