### PR TITLE
fix: RTL for the upgrade notification list

### DIFF
--- a/src/generic/upgrade-notification/UpgradeNotification.scss
+++ b/src/generic/upgrade-notification/UpgradeNotification.scss
@@ -22,9 +22,8 @@
 // An additional Font Awesome stylesheet is imported by Braze in
 // stage/production but not devstack.
 .upgrade-notification-ul.fa-ul {
-  padding-left: 1.25rem;
-  padding-top: 0.875rem;
-  padding-right: 1.25rem;
+  padding: 0.875rem 1.25rem 0;
+  margin: 0 0 1rem 2.5rem;
 }
 
 .upgrade-notification-text {


### PR DESCRIPTION
#### Description:
This pull request contains minor fixes for RTL display of the upgrade notification list.

### Screenshots before:
| LTR  |  RTL  |
|---|---|
|  <img width="691" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/38a5d79c-200a-4f50-9bc9-349c3a36d150"> |  <img width="666" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/55203a23-8ac9-49a6-92df-1ea4d8b0d001"> |

### Screenshots after:
| LTR  |  RTL  |
|---|---|
|  <img width="691" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/38a5d79c-200a-4f50-9bc9-349c3a36d150"> |  <img width="652" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/feb763f4-1007-4430-8d66-50b57927aa9c"> |

#### Related Pull Requests:
PR to the open-release/palm.master branch: https://github.com/openedx/frontend-app-learning/pull/1221
PR to the open-release/quince.master branch: https://github.com/openedx/frontend-app-learning/pull/1228
