### PR TITLE
feat: tutor-mfe compatiblilty for `atlas pull` | FC-0012

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,15 @@ pull_translations:
 	rm -rf src/i18n/messages
 	mkdir src/i18n/messages
 	cd src/i18n/messages \
-      && atlas pull --filter=$(transifex_langs) \
+      && atlas pull $(ATLAS_OPTIONS) \
+               translations/frontend-platform/src/i18n/messages:frontend-platform \
                translations/paragon/src/i18n/messages:paragon \
                translations/frontend-component-header/src/i18n/messages:frontend-component-header \
                translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+               translations/frontend-lib-special-exams/src/i18n/messages:frontend-lib-special-exams \
                translations/frontend-app-learning/src/i18n/messages:frontend-app-learning
 
-	$(intl_imports) paragon frontend-component-header frontend-component-footer frontend-app-learning
+	$(intl_imports) frontend-platform paragon frontend-component-header frontend-component-footer frontend-lib-special-exams frontend-app-learning
 endif
 
 # This target is used by Travis.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@edx/frontend-lib-learning-assistant": "^1.20.1",
         "@edx/frontend-lib-special-exams": "2.27.0",
         "@edx/frontend-platform": "5.5.2",
+        "@edx/openedx-atlas": "^0.6.0",
         "@edx/paragon": "20.46.0",
         "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.7.0",
         "@fortawesome/fontawesome-svg-core": "1.3.0",
@@ -3698,6 +3699,14 @@
       "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
       "dependencies": {
         "@newrelic/publish-sourcemap": "^5.0.1"
+      }
+    },
+    "node_modules/@edx/openedx-atlas": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/openedx-atlas/-/openedx-atlas-0.6.0.tgz",
+      "integrity": "sha512-wZO7hA4VJ/bXjaQNNR7KXGYyTCNs1mBJd3HwQK2EmOwFZYFNX6nzSAm9S7HCfi/kb1PCRpmp3wJt+v/Eu9BEQg==",
+      "bin": {
+        "atlas": "atlas"
       }
     },
     "node_modules/@edx/paragon": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@edx/frontend-lib-special-exams": "2.27.0",
     "@edx/frontend-lib-learning-assistant": "^1.20.1",
     "@edx/frontend-platform": "5.5.2",
+    "@edx/openedx-atlas": "^0.6.0",
     "@edx/paragon": "20.46.0",
     "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.7.0",
     "@fortawesome/fontawesome-svg-core": "1.3.0",


### PR DESCRIPTION
Similar to https://github.com/openedx/frontend-app-communications/pull/187.


### Changes
 - install atlas
 - remove `--filter` to pull all languages by default
 - use ATLAS_OPTIONS to allow custom `--filter`
 - include frontend-lib-special-exams in `atlas pull`

## Refs
This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).

