### PR TITLE
fix: fixed empty section issue

### DIFF
--- a/src/courseware/course/new-sidebar/Sidebar.jsx
+++ b/src/courseware/course/new-sidebar/Sidebar.jsx
@@ -4,9 +4,9 @@ import SidebarContext from './SidebarContext';
 import { SIDEBARS } from './sidebars';
 
 const Sidebar = () => {
-  const { currentSidebar } = useContext(SidebarContext);
+  const { currentSidebar, isDiscussionbarAvailable, isNotificationbarAvailable } = useContext(SidebarContext);
 
-  if (currentSidebar === null) { return null; }
+  if (currentSidebar === null || (!isDiscussionbarAvailable && !isNotificationbarAvailable)) { return null; }
   const SidebarToRender = SIDEBARS[currentSidebar].Sidebar;
 
   return (

--- a/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
@@ -20,7 +20,10 @@ const SidebarProvider = ({
 }) => {
   const shouldDisplayFullScreen = useWindowSize().width < breakpoints.large.minWidth;
   const shouldDisplaySidebarOpen = useWindowSize().width > breakpoints.medium.minWidth;
-  const [currentSidebar, setCurrentSidebar] = useState(null);
+  const query = new URLSearchParams(window.location.search);
+  const initialSidebar = (shouldDisplaySidebarOpen || query.get('sidebar') === 'true')
+    ? SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID : null;
+  const [currentSidebar, setCurrentSidebar] = useState(initialSidebar);
   const [notificationStatus, setNotificationStatus] = useState(getLocalStorage(`notificationStatus.${courseId}`));
   const [hideDiscussionbar, setHideDiscussionbar] = useState(false);
   const [hideNotificationbar, setHideNotificationbar] = useState(false);
@@ -29,7 +32,7 @@ const SidebarProvider = ({
   );
   const topic = useModel('discussionTopics', unitId);
   const { verifiedMode } = useModel('courseHomeMeta', courseId);
-  const isDiscussionbarAvailable = topic?.id && topic?.enabledInContext;
+  const isDiscussionbarAvailable = (topic?.id && topic?.enabledInContext) || false;
   const isNotificationbarAvailable = !isEmpty(verifiedMode);
 
   const onNotificationSeen = useCallback(() => {
@@ -40,9 +43,7 @@ const SidebarProvider = ({
   useEffect(() => {
     setHideDiscussionbar(!isDiscussionbarAvailable);
     setHideNotificationbar(!isNotificationbarAvailable);
-    if (isDiscussionbarAvailable || isNotificationbarAvailable) {
-      setCurrentSidebar(SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID);
-    }
+    setCurrentSidebar(SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID);
   }, [unitId, topic]);
 
   useEffect(() => {

--- a/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
@@ -20,10 +20,7 @@ const SidebarProvider = ({
 }) => {
   const shouldDisplayFullScreen = useWindowSize().width < breakpoints.large.minWidth;
   const shouldDisplaySidebarOpen = useWindowSize().width > breakpoints.medium.minWidth;
-  const query = new URLSearchParams(window.location.search);
-  const initialSidebar = (shouldDisplaySidebarOpen || query.get('sidebar') === 'true')
-    ? SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID : null;
-  const [currentSidebar, setCurrentSidebar] = useState(initialSidebar);
+  const [currentSidebar, setCurrentSidebar] = useState(null);
   const [notificationStatus, setNotificationStatus] = useState(getLocalStorage(`notificationStatus.${courseId}`));
   const [hideDiscussionbar, setHideDiscussionbar] = useState(false);
   const [hideNotificationbar, setHideNotificationbar] = useState(false);
@@ -43,7 +40,9 @@ const SidebarProvider = ({
   useEffect(() => {
     setHideDiscussionbar(!isDiscussionbarAvailable);
     setHideNotificationbar(!isNotificationbarAvailable);
-    setCurrentSidebar(SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID);
+    if (isDiscussionbarAvailable || isNotificationbarAvailable) {
+      setCurrentSidebar(SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID);
+    }
   }, [unitId, topic]);
 
   useEffect(() => {


### PR DESCRIPTION
[INF-1254](https://2u-internal.atlassian.net/browse/INF-1254)

**Description**
An empty section is displayed when there are no notifications or discussion bars available for the in-context sidebar.
https://www.loom.com/share/5237ee3f8d5f49c884567cbeb7af5262?sid=ab72518e-4cf4-410b-8be9-ce71969a80fb


**A.C**
Section shouldn’t be visible when notification and discussion bar are not available for the incontext sidebar.