### PR TITLE
feat: update version of frontend-lib-learning-assistant to 1.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-component-footer": "12.2.1",
         "@edx/frontend-component-header": "4.6.0",
-        "@edx/frontend-lib-learning-assistant": "^1.20.1",
+        "@edx/frontend-lib-learning-assistant": "^1.21.0",
         "@edx/frontend-lib-special-exams": "2.27.0",
         "@edx/frontend-platform": "5.5.2",
         "@edx/openedx-atlas": "^0.6.0",
@@ -3461,9 +3461,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-1.20.1.tgz",
-      "integrity": "sha512-/JUSfs4CZwZj2Bg0BqlMGIC6BrDu4PufUSFnrgusL4ZD/N8DR3UyX/AQZml7S9O/ci4OY3YU7V4VDM8X00+6Lg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-1.21.0.tgz",
+      "integrity": "sha512-KHmKBKtDxNVWCLOvvuoe1Sboc5BqI0mQP1UX0mhF9USI7ebZ5tPB1oxy6XK7ZhMBQPXMUBoWVh2Krf7P4NhWeg==",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@edx/frontend-component-footer": "12.2.1",
     "@edx/frontend-component-header": "4.6.0",
     "@edx/frontend-lib-special-exams": "2.27.0",
-    "@edx/frontend-lib-learning-assistant": "^1.20.1",
+    "@edx/frontend-lib-learning-assistant": "^1.21.0",
     "@edx/frontend-platform": "5.5.2",
     "@edx/openedx-atlas": "^0.6.0",
     "@edx/paragon": "20.46.0",

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -8,6 +8,23 @@ import { initializeMockApp, render, screen } from '../../../setupTest';
 
 import Chat from './Chat';
 
+// We do a partial mock to avoid mocking out other exported values (e.g. the reducer).
+// We mock out the Xpert component, because the Xpert component has its own rules for whether it renders
+// or not, and this includes the results of API calls it makes. We don't want to test those rules here, just
+// whether the Xpert is rendered by the Chat component in certain conditions. Instead of actually rendering
+// Xpert, we render and assert on a mocked component.
+const mockXpertTestId = 'xpert';
+
+jest.mock('@edx/frontend-lib-learning-assistant', () => {
+  const originalModule = jest.requireActual('@edx/frontend-lib-learning-assistant');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    Xpert: () => (<div data-testid={mockXpertTestId}>mocked Xpert</div>),
+  };
+});
+
 initializeMockApp();
 
 const courseId = 'course-v1:edX+DemoX+Demo_Course';
@@ -51,7 +68,7 @@ describe('Chat', () => {
           { store },
         );
 
-        const chat = screen.queryByTestId('toggle-button');
+        const chat = screen.queryByTestId(mockXpertTestId);
         if (test.isVisible) {
           expect(chat).toBeInTheDocument();
         } else {
@@ -85,7 +102,7 @@ describe('Chat', () => {
         { store },
       );
 
-      const chat = screen.queryByTestId('toggle-button');
+      const chat = screen.queryByTestId(mockXpertTestId);
       if (test.isVisible) {
         expect(chat).toBeInTheDocument();
       } else {
@@ -147,7 +164,7 @@ describe('Chat', () => {
           { store },
         );
 
-        const chat = screen.queryByTestId('toggle-button');
+        const chat = screen.queryByTestId(mockXpertTestId);
         if (test.isVisible) {
           expect(chat).toBeInTheDocument();
         } else {
@@ -178,7 +195,7 @@ describe('Chat', () => {
       { store },
     );
 
-    const chat = screen.queryByTestId('toggle-button');
+    const chat = screen.queryByTestId(mockXpertTestId);
     expect(chat).not.toBeInTheDocument();
   });
 
@@ -203,7 +220,7 @@ describe('Chat', () => {
       { store },
     );
 
-    const chat = screen.queryByTestId('toggle-button');
+    const chat = screen.queryByTestId(mockXpertTestId);
     expect(chat).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Description:

**Jira**: [COSMO-161](https://2u-internal.atlassian.net/browse/COSMO-161) (private)

This commit installs version `1.21.0` of `@edx/frontend-lib-learning-assistant`.

This release uses a new GET endpoint published on the Learning Assistant backend to determine whether the Learning Assistant feature is enabled. If the features is not enabled, the Learning Assistant is not rendered, and vice-versa.