### PR TITLE
fix: course update iframe

### DIFF
--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -29,7 +29,7 @@ const LmsHtmlFragment = ({
   const iframe = useRef(null);
   function resetIframeHeight() {
     if (iframe?.current?.contentWindow?.document?.body) {
-      iframe.current.height = iframe.current.contentWindow.document.body.scrollHeight;
+      iframe.current.height = iframe.current.contentWindow.document.body.parentNode.scrollHeight;
     }
   }
 

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -257,6 +257,22 @@ describe('Outline Tab', () => {
       });
     });
 
+    it('ignores comments and misformatted HTML', async () => {
+      setTabData({
+        welcome_message_html: '<p class="additional-spaces-in-tag"   >'
+      + '<!-- Even if the welcome_message_html length is above the limit because of comments, we hope it will not be shortened. -->'
+      + '<!-- Even if the welcome_message_html length is above the limit because of comments, we hope it will not be shortened. -->'
+      + 'Test welcome message that happens to be longer than one hundred words because of comments but displayed content is less.'
+      + 'It should not be shortened.'
+      + '<!-- Even if the welcome_message_html length is above the limit because of comments, we hope it will not be shortened. -->'
+      + '<!-- Even if the welcome_message_html length is above the limit because of comments, we hope it will not be shortened. -->'
+      + '</p>',
+      });
+      await fetchAndRender();
+      const showMoreButton = screen.queryByRole('button', { name: 'Show More' });
+      expect(showMoreButton).not.toBeInTheDocument();
+    });
+
     it('does not display if no update available', async () => {
       setTabData({ welcome_message_html: null });
       await fetchAndRender();


### PR DESCRIPTION
# Intro

This PR addresses a bug that emerges in course updates displayed in the `LmsHtmlFragment` component. Currently, we rely on the [body's scrollHeight](https://github.com/openedx/frontend-app-learning/blob/5604def491098d763801ce198cd977753c550f56/src/course-home/outline-tab/LmsHtmlFragment.jsx#L32) to set the iframe 's height. This poses a problem in case the body node's height is inferior to the html node's height resulting in hidden content. (cf. example below)

 This PR also deals with another issue regarding the `Show More` button and whether the message can be shortened. Presently, we [compare ](https://github.com/openedx/frontend-app-learning/blob/5604def491098d763801ce198cd977753c550f56/src/course-home/outline-tab/widgets/WelcomeMessage.jsx#L22)the original update's length with a truncated version's length to determine if the message can be shortened. We rely on [truncate-html](https://www.npmjs.com/package/truncate-html) module to truncate the message.  This module parses the content before the truncating and can change its length even if there is no need for truncating.

```javascript
const truncate = require("truncate-html")
let a = "<h1  >Test</h1>"  // notice the additional spaces
let b = truncate(a, 100, { byWords: true, keepWhitespaces: true })
console.log("a:", a, "    ", "a.length:", a.length, "    ", "b:", b, "    ", "b.length:", b.length)
// a: <h1  >Test</h1>      a.length: 15      b: <h1>Test</h1>      b.length: 13
```

In addition, `truncate-html` strips comments regardless of truncating and this results in a length change. That's why this PR introduces a "cleaning" step that aims to format the update into a canonical format before truncating it. 

`useMemo` is also used to avoid recomputing the truncate at every render. 

# Reproducing insufficient height issue
1-  head to studio Course Update section e.g. http://localhost:18010/course_info/course-v1:edX+DemoX+Demo_Course
2-  Create a course update containing the following HTML: 
```HTML
<h3><img src="" width="117" height="117" align="left" /></h3>
<p></p>
<p></p>
<hr />
<p></p>
<p></p>
<h3><strong>Test Test Test Test!</strong></h3>
<p><strong>-Test Test Test Test Test Test Test Test, Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test <a href="#" target="_blank" rel="noopener">Test Test Test Test Test Test Test Test</a>. </strong></p>
<p><strong>-Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test  Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test.</strong></p>
<p>Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test--&gt; Home Page</p>
<p>-Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test</p>
```
3 - Head to the course http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/home and notice that the lower part of the update is not fully displayed after clicking on `Show More`


https://github.com/openedx/frontend-app-learning/assets/28169169/e4465cc4-ba3f-45c7-b89e-d5bf0e33daf3

# Reproducing unnecessary  "Show More"
1-  head to studio Course Update section e.g. http://localhost:18010/course_info/course-v1:edX+DemoX+Demo_Course
2-  Create a course update containing the following HTML: 
```HTML
<p > I am short</p>
```
3 - Head to the course http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course/home
4 - The `Show More` button is displayed.

