### PR TITLE
CoursewareSearch - Show filters if needed only

### DIFF
--- a/src/course-home/courseware-search/CoursewareResultsFilter.jsx
+++ b/src/course-home/courseware-search/CoursewareResultsFilter.jsx
@@ -22,9 +22,13 @@ export const CoursewareSearchResultsFilter = ({ intl }) => {
 
   const { results: data = [] } = lastSearch;
 
-  if (!data.length) { return null; }
+  // If there's no data, we show an empty result.
+  if (!data.length) { return <CoursewareSearchResults />; }
 
   const results = useMemo(() => {
+    // This reducer distributes the data into different groups to make it easy to
+    // use on the filters.
+    // All results are added to the "all" key and then to its proper group key as well.
     const grouped = data.reduce((acc, { type, ...rest }) => {
       const resultType = filterTypes.includes(type) ? type : filterOther;
       acc[filterAll].push({ type: resultType, ...rest });
@@ -32,7 +36,7 @@ export const CoursewareSearchResultsFilter = ({ intl }) => {
       return acc;
     }, { [filterAll]: [] });
 
-    // This is just to keep the tab order
+    // This is just to format the output object with the expected tab order.
     const output = {};
     validFilters.forEach(key => { if (grouped[key]) { output[key] = grouped[key]; } });
 
@@ -60,11 +64,11 @@ export const CoursewareSearchResultsFilter = ({ intl }) => {
       activeKey={activeKey}
       onSelect={setFilter}
     >
-      {filters.filter(({ count }) => (count > 0)).map(({ key, label }) => (results[key].length ? (
+      {filters.filter(({ count }) => (count > 0)).map(({ key, label }) => (
         <Tab key={key} eventKey={key} title={label} data-testid={`courseware-search-results-tabs-${key}`}>
           <CoursewareSearchResults results={results[key]} />
         </Tab>
-      ) : null))}
+      ))}
     </Tabs>
   );
 };

--- a/src/course-home/courseware-search/CoursewareResultsFilter.jsx
+++ b/src/course-home/courseware-search/CoursewareResultsFilter.jsx
@@ -45,6 +45,11 @@ export const CoursewareSearchResultsFilter = ({ intl }) => {
 
   const activeKey = allowedFilterKeys[filterKeyword] ? filterKeyword : allFilterKey;
 
+  const filterCount = filters.reduce((sum, { count }) => (count ? 1 : 0), 0);
+
+  // Filter is not useful if it has only 2 tabs (The "all" tab and another one with the same items).
+  if (filterCount < 3) { return null; }
+
   return (
     <Tabs
       id="courseware-search-results-tabs"
@@ -54,11 +59,11 @@ export const CoursewareSearchResultsFilter = ({ intl }) => {
       activeKey={activeKey}
       onSelect={setFilter}
     >
-      {filters.map(({ key, label }) => (
+      {filters.filter(({ count }) => (count > 0)).map(({ key, label }) => (results[key].length ? (
         <Tab key={key} eventKey={key} title={label} data-testid={`courseware-search-results-tabs-${key}`}>
           <CoursewareSearchResults results={results[key]} />
         </Tab>
-      ))}
+      ) : null))}
     </Tabs>
   );
 };

--- a/src/course-home/courseware-search/CoursewareResultsFilter.test.jsx
+++ b/src/course-home/courseware-search/CoursewareResultsFilter.test.jsx
@@ -52,21 +52,23 @@ function renderComponent(props = {}) {
 describe('CoursewareSearchResultsFilter', () => {
   beforeAll(initializeMockApp);
 
-  describe('</CoursewareSearchResultsFilter />', () => {
-    beforeEach(() => {
-      useCoursewareSearchParams.mockReturnValue(coursewareSearch);
-    });
+  beforeEach(() => {
+    useCoursewareSearchParams.mockReturnValue(coursewareSearch);
+  });
 
-    afterEach(() => {
-      jest.clearAllMocks();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when returning full results', () => {
+    beforeEach(async () => {
+      useModel.mockReturnValue(searchResultsFactory());
+      await renderComponent();
     });
 
     it('should render without errors', async () => {
-      useModel.mockReturnValue(searchResultsFactory());
-
-      await renderComponent();
-
       await waitFor(() => {
+        expect(screen.queryByTestId('courseware-search-results-tabs')).toBeInTheDocument();
         expect(screen.queryByTestId('courseware-search-results-tabs-all')).toBeInTheDocument();
         expect(screen.queryByTestId('courseware-search-results-tabs-text')).toBeInTheDocument();
         expect(screen.queryByTestId('courseware-search-results-tabs-video')).toBeInTheDocument();
@@ -74,26 +76,39 @@ describe('CoursewareSearchResultsFilter', () => {
         expect(screen.queryByTestId('courseware-search-results-tabs-other')).toBeInTheDocument();
       });
     });
+  });
 
-    describe('when there are not results', () => {
-      it('should render without errors', async () => {
-        useModel.mockReturnValue(searchResultsFactory('blah', {
-          results: [],
-          filters: [],
-          total: 0,
-          maxScore: null,
-          ms: 5,
-        }));
+  describe('when returning only one result type', () => {
+    beforeEach(async () => {
+      // Filter only videos
+      const results = searchResultsFactory().filter(({ type }) => type === 'video');
 
-        await renderComponent();
+      useModel.mockReturnValue(results);
+      await renderComponent();
+    });
 
-        await waitFor(() => {
-          expect(screen.queryByTestId('courseware-search-results-tabs-all')).toBeInTheDocument();
-          expect(screen.queryByTestId('courseware-search-results-tabs-text')).toBeInTheDocument();
-          expect(screen.queryByTestId('courseware-search-results-tabs-video')).toBeInTheDocument();
-          expect(screen.queryByTestId('courseware-search-results-tabs-sequence')).toBeInTheDocument();
-          expect(screen.queryByTestId('courseware-search-results-tabs-other')).toBeInTheDocument();
-        });
+    it('should render without errors', async () => {
+      await waitFor(() => {
+        expect(screen.queryByTestId('courseware-search-results-tabs')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when there are not results', () => {
+    beforeEach(async () => {
+      useModel.mockReturnValue(searchResultsFactory('blah', {
+        results: [],
+        filters: [],
+        total: 0,
+        maxScore: null,
+        ms: 5,
+      }));
+      await renderComponent();
+    });
+
+    it('should not render', async () => {
+      await waitFor(() => {
+        expect(screen.queryByTestId('courseware-search-results-tabs')).not.toBeInTheDocument();
       });
     });
   });

--- a/src/course-home/courseware-search/CoursewareResultsFilter.test.jsx
+++ b/src/course-home/courseware-search/CoursewareResultsFilter.test.jsx
@@ -68,29 +68,38 @@ describe('CoursewareSearchResultsFilter', () => {
 
     it('should render without errors', async () => {
       await waitFor(() => {
-        expect(screen.queryByTestId('courseware-search-results-tabs')).toBeInTheDocument();
-        expect(screen.queryByTestId('courseware-search-results-tabs-all')).toBeInTheDocument();
-        expect(screen.queryByTestId('courseware-search-results-tabs-text')).toBeInTheDocument();
-        expect(screen.queryByTestId('courseware-search-results-tabs-video')).toBeInTheDocument();
-        expect(screen.queryByTestId('courseware-search-results-tabs-sequence')).toBeInTheDocument();
-        expect(screen.queryByTestId('courseware-search-results-tabs-other')).toBeInTheDocument();
+        expect(useCoursewareSearchParams).toBeCalled();
       });
+
+      expect(screen.queryByTestId('courseware-search-results-tabs')).toBeInTheDocument();
+      expect(screen.queryByTestId('courseware-search-results-tabs-all')).toBeInTheDocument();
+      expect(screen.queryByTestId('courseware-search-results-tabs-text')).toBeInTheDocument();
+      expect(screen.queryByTestId('courseware-search-results-tabs-video')).toBeInTheDocument();
+      expect(screen.queryByTestId('courseware-search-results-tabs-sequence')).toBeInTheDocument();
+      expect(screen.queryByTestId('courseware-search-results-tabs-other')).toBeInTheDocument();
     });
   });
 
   describe('when returning only one result type', () => {
     beforeEach(async () => {
-      // Filter only videos
-      const results = searchResultsFactory().filter(({ type }) => type === 'video');
+      // Get results for only videos
+      const data = searchResultsFactory();
+      const onlyVideos = data.results.filter(({ type }) => type === 'video');
+      const filteredResults = {
+        ...data,
+        results: onlyVideos,
+      };
 
-      useModel.mockReturnValue(results);
+      useModel.mockReturnValue(filteredResults);
       await renderComponent();
     });
 
-    it('should render without errors', async () => {
+    it('should not render', async () => {
       await waitFor(() => {
-        expect(screen.queryByTestId('courseware-search-results-tabs')).not.toBeInTheDocument();
+        expect(useCoursewareSearchParams).toBeCalled();
       });
+
+      expect(screen.queryByTestId('courseware-search-results-tabs')).not.toBeInTheDocument();
     });
   });
 
@@ -108,8 +117,10 @@ describe('CoursewareSearchResultsFilter', () => {
 
     it('should not render', async () => {
       await waitFor(() => {
-        expect(screen.queryByTestId('courseware-search-results-tabs')).not.toBeInTheDocument();
+        expect(useCoursewareSearchParams).toBeCalled();
       });
+
+      expect(screen.queryByTestId('courseware-search-results-tabs')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/course-home/courseware-search/CoursewareSearch.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.jsx
@@ -122,16 +122,16 @@ const CoursewareSearch = ({ intl, ...sectionProps }) => {
           )}
           {status === 'results' ? (
             <>
-              <div
-                className="courseware-search__results-summary"
-                aria-live="polite"
-                aria-relevant="all"
-                aria-atomic="true"
-                data-testid="courseware-search-summary"
-              >{total > 0
-                ? intl.formatMessage(messages.searchResultsLabel, { total, keyword: lastSearchKeyword })
-                : intl.formatMessage(messages.searchResultsNone)}
-              </div>
+              {total > 0 ? (
+                <div
+                  className="courseware-search__results-summary"
+                  aria-live="polite"
+                  aria-relevant="all"
+                  aria-atomic="true"
+                  data-testid="courseware-search-summary"
+                >{intl.formatMessage(messages.searchResultsLabel, { total, keyword: lastSearchKeyword })}
+                </div>
+              ) : null}
               <CoursewareSearchResultsFilterContainer />
             </>
           ) : null}

--- a/src/course-home/courseware-search/CoursewareSearch.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.test.jsx
@@ -236,14 +236,14 @@ describe('CoursewareSearch', () => {
       expect(screen.queryByTestId('courseware-search-error')).toBeInTheDocument();
     });
 
-    it('should show "No results found." if results is empty', () => {
+    it('should not show a summary if there are no results', () => {
       mockModels({
         searchKeyword: 'test',
         total: 0,
       });
       renderComponent();
 
-      expect(screen.queryByTestId('courseware-search-summary').textContent).toBe('No results found.');
+      expect(screen.queryByTestId('courseware-search-summary')).not.toBeInTheDocument();
     });
 
     it('should show a summary for the results', () => {

--- a/src/course-home/courseware-search/CoursewareSearchResults.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchResults.jsx
@@ -8,9 +8,10 @@ import PropTypes from 'prop-types';
 import CoursewareSearchEmpty from './CoursewareSearchEmpty';
 
 const iconTypeMapping = {
-  document: Folder,
   text: TextFields,
   video: VideoCamera,
+  sequence: Folder,
+  other: Article,
 };
 
 const defaultIcon = Article;
@@ -34,9 +35,7 @@ const CoursewareSearchResults = ({ results = [] }) => {
       }) => {
         const key = type.toLowerCase();
         const icon = iconTypeMapping[key] || defaultIcon;
-
         const isExternal = !url.startsWith('/');
-
         const linkProps = isExternal ? {
           href: url,
           target: '_blank',

--- a/src/course-home/courseware-search/__snapshots__/CoursewareSearchResults.test.jsx.snap
+++ b/src/course-home/courseware-search/__snapshots__/CoursewareSearchResults.test.jsx.snap
@@ -26,7 +26,7 @@ exports[`CoursewareSearchResults when list of results is provided should match t
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M3 3v18h18V3H3Zm11 14H7v-2h7v2Zm3-4H7v-2h10v2Zm0-4H7V7h10v2Z"
+            d="M10 4H2v16h20V6H12l-2-2z"
             fill="currentColor"
           />
         </svg>
@@ -140,7 +140,7 @@ exports[`CoursewareSearchResults when list of results is provided should match t
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M3 3v18h18V3H3Zm11 14H7v-2h7v2Zm3-4H7v-2h10v2Zm0-4H7V7h10v2Z"
+            d="M10 4H2v16h20V6H12l-2-2z"
             fill="currentColor"
           />
         </svg>

--- a/src/course-home/courseware-search/courseware-search.scss
+++ b/src/course-home/courseware-search/courseware-search.scss
@@ -51,6 +51,8 @@
 
   &__empty {
     color: $gray-500;
+    padding: 6rem 0;
+    text-align: center;
   }
 
   &__item {

--- a/src/course-home/courseware-search/hooks.js
+++ b/src/course-home/courseware-search/hooks.js
@@ -70,9 +70,10 @@ export function useLockScroll() {
   }, []);
 }
 
+const initSearchParams = { q: '', f: '' };
 export function useCoursewareSearchParams() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const clearSearchParams = () => setSearchParams({ q: '', f: '' });
+  const [searchParams, setSearchParams] = useSearchParams(initSearchParams);
+  const clearSearchParams = () => setSearchParams(initSearchParams);
 
   const query = searchParams.get('q');
   const filter = searchParams.get('f')?.toLowerCase();

--- a/src/course-home/courseware-search/hooks.js
+++ b/src/course-home/courseware-search/hooks.js
@@ -75,7 +75,7 @@ export function useCoursewareSearchParams() {
   const clearSearchParams = () => setSearchParams({ q: '', f: '' });
 
   const query = searchParams.get('q');
-  const filter = searchParams.get('f');
+  const filter = searchParams.get('f')?.toLowerCase();
 
   const setQuery = (q) => setSearchParams((params) => ({ q, f: params.get('f') }));
   const setFilter = (f) => setSearchParams((params) => ({ q: params.get('q'), f }));

--- a/src/course-home/courseware-search/hooks.test.jsx
+++ b/src/course-home/courseware-search/hooks.test.jsx
@@ -1,9 +1,13 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { fetchCoursewareSearchSettings } from '../data/thunks';
 import {
-  useCoursewareSearchFeatureFlag, useCoursewareSearchState, useElementBoundingBox, useLockScroll,
+  useCoursewareSearchFeatureFlag,
+  useCoursewareSearchParams,
+  useCoursewareSearchState,
+  useElementBoundingBox,
+  useLockScroll,
 } from './hooks';
 
 jest.mock('react-redux');
@@ -182,6 +186,47 @@ describe('CoursewareSearch Hooks', () => {
       hook.unmount();
 
       expect(removeBodyClassSpy).toHaveBeenCalledWith('_search-no-scroll');
+    });
+  });
+
+  describe('useSearchParams', () => {
+    const initSearch = { q: '', f: '' };
+    const q = { value: '' };
+    const f = { value: '' };
+    const mockedQuery = { q, f };
+    const searchParams = { get: (prop) => mockedQuery[prop].value };
+    const setSearchParams = jest.fn();
+
+    beforeEach(() => {
+      useSearchParams.mockImplementation(() => [searchParams, setSearchParams]);
+    });
+
+    it('should init the search params properly', () => {
+      const {
+        query, filter, setQuery, setFilter, clearSearchParams,
+      } = useCoursewareSearchParams();
+
+      expect(useSearchParams).toBeCalledWith(initSearch);
+      expect(query).toBe('');
+      expect(filter).toBe('');
+
+      setQuery('setQuery');
+      expect(setSearchParams).toBeCalledWith(expect.any(Function));
+
+      setFilter('setFilter');
+      expect(setSearchParams).toBeCalledWith(expect.any(Function));
+
+      clearSearchParams();
+      expect(setSearchParams).toBeCalledWith(initSearch);
+    });
+
+    it('should return the query and lowercase filter if any', () => {
+      q.value = '42';
+      f.value = 'LOWERCASE';
+      const { query, filter } = useCoursewareSearchParams();
+
+      expect(query).toBe('42');
+      expect(filter).toBe('lowercase');
     });
   });
 });


### PR DESCRIPTION
Description
Ticket: [KBK-108 🔒](https://2u-internal.atlassian.net/browse/KBK-108)

These changes hide the filter options with no results (no use). It also hides the filter entirely if the results consists of only one result type. In addition to this, I'm fixing some other minor issues that prevented the search results to show properly.

UI changes
Full results
all-result-types

Partial filters results
two-result-types

Only one result type (no need for filtering)
one-result-type-only

Removed double message on empty results (also improved the UI a bit)
no-results