### PR TITLE
feat: gate visibility of chat component by active attempt

### DIFF
--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -1,4 +1,5 @@
 import { createPortal } from 'react-dom';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { Xpert } from '@edx/frontend-lib-learning-assistant';
@@ -13,6 +14,10 @@ const Chat = ({
   unitId,
   endDate,
 }) => {
+  const {
+    activeAttempt, exam,
+  } = useSelector(state => state.specialExams);
+
   const VERIFIED_MODES = [
     'professional',
     'verified',
@@ -41,6 +46,10 @@ const Chat = ({
     enabled
     && (hasVerifiedEnrollment || isStaff) // display only to verified learners or staff
     && !endDatePassed()
+    // it is necessary to check both whether the user is in an exam, and whether or not they are viewing an exam
+    // this will prevent the learner from interacting with the tool at any point of the exam flow, even at the
+    // entrance interstitial.
+    && !(activeAttempt?.attempt_id || exam?.id)
   );
 
   return (

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,6 @@
 import { reducer as learningAssistantReducer } from '@edx/frontend-lib-learning-assistant';
-import { configureStore } from '@reduxjs/toolkit';
 import { reducer as specialExamsReducer } from '@edx/frontend-lib-special-exams';
+import { configureStore } from '@reduxjs/toolkit';
 import { reducer as courseHomeReducer } from './course-home/data';
 import { reducer as coursewareReducer } from './courseware/data/slice';
 import { reducer as recommendationsReducer } from './courseware/course/course-exit/data/slice';


### PR DESCRIPTION
## [COSMO-86](https://2u-internal.atlassian.net/browse/COSMO-86)

The chat component should not be visible if a learner has an active attempt. The special exams library has been refactored so that the exam state is accessible outside of components defined in the exams library. This PR makes use of the newly available exams reducer to gave chat visibility.