### PR TITLE
feat: gate chat visibility by course end date

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -91,6 +91,7 @@ const Course = ({
               courseId={courseId}
               contentToolsEnabled={course.showCalculator || course.notes.enabled}
               unitId={unitId}
+              endDate={course.end ? course.end : ''}
             />
             {enableNewSidebar === 'true' ? <NewSidebarTriggers /> : <SidebarTriggers /> }
           </>

--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -11,6 +11,7 @@ const Chat = ({
   courseId,
   contentToolsEnabled,
   unitId,
+  endDate,
 }) => {
   const VERIFIED_MODES = [
     'professional',
@@ -36,9 +37,17 @@ const Chat = ({
     && [...VERIFIED_MODES, ...AUDIT_MODES].some(mode => mode === enrollmentMode)
   );
 
+  const endDatePassed = () => {
+    const date = new Date();
+    const utcDate = date.toISOString();
+
+    return endDate ? utcDate > endDate : false; // evaluate if end date has passed only if course has end date
+  };
+
   const shouldDisplayChat = (
     enabled
     && (isEnrolled || isStaff) // display only to enrolled or staff
+    && !endDatePassed()
   );
 
   return (
@@ -59,6 +68,7 @@ Chat.propTypes = {
   courseId: PropTypes.string.isRequired,
   contentToolsEnabled: PropTypes.bool.isRequired,
   unitId: PropTypes.string.isRequired,
+  endDate: PropTypes.string.isRequired,
 };
 
 Chat.defaultProps = {

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -19,6 +19,7 @@ const enabledModes = [
   'paid-executive-education', 'paid-bootcamp', 'audit', 'honor', 'unpaid-executive-education', 'unpaid-bootcamp',
 ];
 const disabledModes = [null, undefined, 'xyz'];
+const currentTime = new Date();
 
 describe('Chat', () => {
   // Generate test cases.
@@ -44,6 +45,7 @@ describe('Chat', () => {
               enabled
               courseId={courseId}
               contentToolsEnabled={false}
+              endDate={new Date(currentTime.getTime() + 10 * 60000).toISOString()}
             />
           </BrowserRouter>,
           { store },
@@ -77,6 +79,7 @@ describe('Chat', () => {
             enabled
             courseId={courseId}
             contentToolsEnabled={false}
+            endDate={new Date(currentTime.getTime() + 10 * 60000).toISOString()}
           />
         </BrowserRouter>,
         { store },
@@ -138,6 +141,7 @@ describe('Chat', () => {
               enabled={test.enabled}
               courseId={courseId}
               contentToolsEnabled={false}
+              endDate={new Date(currentTime.getTime() + 10 * 60000).toISOString()}
             />
           </BrowserRouter>,
           { store },
@@ -151,5 +155,55 @@ describe('Chat', () => {
         }
       },
     );
+  });
+
+  it('if course end date has passed, component should not be visible', async () => {
+    const store = configureStore({
+      reducer: {
+        learningAssistant: learningAssistantReducer,
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <Chat
+          enrollmentMode="verified"
+          isStaff
+          enabled
+          courseId={courseId}
+          contentToolsEnabled={false}
+          endDate={new Date(currentTime.getTime() - 10 * 60000).toISOString()}
+        />
+      </BrowserRouter>,
+      { store },
+    );
+
+    const chat = screen.queryByTestId('toggle-button');
+    expect(chat).not.toBeInTheDocument();
+  });
+
+  it('if course has no end date, component should be visible', async () => {
+    const store = configureStore({
+      reducer: {
+        learningAssistant: learningAssistantReducer,
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <Chat
+          enrollmentMode="verified"
+          isStaff
+          enabled
+          courseId={courseId}
+          contentToolsEnabled={false}
+          endDate={null}
+        />
+      </BrowserRouter>,
+      { store },
+    );
+
+    const chat = screen.queryByTestId('toggle-button');
+    expect(chat).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## [COSMO-144](https://2u-internal.atlassian.net/browse/COSMO-144)

Visibility of the chat component should be gated by course end date, meaning that only learners who are enrolled in active courses (i.e. courses for which the end date has not passed) can access this component.