### PR TITLE
fix: container width and responsive for navigation block

### DIFF
--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -140,26 +140,28 @@ const Sequence = ({
   const gated = sequence && sequence.gatedContent !== undefined && sequence.gatedContent.gated;
 
   const defaultContent = (
-    <div className="sequence-container d-inline-flex flex-row">
+    <div className="sequence-container d-inline-flex flex-row w-100">
       <div className={classNames('sequence w-100', { 'position-relative': shouldDisplayNotificationTriggerInSequence })}>
-        <SequenceNavigation
-          sequenceId={sequenceId}
-          unitId={unitId}
-          className="mb-4"
-          nextHandler={() => {
-            logEvent('edx.ui.lms.sequence.next_selected', 'top');
-            handleNext();
-          }}
-          onNavigate={(destinationUnitId) => {
-            logEvent('edx.ui.lms.sequence.tab_selected', 'top', destinationUnitId);
-            handleNavigate(destinationUnitId);
-          }}
-          previousHandler={() => {
-            logEvent('edx.ui.lms.sequence.previous_selected', 'top');
-            handlePrevious();
-          }}
-        />
-        {shouldDisplayNotificationTriggerInSequence && <SidebarTriggers />}
+        <div className="sequence-navigation-container">
+          <SequenceNavigation
+            sequenceId={sequenceId}
+            unitId={unitId}
+            className="mb-4"
+            nextHandler={() => {
+              logEvent('edx.ui.lms.sequence.next_selected', 'top');
+              handleNext();
+            }}
+            onNavigate={(destinationUnitId) => {
+              logEvent('edx.ui.lms.sequence.tab_selected', 'top', destinationUnitId);
+              handleNavigate(destinationUnitId);
+            }}
+            previousHandler={() => {
+              logEvent('edx.ui.lms.sequence.previous_selected', 'top');
+              handlePrevious();
+            }}
+          />
+          {shouldDisplayNotificationTriggerInSequence && <SidebarTriggers />}
+        </div>
 
         <div className="unit-container flex-grow-1">
           <SequenceContent

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -106,11 +106,10 @@ const SequenceNavigation = ({
   };
 
   return sequenceStatus === LOADED && (
-    <nav id="courseware-sequenceNavigation" className={classNames('sequence-navigation', className)} style={{ width: shouldDisplayNotificationTriggerInSequence ? '90%' : null }}>
+    <nav id="courseware-sequenceNavigation" className={classNames('sequence-navigation', className, { 'mr-2': shouldDisplayNotificationTriggerInSequence })}>
       {renderPreviousButton()}
       {renderUnitButtons()}
       {renderNextButton()}
-
     </nav>
   );
 };

--- a/src/courseware/course/sidebar/SidebarTriggers.jsx
+++ b/src/courseware/course/sidebar/SidebarTriggers.jsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { useContext } from 'react';
+import { breakpoints, useWindowSize } from '@edx/paragon';
 import SidebarContext from './SidebarContext';
 import { SIDEBAR_ORDER, SIDEBARS } from './sidebars';
 
@@ -8,6 +9,9 @@ const SidebarTriggers = () => {
     toggleSidebar,
     currentSidebar,
   } = useContext(SidebarContext);
+
+  const isMobileView = useWindowSize().width < breakpoints.small.minWidth;
+
   return (
     <div className="d-flex ml-auto">
       {SIDEBAR_ORDER.map((sidebarId) => {
@@ -15,7 +19,7 @@ const SidebarTriggers = () => {
         const isActive = sidebarId === currentSidebar;
         return (
           <div
-            className={classNames('mt-3', { 'border-primary-700': isActive })}
+            className={classNames({ 'mt-3': !isMobileView, 'border-primary-700': isActive })}
             style={{ borderBottom: isActive ? '2px solid' : null }}
             key={sidebarId}
           >

--- a/src/courseware/course/sidebar/common/TriggerBase.jsx
+++ b/src/courseware/course/sidebar/common/TriggerBase.jsx
@@ -8,7 +8,7 @@ const SidebarTriggerBase = ({
   children,
 }) => (
   <button
-    className="border border-light-400 bg-transparent align-items-center align-content-center d-flex"
+    className="border border-light-400 bg-transparent align-items-center align-content-center d-flex notification-btn"
     type="button"
     onClick={onClick}
     aria-label={ariaLabel}

--- a/src/generic/tabs/useIndexOfLastVisibleChild.js
+++ b/src/generic/tabs/useIndexOfLastVisibleChild.js
@@ -6,6 +6,7 @@ const invisibleStyle = {
   left: 0,
   pointerEvents: 'none',
   visibility: 'hidden',
+  maxWidth: '100%',
 };
 
 /**

--- a/src/index.scss
+++ b/src/index.scss
@@ -84,7 +84,6 @@
   flex-direction: column;
   flex-grow: 1;
   margin-bottom: 4rem;
-  width: 100%;
   margin-right: auto;
   margin-left: auto;
 }
@@ -96,8 +95,24 @@
   }
 }
 
+.sequence-navigation-container {
+  display: flex;
+  align-items: flex-start;
+}
+
+.notification-btn {
+  @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+    height: 3rem;
+  }
+}
+
 .sequence-navigation {
   display: flex;
+  flex-grow: 1;
+
+  @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+    max-width: 100%;
+  }
 
   @media (min-width: map-get($grid-breakpoints, "sm")) {
     margin: -1px -1px 0;
@@ -165,9 +180,10 @@
   }
 
   .sequence-navigation-tabs {
+    overflow: auto;
     .btn {
       flex-basis: 100%;
-      min-width: 2rem;
+      min-width: 3rem;
     }
   }
 


### PR DESCRIPTION
#### Description:
This pull request contains minor fixes related to responsiveness and block rebuilding.
- Fixed container width on mobile devices

|  Before |  After |
|---|---|
|  ![image](https://github.com/openedx/frontend-app-learning/assets/17108583/67d01690-a5c9-46e8-82b8-4bb5201402f7) |  ![image](https://github.com/openedx/frontend-app-learning/assets/17108583/62461b01-3682-47ed-bc12-13c19de0be8d) |

- Fixed adaptation of controls and navigation

|  Before (500px) |  Before (375px) |
|---|---|
|  <img width="352" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/14318dd0-f90e-4676-889c-37588b2368a8"> | <img width="273" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/2e9550eb-fca9-4fe7-9488-dfaf0acf830b"> |

|  After (700px) | After (600px) | After (500px) | After (375px) |
|---|---|---|---|
|  ![image](https://github.com/openedx/frontend-app-learning/assets/17108583/55a8a9e1-94fa-4540-bd96-8b04f184bdcd)  |  ![image](https://github.com/openedx/frontend-app-learning/assets/17108583/a7b7cd84-0dca-44b0-b453-95cdc3606e88)  |  ![image](https://github.com/openedx/frontend-app-learning/assets/17108583/db7dc733-d2a7-43bc-8664-bc421029d203)  |  ![image](https://github.com/openedx/frontend-app-learning/assets/17108583/b06df298-84d0-4fc2-8a04-dafd5141c4dc)  |

#### Related Pull Requests
PR to the open-release/palm.master branch: https://github.com/openedx/frontend-app-learning/pull/1218
PR to the master branch: https://github.com/openedx/frontend-app-learning/pull/1219

