### PR TITLE
fix: make progress graph respect course settings

### DIFF
--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -193,6 +193,13 @@ export async function getCourseHomeCourseMetadata(courseId, rootSlug) {
   return normalizeCourseHomeCourseMetadata(data, rootSlug);
 }
 
+export async function getCourseAdvancedSettings(courseId) {
+  let url = `${getConfig().STUDIO_BASE_URL}/api/contentstore/v0/advanced_settings/${courseId}`;
+  url = appendBrowserTimezoneToUrl(url);
+  const { data } = await getAuthenticatedHttpClient().get(url);
+  return data;
+}
+
 // For debugging purposes, you might like to see a fully loaded dates tab.
 // Just uncomment the next few lines and the immediate 'return' in the function below
 // import { Factory } from 'rosie';

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -3,6 +3,7 @@ import { camelCaseObject } from '@edx/frontend-platform';
 import {
   executePostFromPostEvent,
   getCourseHomeCourseMetadata,
+  getCourseAdvancedSettings,
   getDatesTabData,
   getOutlineTabData,
   getProgressTabData,
@@ -42,6 +43,18 @@ export function fetchTab(courseId, tab, getTabData, targetUserId) {
           ...courseHomeCourseMetadata,
         },
       }));
+
+      if (tab === 'progress') {
+        const courseAdvancedSettings = await getCourseAdvancedSettings(courseId);
+        dispatch(addModel({
+          modelType: 'courseAdvancedSettings',
+          model: {
+            id: courseId,
+            ...courseAdvancedSettings,
+          },
+        }));
+      }
+
       const tabDataResult = getTabData && await getTabData(courseId, targetUserId);
       if (tabDataResult) {
         dispatch(addModel({

--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -17,6 +17,9 @@ const ProgressTab = () => {
     courseId,
   } = useSelector(state => state.courseHome);
 
+  const advancedSettings = useModel('courseAdvancedSettings', courseId);
+  const disableProgressGraph = advancedSettings.disable_progress_graph;
+
   const {
     gradesFeatureIsFullyLocked,
   } = useModel('progress', courseId);
@@ -38,7 +41,7 @@ const ProgressTab = () => {
       <div className="row w-100 m-0">
         {/* Main body */}
         <div className="col-12 col-md-8 p-0">
-          <CourseCompletion />
+          {!disableProgressGraph.value && <CourseCompletion />}
           {!wideScreen && <CertificateStatus />}
           <CourseGrade />
           <div className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`} aria-hidden={gradesFeatureIsFullyLocked}>


### PR DESCRIPTION
Closes https://github.com/openedx/frontend-app-learning/issues/753

## Description:

Currently, [#517](https://github.com/openedx/frontend-app-course-authoring/issues/517) faces an issue when the progress graph toggle is enabled/disabled but the settings are not respected, this PR requires [#3308](https://github.com/openedx/edx-platform/pull/33308 disable_progress_graph) to be merged so disable_progress_graph flag becomes available through the course_metadata api response.

- Testing instructions:
