### PR TITLE
feat: stick discussion sidebar to top

### DIFF
--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsSidebar.jsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsSidebar.jsx
@@ -17,7 +17,7 @@ const DiscussionsNotificationsSidebar = () => {
     <SidebarBase
       ariaLabel={intl.formatMessage(messages.discussionNotificationTray)}
       sidebarId={ID}
-      className="d-flex flex-column flex-fill"
+      className="d-flex flex-column flex-fill sticky-top vh-100"
       showTitleBar={false}
       showBorder={false}
     >

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -32,7 +32,7 @@ const DiscussionsSidebar = ({ intl }) => {
     >
       <iframe
         src={`${discussionsUrl}?inContextSidebar`}
-        className="d-flex w-100 h-100 border-0"
+        className="d-flex sticky-top vh-100 w-100 border-0"
         title={intl.formatMessage(messages.discussionsTitle)}
         allow="clipboard-write"
         loading="lazy"

--- a/src/index.scss
+++ b/src/index.scss
@@ -368,6 +368,11 @@
   }
 }
 
+.sticky-top {
+  position: sticky;
+  top: 0;
+}
+
 // Import component-specific sass files
 @import "courseware/course/celebration/CelebrationModal.scss";
 @import "courseware/course/sidebar/sidebars/notifications/NotificationIcon.scss";


### PR DESCRIPTION
Discussion sidebar has been sticked to top of screen for both new sidebar and old sidebar.

Ticket: [INF-1034](https://2u-internal.atlassian.net/browse/INF-1034)

## Screenshots
### Before
<img width="1440" alt="inf-1034_01_before" src="https://github.com/openedx/frontend-app-learning/assets/77053848/50439032-b045-4994-96a5-13c7e60bee51">

### After
<img width="1393" alt="inf-1034_02_after" src="https://github.com/openedx/frontend-app-learning/assets/77053848/69bf2677-63b9-4ccb-8baa-e4a40ba2a7e4">

