### PR TITLE
feat: add technical support URL in the LTI-based provider proctored exam download instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@edx/frontend-component-footer": "12.2.1",
         "@edx/frontend-component-header": "4.6.0",
         "@edx/frontend-lib-learning-assistant": "^1.18.0",
-        "@edx/frontend-lib-special-exams": "2.25.0",
+        "@edx/frontend-lib-special-exams": "2.26.0",
         "@edx/frontend-platform": "5.5.2",
         "@edx/paragon": "20.46.0",
         "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.7.0",
@@ -3539,9 +3539,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.25.0.tgz",
-      "integrity": "sha512-QRc7BKI+xCmI1pLUoO4W7T1+LMtJ6F5+faYm2sxO8sVpy+/nLUWICiPresqxrH/EScDCPJrCLjoYTxoF1JQwAQ==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.26.0.tgz",
+      "integrity": "sha512-havK1JHJT6cLTK6P/qw5Kl0bqMQJTcVdk0P1humHqtuUGr7gn/b9/4ADni9X7grMAXBwK8oYzMVk8nrrE3owXg==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@edx/frontend-component-footer": "12.2.1",
     "@edx/frontend-component-header": "4.6.0",
     "@edx/frontend-lib-learning-assistant": "^1.18.0",
-    "@edx/frontend-lib-special-exams": "2.25.0",
+    "@edx/frontend-lib-special-exams": "2.26.0",
     "@edx/frontend-platform": "5.5.2",
     "@edx/paragon": "20.46.0",
     "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.7.0",


### PR DESCRIPTION
### Description

**Jira**: [COSMO-130](https://2u-internal.atlassian.net/browse/COSMO-130)

This commit changes the installed version of the `frontend-lib-special-exams` module from `2.25.0` to `2.26.0`.

This release adds support for displaying a technical support URL for LTI-based providers on the download instructions interstitial of proctored exams. The download instructions will display a technical support URL when it is returned from the proctoring settings backend endpoint. If the technical support URL is not available, then the technical support email and technical support phone number will be used instead.