### PR TITLE
feat: show chat for desktop only

### DIFF
--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -54,6 +54,7 @@ const Course = ({
     celebrations && !celebrations.streakLengthToCelebrate && celebrations.weeklyGoal,
   );
   const shouldDisplayTriggers = windowWidth >= breakpoints.small.minWidth;
+  const shouldDisplayChat = windowWidth >= breakpoints.medium.minWidth;
   const daysPerWeek = course?.courseGoals?.selectedGoal?.daysPerWeek;
 
   useEffect(() => {
@@ -82,7 +83,7 @@ const Course = ({
           isStaff={isStaff}
           unitId={unitId}
         />
-        {shouldDisplayTriggers && (
+        {shouldDisplayChat && (
           <>
             <Chat
               enabled={course.learningAssistantEnabled}
@@ -93,6 +94,10 @@ const Course = ({
               unitId={unitId}
               endDate={course.end ? course.end : ''}
             />
+          </>
+        )}
+        {shouldDisplayTriggers && (
+          <>
             {enableNewSidebar === 'true' ? <NewSidebarTriggers /> : <SidebarTriggers /> }
           </>
         )}


### PR DESCRIPTION
### Context

The Chatbot UI is conditionally displayed based on the screen width of a browser. The current breakpoint allows for mobile browsers in landscape mode to be able to view the chat toggle, although the tool itself has not been tested for mobile use yet. 

The breakpoint should be changed to prevent mobile users from seeing the chat toggle. The updated breakpoint should only apply to the Chat toggle, not to any other triggers in the Learning MFE.

### Changes
- Added new breakpoint specific to chat
- Set to min medium based on available breakpoints here: https://paragon-openedx.netlify.app/foundations/responsive/#available-breakpoints

### Screenshots

<img width="790" alt="Screenshot 2024-02-07 at 3 17 09 PM" src="https://github.com/openedx/frontend-app-learning/assets/46579265/5fc7c6af-a606-41cf-9942-2cd1bdcb5cd2">
<img width="704" alt="Screenshot 2024-02-07 at 3 17 23 PM" src="https://github.com/openedx/frontend-app-learning/assets/46579265/86eaccca-ae21-4c49-aa9c-3276cc518c54">
