### PR TITLE
fix: Fix dropdown menu in breadcrumbs

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -77,6 +77,10 @@
   }
 }
 
+.pgn__menu-select .pgn__menu-select-popup {
+  position: static;
+}
+
 .sequence-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This is backport from this MR https://github.com/openedx/frontend-app-learning/pull/1190

This bug was introduced in the latest versions of Paragon after adding the position: relative parameter to the .pgn__menu-select-popup element. You can find the relevant pull request here: https://github.com/openedx/paragon/pull/1281

I have been in communication with the Paragon team, and they convinced me that this fix is necessary for the Menu component. As a result, we have decided to include this minor fix in the Learning MFE.

Before fix:

https://github.com/openedx/frontend-app-learning/assets/19806032/f9433eaf-6315-4d14-8410-a9881a8db164

After fix:

https://github.com/openedx/frontend-app-learning/assets/19806032/6f3fa180-1e98-4693-8ac8-a08f7bf76160
