### PR TITLE
fix: Handle rtl/ltr for hangouts

### DIFF
--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -9,8 +9,9 @@ const LmsHtmlFragment = ({
   title,
   ...rest
 }) => {
+  const direction = document.documentElement?.getAttribute('dir') || 'ltr';
   const wholePage = `
-    <html>
+    <html dir="${direction}">
       <head>
         <base href="${getConfig().LMS_BASE_URL}" target="_parent">
         <link rel="stylesheet" href="/static/${getConfig().LEGACY_THEME_NAME ? `${getConfig().LEGACY_THEME_NAME}/` : ''}css/bootstrap/lms-main.css">


### PR DESCRIPTION
For some reason, Handouts didn't match the direction when RTL/LTR lang was chosen