### PR TITLE
feat: remove segment event

### DIFF
--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import { Xpert } from '@edx/frontend-lib-learning-assistant';
 import { injectIntl } from '@edx/frontend-platform/i18n';
 
-import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-
 const Chat = ({
   enabled,
   enrollmentMode,
@@ -41,14 +39,6 @@ const Chat = ({
     enabled
     && (isEnrolled || isStaff) // display only to enrolled or staff
   );
-
-  // TODO: Remove this Segment alert. This has been added purely to diagnose whether
-  //       usage issues are as a result of the Xpert toggle button not appearing.
-  if (shouldDisplayChat) {
-    sendTrackEvent('edx.ui.lms.learning_assistant.render', {
-      course_id: courseId,
-    });
-  }
 
   return (
     <>

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -8,8 +8,6 @@ import { initializeMockApp, render, screen } from '../../../setupTest';
 
 import Chat from './Chat';
 
-jest.mock('@edx/frontend-platform/analytics');
-
 initializeMockApp();
 
 const courseId = 'course-v1:edX+DemoX+Demo_Course';


### PR DESCRIPTION
## [COSMO-9](https://2u-internal.atlassian.net/browse/COSMO-9)

With the end of our first experiment related to the learning assistant experience, the Cosmonauts team would also like to remove a segment event logged for each render of the chat component. This segment was added for both experimental and diagnostic purposes, so with the end of the experiment, this is no longer needed.