### PR TITLE
fix: make progress graph respect course settings

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -18,7 +18,7 @@ const ProgressTab = () => {
   } = useSelector(state => state.courseHome);
 
   const {
-    gradesFeatureIsFullyLocked,
+    gradesFeatureIsFullyLocked, disableProgressGraph,
   } = useModel('progress', courseId);
 
   const applyLockedOverlay = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
@@ -38,7 +38,7 @@ const ProgressTab = () => {
       <div className="row w-100 m-0">
         {/* Main body */}
         <div className="col-12 col-md-8 p-0">
-          <CourseCompletion />
+          {!disableProgressGraph && <CourseCompletion />}
           {!wideScreen && <CertificateStatus />}
           <CourseGrade />
           <div className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`} aria-hidden={gradesFeatureIsFullyLocked}>


### PR DESCRIPTION
Closes [#517](https://github.com/openedx/frontend-app-course-authoring/issues/517)

## Description:

Currently, [#517](https://github.com/openedx/frontend-app-course-authoring/issues/517) faces an issue when the progress graph toggle is enabled/disabled but the settings are not respected, this PR requires merge of [#33308](https://github.com/openedx/edx-platform/pull/33308) as a prerequisite so the disableProgressGraph attribute is available through course_metadata endpoint.

## Testing Instructions:

- Perform `git pull` on **edx-platform** repository followed by `git checkout fix-progress-graph`, it allows the backend to send _disableProgressGraph_ attribute to our frontend-learning-app.
- Login as edx user on studio.
- Navigate to [admin > waffle_utils > Waffle flag org overrides](http://localhost:18000/admin/waffle_utils/waffleflagorgoverridemodel/)

- Add and enable these flags:
![CleanShot 2023-09-21 at 17 25 43@2x](https://github.com/openedx/frontend-app-learning/assets/20343475/6ba11bcd-949b-4324-bc2b-9c1e9952da53)

- Navigate to Pages and Resources Tab in [frontend-course-authoring app](http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/pages-and-resources) Demo Course page and toggle Enable Progress Graph to test the settings. Make sure you save the settings to reflect the changes.

<img width="722" alt="CleanShot 2023-09-21 at 17 28 26@2x" src="https://github.com/openedx/frontend-app-learning/assets/20343475/ce536b8b-2b4f-4186-8245-42a03b038366">

- Sign out on [studio](http://localhost:18000/logout) and login as normal user (**honor**) to perform the check.

- Visit demo course [progress](http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/progress) tab to see if the progress graph is respecting the configuration.

## Results:

### Disabled Progress Graph:

- ### Toggle Settings:

<img width="1142" alt="CleanShot 2023-09-21 at 17 37 54@2x" src="https://github.com/openedx/frontend-app-learning/assets/20343475/560f168e-4348-4daa-b75e-45a5502e92b4">

- ### Result:
<img width="1144" alt="CleanShot 2023-09-21 at 17 39 23@2x" src="https://github.com/openedx/frontend-app-learning/assets/20343475/3bd22303-a40f-4b76-8e40-96a49f8aa29a">

### Enabled Progress Graph:

- ### Toggle Settings:

<img width="1144" alt="CleanShot 2023-09-21 at 17 40 00@2x" src="https://github.com/openedx/frontend-app-learning/assets/20343475/09ee90cc-9f64-4146-a876-8c5392a3dece">

- ### Result:

<img width="1144" alt="CleanShot 2023-09-21 at 17 42 28@2x" src="https://github.com/openedx/frontend-app-learning/assets/20343475/6c951933-ab1c-44bb-b988-45b7be90a947">



