### PR TITLE
chore: update sidebar logic

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -17,7 +17,6 @@ import SidebarProvider from './sidebar/SidebarContextProvider';
 import SidebarTriggers from './sidebar/SidebarTriggers';
 
 import { useModel } from '../../generic/model-store';
-import { getSessionStorage, setSessionStorage } from '../../data/sessionStorage';
 
 const Course = ({
   courseId,
@@ -32,7 +31,6 @@ const Course = ({
   const {
     celebrations,
     isStaff,
-    verifiedMode,
   } = useModel('courseHomeMeta', courseId);
   const sequence = useModel('sequences', sequenceId);
   const section = useModel('sections', sequence ? sequence.sectionId : null);
@@ -54,16 +52,6 @@ const Course = ({
   );
   const shouldDisplayTriggers = windowWidth >= breakpoints.small.minWidth;
   const daysPerWeek = course?.courseGoals?.selectedGoal?.daysPerWeek;
-
-  // 1. open the notification tray if the user has not purchased the course and is on a desktop
-  // 2. default to close on the first time access
-  // 3. use the last state if the user has access the course before
-  const shouldDisplayNotificationTrayOpenOnLoad = windowWidth > breakpoints.medium.minWidth && !!verifiedMode;
-  if (shouldDisplayNotificationTrayOpenOnLoad) {
-    setSessionStorage(`notificationTrayStatus.${courseId}`, 'open');
-  } else if (!getSessionStorage(`notificationTrayStatus.${courseId}`)) {
-    setSessionStorage(`notificationTrayStatus.${courseId}`, 'closed');
-  }
 
   useEffect(() => {
     const celebrateFirstSection = celebrations && celebrations.firstSection;

--- a/src/courseware/course/sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.jsx
@@ -27,7 +27,6 @@ const SidebarProvider = ({
   useEffect(() => {
     // if the user hasn't purchased the course, show the notifications sidebar
     setCurrentSidebar(verifiedMode ? SIDEBARS.NOTIFICATIONS.ID : SIDEBARS.DISCUSSIONS.ID);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unitId]);
 
   const onNotificationSeen = useCallback(() => {

--- a/src/courseware/course/sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.jsx
@@ -26,7 +26,7 @@ const SidebarProvider = ({
 
   useEffect(() => {
     // if the user hasn't purchased the course, show the notifications sidebar
-    setCurrentSidebar(!!verifiedMode ? SIDEBARS.NOTIFICATIONS.ID : SIDEBARS.DISCUSSIONS.ID);
+    setCurrentSidebar(verifiedMode ? SIDEBARS.NOTIFICATIONS.ID : SIDEBARS.DISCUSSIONS.ID);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unitId]);
 

--- a/src/courseware/course/sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.jsx
@@ -4,7 +4,9 @@ import React, {
   useEffect, useState, useMemo, useCallback,
 } from 'react';
 
+import { useModel } from '../../../generic/model-store';
 import { getLocalStorage, setLocalStorage } from '../../../data/localStorage';
+
 import SidebarContext from './SidebarContext';
 import { SIDEBARS } from './sidebars';
 
@@ -13,6 +15,7 @@ const SidebarProvider = ({
   unitId,
   children,
 }) => {
+  const { verifiedMode } = useModel('courseHomeMeta', courseId);
   const shouldDisplayFullScreen = useWindowSize().width < breakpoints.large.minWidth;
   const shouldDisplaySidebarOpen = useWindowSize().width > breakpoints.medium.minWidth;
   const query = new URLSearchParams(window.location.search);
@@ -22,7 +25,8 @@ const SidebarProvider = ({
   const [upgradeNotificationCurrentState, setUpgradeNotificationCurrentState] = useState(getLocalStorage(`upgradeNotificationCurrentState.${courseId}`));
 
   useEffect(() => {
-    setCurrentSidebar(SIDEBARS.DISCUSSIONS.ID);
+    // if the user hasn't purchased the course, show the notifications sidebar
+    setCurrentSidebar(!!verifiedMode ? SIDEBARS.NOTIFICATIONS.ID : SIDEBARS.DISCUSSIONS.ID);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unitId]);
 

--- a/src/courseware/course/sidebar/sidebars/index.js
+++ b/src/courseware/course/sidebar/sidebars/index.js
@@ -1,5 +1,5 @@
 import * as notifications from './notifications';
-import * as discusssions from './discussions';
+import * as discussions from './discussions';
 
 export const SIDEBARS = {
   [notifications.ID]: {
@@ -7,14 +7,14 @@ export const SIDEBARS = {
     Sidebar: notifications.Sidebar,
     Trigger: notifications.Trigger,
   },
-  [discusssions.ID]: {
-    ID: discusssions.ID,
-    Sidebar: discusssions.Sidebar,
-    Trigger: discusssions.Trigger,
+  [discussions.ID]: {
+    ID: discussions.ID,
+    Sidebar: discussions.Sidebar,
+    Trigger: discussions.Trigger,
   },
 };
 
 export const SIDEBAR_ORDER = [
-  discusssions.ID,
+  discussions.ID,
   notifications.ID,
 ];

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
@@ -42,6 +42,7 @@ const NotificationTray = ({ intl }) => {
       title={intl.formatMessage(messages.notificationTitle)}
       ariaLabel={intl.formatMessage(messages.notificationTray)}
       sidebarId={ID}
+      width="50rem"
       className={classNames({ 'h-100': !verifiedMode && !shouldDisplayFullScreen })}
     >
       <div>{verifiedMode

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTrigger.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTrigger.jsx
@@ -2,7 +2,6 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import React, { useContext, useEffect } from 'react';
 import { getLocalStorage, setLocalStorage } from '../../../../../data/localStorage';
-import { getSessionStorage, setSessionStorage } from '../../../../../data/sessionStorage';
 import messages from '../../../messages';
 import SidebarTriggerBase from '../../common/TriggerBase';
 import SidebarContext from '../../SidebarContext';
@@ -47,17 +46,8 @@ const NotificationTrigger = ({
     UpdateUpgradeNotificationLastSeen();
   });
 
-  const handleClick = () => {
-    if (getSessionStorage(`notificationTrayStatus.${courseId}`) === 'open') {
-      setSessionStorage(`notificationTrayStatus.${courseId}`, 'closed');
-    } else {
-      setSessionStorage(`notificationTrayStatus.${courseId}`, 'open');
-    }
-    onClick();
-  };
-
   return (
-    <SidebarTriggerBase onClick={handleClick} ariaLabel={intl.formatMessage(messages.openNotificationTrigger)}>
+    <SidebarTriggerBase onClick={onClick} ariaLabel={intl.formatMessage(messages.openNotificationTrigger)}>
       <NotificationIcon status={notificationStatus} notificationColor="bg-danger-500" />
     </SidebarTriggerBase>
   );

--- a/src/data/sessionStorage.js
+++ b/src/data/sessionStorage.js
@@ -7,10 +7,7 @@
 function getSessionStorage(key) {
   try {
     if (global.sessionStorage) {
-      const rawItem = global.sessionStorage.getItem(key);
-      if (rawItem) {
-        return JSON.parse(rawItem);
-      }
+      return global.sessionStorage.getItem(key);
     }
   } catch (e) {
     // If this fails for some reason, just return null.
@@ -21,7 +18,7 @@ function getSessionStorage(key) {
 function setSessionStorage(key, value) {
   try {
     if (global.sessionStorage) {
-      global.sessionStorage.setItem(key, JSON.stringify(value));
+      global.sessionStorage.setItem(key, value);
     }
   } catch (e) {
     // If this fails, just bail.


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/AU-1552

1. If a course has an upgrade option, it will automatically open whenever the page is refreshed. 
2. If a course has already been upgraded, it will behave as it used to
    1. Open discussion board when available
    2. Else don't open the sidebar

### **After Fix**    
**Desktop**
<img width="879" alt="Screenshot 2023-11-22 at 12 41 08 PM" src="https://github.com/openedx/frontend-app-learning/assets/79941147/4d612703-4ccd-434a-94e5-c07aace3719b">
**Mobile**
<img width="478" alt="Screenshot 2023-11-22 at 12 40 16 PM" src="https://github.com/openedx/frontend-app-learning/assets/79941147/8a545196-2aed-45da-8f55-c016128b1358">

