### PR TITLE
feat: add class to loading component

### DIFF
--- a/src/generic/PageLoading.jsx
+++ b/src/generic/PageLoading.jsx
@@ -18,7 +18,7 @@ export default class PageLoading extends Component {
 
   render() {
     return (
-      <div>
+      <div className="page-loading">
         <div
           className="d-flex justify-content-center align-items-center flex-column"
           style={{


### PR DESCRIPTION
# Description
We need to modify the height of the loading element for a theme. As the codebase stands it doesn't have any usable selector for this. This PR adds a `page-loading`class for easy theming.