### PR TITLE
feat: use navigation sequence metadata to disable navigation components

### DIFF
--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -518,6 +518,7 @@ Object {
               "hideFromTOC": undefined,
               "icon": null,
               "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@bcdabcdabcdabcdabcdabcdabcdabcd1",
+              "navigationDisabled": undefined,
               "sectionId": "block-v1:edX+DemoX+Demo_Course+type@chapter+block@bcdabcdabcdabcdabcdabcdabcdabcd2",
               "showLink": true,
               "title": "Title of Sequence",

--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -154,6 +154,7 @@ export function normalizeOutlineBlocks(courseId, blocks) {
           showLink: !!block.lms_web_url,
           title: block.display_name,
           hideFromTOC: block.hide_from_toc,
+          navigationDisabled: block.navigation_disabled,
         };
         break;
 

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -37,6 +37,7 @@ const Course = ({
   const sequence = useModel('sequences', sequenceId);
   const section = useModel('sections', sequence ? sequence.sectionId : null);
   const enableNewSidebar = getConfig().ENABLE_NEW_SIDEBAR;
+  const navigationDisabled = sequence?.navigationDisabled ?? false;
 
   const pageTitleBreadCrumbs = [
     sequence,
@@ -76,13 +77,17 @@ const Course = ({
         <title>{`${pageTitleBreadCrumbs.join(' | ')} | ${getConfig().SITE_NAME}`}</title>
       </Helmet>
       <div className="position-relative d-flex align-items-center mb-4 mt-1">
-        <CourseBreadcrumbs
-          courseId={courseId}
-          sectionId={section ? section.id : null}
-          sequenceId={sequenceId}
-          isStaff={isStaff}
-          unitId={unitId}
-        />
+        {!navigationDisabled && (
+        <>
+          <CourseBreadcrumbs
+            courseId={courseId}
+            sectionId={section ? section.id : null}
+            sequenceId={sequenceId}
+            isStaff={isStaff}
+            unitId={unitId}
+          />
+        </>
+        )}
         {shouldDisplayChat && (
           <>
             <Chat

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -77,7 +77,7 @@ const Course = ({
         <title>{`${pageTitleBreadCrumbs.join(' | ')} | ${getConfig().SITE_NAME}`}</title>
       </Helmet>
       <div className="position-relative d-flex align-items-center mb-4 mt-1">
-        {!navigationDisabled && (
+        {navigationDisabled || (
         <>
           <CourseBreadcrumbs
             courseId={courseId}

--- a/src/courseware/course/Course.test.jsx
+++ b/src/courseware/course/Course.test.jsx
@@ -78,6 +78,27 @@ describe('Course', () => {
     );
   });
 
+  it('removes breadcrumbs when navigation is disabled', async () => {
+    const sequenceBlocks = [Factory.build(
+      'block',
+      { type: 'sequential', children: [] },
+      { courseId: mockData.courseId },
+    )];
+    const sequenceMetadata = [Factory.build(
+      'sequenceMetadata',
+      { navigation_disabled: true },
+      { courseId: mockData.courseId, sequenceBlock: sequenceBlocks[0] },
+    )];
+    const testStore = await initializeTestStore({ sequenceBlocks, sequenceMetadata }, false);
+    const testData = {
+      ...mockData,
+      sequenceId: sequenceBlocks[0].id,
+      onNavigate: jest.fn(),
+    };
+    render(<Course {...testData} />, { store: testStore, wrapWithRouter: true });
+    expect(screen.queryByRole('navigation', { name: 'breadcrumb' })).not.toBeInTheDocument();
+  });
+
   it('displays first section celebration modal', async () => {
     const courseHomeMetadata = Factory.build('courseHomeMetadata', { celebrations: { firstSection: true } });
     const testStore = await initializeTestStore({ courseHomeMetadata }, false);

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -32,7 +32,12 @@ const SequenceNavigation = ({
 }) => {
   const sequence = useModel('sequences', sequenceId);
   const {
-    isFirstUnit, isLastUnit, nextLink, previousLink,
+    isFirstUnit,
+    isLastUnit,
+    nextLink,
+    previousLink,
+    navigationDisabledPrevSequence,
+    navigationDisabledNextSequence,
   } = useSequenceNavigationMetadata(sequenceId, unitId);
   const {
     courseId,
@@ -68,8 +73,7 @@ const SequenceNavigation = ({
   const renderPreviousButton = () => {
     const disabled = isFirstUnit;
     const prevArrow = isRtl(getLocale()) ? ChevronRight : ChevronLeft;
-
-    return (
+    return !navigationDisabledPrevSequence && (
       <Button
         variant="link"
         className="previous-btn"
@@ -90,7 +94,7 @@ const SequenceNavigation = ({
     const disabled = isLastUnit && !exitActive;
     const nextArrow = isRtl(getLocale()) ? ChevronLeft : ChevronRight;
 
-    return (
+    return !navigationDisabledNextSequence && (
       <Button
         variant="link"
         className="next-btn"

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -73,7 +73,7 @@ const SequenceNavigation = ({
   const renderPreviousButton = () => {
     const disabled = isFirstUnit;
     const prevArrow = isRtl(getLocale()) ? ChevronRight : ChevronLeft;
-    return !navigationDisabledPrevSequence && (
+    return navigationDisabledPrevSequence || (
       <Button
         variant="link"
         className="previous-btn"
@@ -94,7 +94,7 @@ const SequenceNavigation = ({
     const disabled = isLastUnit && !exitActive;
     const nextArrow = isRtl(getLocale()) ? ChevronLeft : ChevronRight;
 
-    return !navigationDisabledNextSequence && (
+    return navigationDisabledNextSequence || (
       <Button
         variant="link"
         className="next-btn"

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -161,4 +161,52 @@ describe('Sequence Navigation', () => {
     fireEvent.click(screen.getByRole('link', { name: /next/i }));
     expect(nextHandler).toHaveBeenCalledTimes(1);
   });
+
+  it('removes "Previous" for first unit in sequence when navigation is disabled', async () => {
+    const sequenceBlocks = [Factory.build(
+      'block',
+      { type: 'sequential', children: unitBlocks.map(block => block.id) },
+      { courseId: courseMetadata.id },
+    )];
+    const sequenceMetadata = [Factory.build(
+      'sequenceMetadata',
+      { navigation_disabled: true },
+      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlocks[0] },
+    )];
+    const testStore = await initializeTestStore({ unitBlocks, sequenceBlocks, sequenceMetadata }, false);
+    const testData = {
+      ...mockData,
+      sequenceId: sequenceBlocks[0].id,
+      onNavigate: jest.fn(),
+    };
+    render(<SequenceNavigation {...testData} unitId={unitBlocks[0].id} />, { store: testStore, wrapWithRouter: true });
+    expect(screen.queryByRole('link', { name: /previous/i })).not.toBeInTheDocument();
+  });
+
+  it('removes "Next" for last unit in sequence when navigation is disabled', async () => {
+    const sequenceBlocks = [Factory.build(
+      'block',
+      { type: 'sequential', children: unitBlocks.map(block => block.id) },
+      { courseId: courseMetadata.id },
+    )];
+    const sequenceMetadata = [Factory.build(
+      'sequenceMetadata',
+      { navigation_disabled: true },
+      { courseId: courseMetadata.id, unitBlocks, sequenceBlock: sequenceBlocks[0] },
+    )];
+    const testStore = await initializeTestStore({ unitBlocks, sequenceBlocks, sequenceMetadata }, false);
+    const testData = {
+      ...mockData,
+      sequenceId: sequenceBlocks[0].id,
+      onNavigate: jest.fn(),
+    };
+    render(
+      <SequenceNavigation
+        {...testData}
+        unitId={unitBlocks[unitBlocks.length - 1].id}
+      />,
+      { store: testStore, wrapWithRouter: true },
+    );
+    expect(screen.queryByRole('link', { name: /next/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/courseware/course/sequence/sequence-navigation/hooks.js
+++ b/src/courseware/course/sequence/sequence-navigation/hooks.js
@@ -30,7 +30,7 @@ export function useSequenceNavigationMetadata(currentSequenceId, currentUnitId) 
   const isLastSequence = sequenceIndex === sequenceIds.length - 1;
   const isLastUnitInSequence = unitIndex === sequence.unitIds.length - 1;
   const isLastUnit = isLastSequence && isLastUnitInSequence;
-  const sequenceNavigationDisabled = sequence?.navigationDisabled;
+  const sequenceNavigationDisabled = sequence.navigationDisabled;
   const navigationDisabledPrevSequence = sequenceNavigationDisabled && isFirstUnitInSequence;
   const navigationDisabledNextSequence = sequenceNavigationDisabled && isLastUnitInSequence;
 

--- a/src/courseware/course/sequence/sequence-navigation/hooks.js
+++ b/src/courseware/course/sequence/sequence-navigation/hooks.js
@@ -13,7 +13,12 @@ export function useSequenceNavigationMetadata(currentSequenceId, currentUnitId) 
 
   // If we don't know the sequence and unit yet, then assume no.
   if (courseStatus !== 'loaded' || sequenceStatus !== 'loaded' || !currentSequenceId || !currentUnitId) {
-    return { isFirstUnit: false, isLastUnit: false };
+    return {
+      isFirstUnit: false,
+      isLastUnit: false,
+      navigationDisabledNextSequence: false,
+      navigationDisabledPrevSequence: false,
+    };
   }
 
   const sequenceIndex = sequenceIds.indexOf(currentSequenceId);
@@ -25,6 +30,9 @@ export function useSequenceNavigationMetadata(currentSequenceId, currentUnitId) 
   const isLastSequence = sequenceIndex === sequenceIds.length - 1;
   const isLastUnitInSequence = unitIndex === sequence.unitIds.length - 1;
   const isLastUnit = isLastSequence && isLastUnitInSequence;
+  const sequenceNavigationDisabled = sequence?.navigationDisabled;
+  const navigationDisabledPrevSequence = sequenceNavigationDisabled && isFirstUnitInSequence;
+  const navigationDisabledNextSequence = sequenceNavigationDisabled && isLastUnitInSequence;
 
   const nextSequenceId = sequenceIndex < sequenceIds.length - 1 ? sequenceIds[sequenceIndex + 1] : null;
   const previousSequenceId = sequenceIndex > 0 ? sequenceIds[sequenceIndex - 1] : null;
@@ -52,6 +60,11 @@ export function useSequenceNavigationMetadata(currentSequenceId, currentUnitId) 
   }
 
   return {
-    isFirstUnit, isLastUnit, nextLink, previousLink,
+    isFirstUnit,
+    isLastUnit,
+    nextLink,
+    previousLink,
+    navigationDisabledNextSequence,
+    navigationDisabledPrevSequence,
   };
 }

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -160,6 +160,7 @@ function normalizeSequenceMetadata(sequence) {
       saveUnitPosition: sequence.save_position,
       showCompletion: sequence.show_completion,
       allowProctoringOptOut: sequence.allow_proctoring_opt_out,
+      navigationDisabled: sequence.navigation_disabled,
     },
     units: sequence.items.map(unit => ({
       id: unit.id,


### PR DESCRIPTION
**Settings**

```yaml
EDX_PLATFORM_REPOSITORY: https://github.com/eduNEXT/edx-platform.git
EDX_PLATFORM_VERSION: MJG/hide-from-navigation-toc

TUTOR_GROVE_CMS_ENV_FEATURES: |
  ENABLE_HIDE_FROM_TOC_UI: True
```

### Description
This PR adds a flag check to navigation components (next/previous buttons & course sequence breadcrumbs) to disable them if `navigation_disabled` is True.

The `navigation_disabled` field comes from this edx-platform PR: https://github.com/openedx/edx-platform/pull/34049, which returns the new field as sequence metadata, based on whether the sequence was configured as Hide from TOC. This kind of flag could also be extended for other use cases, not just hidden from TOC. 

These changes are part of a series of PR(s) that implement the [Feature Enhancement Proposal: Hide Sections from course outline](https://openedx.atlassian.net/wiki/spaces/OEPM/pages/3853975595/Feature+Enhancement+Proposal+Hide+Sections+from+course+outline): 
https://github.com/openedx/edx-platform/pulls?q=is%3Apr+is%3Aopen+hide+from+toc
https://github.com/openedx/frontend-app-learning/pulls?q=is%3Apr+is%3Aopen+hide+from+toc

### How to test
Test setup using tutor:
1. `git clone https://github.com/openedx/frontend-app-learning.git`
2. `git fetch origin pull/1273/head:hide-from-sequence-nav`
3. Then, run: `tutor mounts add ./frontend-app-learning`
4. `cd frontend-app-learning && npm install`, ensure you're using node 18
5.  `tutor dev launch`

It's better to test this out along with this PR: https://github.com/openedx/edx-platform/pull/33952. So first, follow the instructions in that PR. Don't change branches; apply these commits on top of the branch. 

For the Learning MFE changes, please follow the instructions listed here. Then, go to the LMS using the link to your hidden subsection, it should look something like this with > 1 and exactly 1:

https://github.com/openedx/frontend-app-learning/assets/64440265/31215268-24f6-4188-8593-2972d78a5a8c

With 1 unit it doesn't show prev, next and sequence breadcrumbs. With more than one, it shows next and previous for units within the same sequence.

### Other information
As I mentioned, this PR is part of a series of PRs implementing the feature enhancement of Hide From TOC. This initiative is an open-source contribution to the Open edX platform funded by a Unidigital project from the Spanish Government - 2023.