### PR TITLE
feat: remove audit access to learning assistant chat

### DIFF
--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -31,10 +31,10 @@ const Chat = ({
     'unpaid-bootcamp',
   ];
 
-  const isEnrolled = (
+  const hasVerifiedEnrollment = (
     enrollmentMode !== null
     && enrollmentMode !== undefined
-    && [...VERIFIED_MODES, ...AUDIT_MODES].some(mode => mode === enrollmentMode)
+    && [...VERIFIED_MODES].some(mode => mode === enrollmentMode)
   );
 
   const endDatePassed = () => {
@@ -46,7 +46,7 @@ const Chat = ({
 
   const shouldDisplayChat = (
     enabled
-    && (isEnrolled || isStaff) // display only to enrolled or staff
+    && (hasVerifiedEnrollment || isStaff) // display only to verified learners or staff
     && !endDatePassed()
   );
 

--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -24,13 +24,6 @@ const Chat = ({
     'paid-bootcamp',
   ];
 
-  const AUDIT_MODES = [
-    'audit',
-    'honor',
-    'unpaid-executive-education',
-    'unpaid-bootcamp',
-  ];
-
   const hasVerifiedEnrollment = (
     enrollmentMode !== null
     && enrollmentMode !== undefined

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -16,9 +16,9 @@ let enabledTestCases = [];
 let disabledTestCases = [];
 const enabledModes = [
   'professional', 'verified', 'no-id-professional', 'credit', 'masters', 'executive-education',
-  'paid-executive-education', 'paid-bootcamp', 'audit', 'honor', 'unpaid-executive-education', 'unpaid-bootcamp',
+  'paid-executive-education', 'paid-bootcamp',
 ];
-const disabledModes = [null, undefined, 'xyz'];
+const disabledModes = [null, undefined, 'xyz', 'audit', 'honor', 'unpaid-executive-education', 'unpaid-bootcamp'];
 const currentTime = new Date();
 
 describe('Chat', () => {


### PR DESCRIPTION
## [COSMO-112](https://2u-internal.atlassian.net/browse/COSMO-112)

As part of a general release, only verified track learners should have access to the chat UI. 