### PR TITLE
chore: bump frontend-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@edx/frontend-component-header": "4.6.0",
         "@edx/frontend-lib-learning-assistant": "^1.14.0",
         "@edx/frontend-lib-special-exams": "2.23.3",
-        "@edx/frontend-platform": "5.0.0",
+        "@edx/frontend-platform": "5.5.2",
         "@edx/paragon": "20.46.0",
         "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.7.0",
         "@fortawesome/fontawesome-svg-core": "1.3.0",
@@ -3623,9 +3623,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.0.0.tgz",
-      "integrity": "sha512-DD9/B4rnC3BKPiWlbEFF1JIYFbWC6vUBKTyN8sf4khi4DNhhWhsobk+iNeCWNzF9UgCPRbniIqesdV1F9NXNZw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.5.2.tgz",
+      "integrity": "sha512-cbUvWcFL/mTc7eypBS/BnCojgWDcJCe3h3ffb3GD7F+Y4ysrFBJYf031qPcgmWNUrN30452dR7r1+sqE7uVvYA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -3653,7 +3653,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-build": ">= 8.1.0 || ^12.9.0-alpha.1",
-        "@edx/paragon": ">= 10.0.0 < 21.0.0",
+        "@edx/paragon": ">= 10.0.0 < 22.0.0",
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/frontend-component-header": "4.6.0",
     "@edx/frontend-lib-learning-assistant": "^1.14.0",
     "@edx/frontend-lib-special-exams": "2.23.3",
-    "@edx/frontend-platform": "5.0.0",
+    "@edx/frontend-platform": "5.5.2",
     "@edx/paragon": "20.46.0",
     "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.7.0",
     "@fortawesome/fontawesome-svg-core": "1.3.0",


### PR DESCRIPTION
This PR resolves the `PUBLIC_PATH` configuration issue by upgrading frontend-platform from `v5.0.0` to `v5.5.2`.