### PR TITLE
feat: optional xblocks

### DIFF
--- a/src/course-home/data/__factories__/progressTabData.factory.js
+++ b/src/course-home/data/__factories__/progressTabData.factory.js
@@ -12,6 +12,11 @@ Factory.define('progressTabData')
       incomplete_count: 1,
       locked_count: 0,
     },
+    optional_completion_summary: {
+      complete_count: 1,
+      incomplete_count: 1,
+      locked_count: 0,
+    },
     course_grade: {
       letter_grade: 'pass',
       percent: 1,

--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -428,6 +428,7 @@ Object {
               "complete": false,
               "courseId": "course-v1:edX+DemoX+Demo_Course",
               "id": "block-v1:edX+DemoX+Demo_Course+type@chapter+block@bcdabcdabcdabcdabcdabcdabcdabcd2",
+              "optional": undefined,
               "resumeBlock": false,
               "sequenceIds": Array [
                 "block-v1:edX+DemoX+Demo_Course+type@sequential+block@bcdabcdabcdabcdabcdabcdabcdabcd1",
@@ -444,6 +445,7 @@ Object {
               "effortTime": 15,
               "icon": null,
               "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@bcdabcdabcdabcdabcdabcdabcdabcd1",
+              "optional": undefined,
               "sectionId": "block-v1:edX+DemoX+Demo_Course+type@chapter+block@bcdabcdabcdabcdabcdabcdabcdabcd2",
               "showLink": true,
               "title": "Title of Sequence",
@@ -636,6 +638,11 @@ Object {
         },
         "hasScheduledContent": false,
         "id": "course-v1:edX+DemoX+Demo_Course",
+        "optionalCompletionSummary": Object {
+          "completeCount": 1,
+          "incompleteCount": 1,
+          "lockedCount": 0,
+        },
         "sectionScores": Array [
           Object {
             "displayName": "First section",

--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -136,6 +136,7 @@ export function normalizeOutlineBlocks(courseId, blocks) {
           title: block.display_name,
           resumeBlock: block.resume_block,
           sequenceIds: block.children || [],
+          optional: block.optional_content,
         };
         break;
 
@@ -152,6 +153,7 @@ export function normalizeOutlineBlocks(courseId, blocks) {
           // link in the outline (even though we ignore the given url and use an internal <Link> to ourselves).
           showLink: !!block.lms_web_url,
           title: block.display_name,
+          optional: block.optional_content,
         };
         break;
 

--- a/src/course-home/outline-tab/Section.jsx
+++ b/src/course-home/outline-tab/Section.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Collapsible, IconButton } from '@edx/paragon';
+import { Badge, Collapsible, IconButton } from '@edx/paragon';
 import { faCheckCircle as fasCheckCircle, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { faCheckCircle as farCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -23,6 +23,7 @@ const Section = ({
     complete,
     sequenceIds,
     title,
+    optional,
   } = section;
   const {
     courseBlocks: {
@@ -64,6 +65,7 @@ const Section = ({
       </div>
       <div className="col-10 ml-3 p-0 font-weight-bold text-dark-500">
         <span className="align-middle">{title}</span>
+        <Badge className="ml-2" variant="light" hidden={!optional}>{intl.formatMessage(messages.optionalContent)}</Badge>
         <span className="sr-only">
           , {intl.formatMessage(complete ? messages.completedSection : messages.incompleteSection)}
         </span>

--- a/src/course-home/outline-tab/SequenceLink.jsx
+++ b/src/course-home/outline-tab/SequenceLink.jsx
@@ -29,6 +29,7 @@ const SequenceLink = ({
     due,
     showLink,
     title,
+    optional,
   } = sequence;
   const {
     userTimezone,
@@ -115,6 +116,9 @@ const SequenceLink = ({
           </div>
         </div>
         <div className="row w-100 m-0 ml-3 pl-3">
+          <small className="text-body pl-2 pr-0">
+            {optional ? intl.formatMessage(messages.optionalContent) : ''}
+          </small>
           <small className="text-body pl-2">
             {due ? dueDateMessage : noDueDateMessage}
           </small>

--- a/src/course-home/outline-tab/messages.js
+++ b/src/course-home/outline-tab/messages.js
@@ -99,6 +99,11 @@ const messages = defineMessages({
     defaultMessage: 'Open',
     description: 'A button to open the given section of the course outline',
   },
+  optionalContent: {
+    id: 'learning.outline.optionalBlock',
+    defaultMessage: 'Optional',
+    description: 'Used as a label to indicate that a section, sequence, or unit is optional.',
+  },
   proctoringInfoPanel: {
     id: 'learning.proctoringPanel.header',
     defaultMessage: 'This course contains proctored exams',

--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -262,6 +262,11 @@ describe('Progress Tab', () => {
           incomplete_count: 1,
           locked_count: 1,
         },
+        optional_completion_summary: {
+          complete_count: 1,
+          incomplete_count: 1,
+          locked_count: 0,
+        },
         verified_mode: {
           access_expiration_date: '2050-01-01T12:00:00',
           currency: 'USD',
@@ -303,6 +308,11 @@ describe('Progress Tab', () => {
           complete_count: 1,
           incomplete_count: 1,
           locked_count: 1,
+        },
+        optional_completion_summary: {
+          complete_count: 1,
+          incomplete_count: 1,
+          locked_count: 0,
         },
         verified_mode: {
           access_expiration_date: '2050-01-01T12:00:00',
@@ -364,6 +374,11 @@ describe('Progress Tab', () => {
           incomplete_count: 1,
           locked_count: 1,
         },
+        optional_completion_summary: {
+          complete_count: 1,
+          incomplete_count: 1,
+          locked_count: 0,
+        },
         section_scores: [
           {
             display_name: 'First section',
@@ -401,6 +416,11 @@ describe('Progress Tab', () => {
           complete_count: 1,
           incomplete_count: 1,
           locked_count: 1,
+        },
+        optional_completion_summary: {
+          complete_count: 1,
+          incomplete_count: 1,
+          locked_count: 0,
         },
         verified_mode: {
           access_expiration_date: '2050-01-01T12:00:00',

--- a/src/course-home/progress-tab/course-completion/CompletionDonutChart.jsx
+++ b/src/course-home/progress-tab/course-completion/CompletionDonutChart.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import {
   getLocale, injectIntl, intlShape, isRtl,
 } from '@edx/frontend-platform/i18n';
+import PropTypes from 'prop-types';
 import { useModel } from '../../../generic/model-store';
 
 import CompleteDonutSegment from './CompleteDonutSegment';
@@ -10,18 +11,20 @@ import IncompleteDonutSegment from './IncompleteDonutSegment';
 import LockedDonutSegment from './LockedDonutSegment';
 import messages from './messages';
 
-const CompletionDonutChart = ({ intl }) => {
+const CompletionDonutChart = ({ intl, optional }) => {
   const {
     courseId,
   } = useSelector(state => state.courseHome);
 
+  const key = optional ? 'optionalCompletionSummary' : 'completionSummary';
+  const label = optional ? intl.formatMessage(messages.optionalDonutLabel) : intl.formatMessage(messages.donutLabel);
+
+  const progress = useModel('progress', courseId);
   const {
-    completionSummary: {
-      completeCount,
-      incompleteCount,
-      lockedCount,
-    },
-  } = useModel('progress', courseId);
+    completeCount,
+    incompleteCount,
+    lockedCount,
+  } = progress[key];
 
   const numTotalUnits = completeCount + incompleteCount + lockedCount;
   const completePercentage = completeCount ? Number(((completeCount / numTotalUnits) * 100).toFixed(0)) : 0;
@@ -29,6 +32,10 @@ const CompletionDonutChart = ({ intl }) => {
   const incompletePercentage = 100 - completePercentage - lockedPercentage;
 
   const isLocaleRtl = isRtl(getLocale());
+
+  if (optional && numTotalUnits === 0) {
+    return <></>;
+  }
 
   return (
     <>
@@ -42,7 +49,7 @@ const CompletionDonutChart = ({ intl }) => {
             {completePercentage}{isLocaleRtl && '\u200f'}%
           </text>
           <text x="50%" y="50%" className="donut-chart-label">
-            {intl.formatMessage(messages.donutLabel)}
+            {label}
           </text>
         </g>
         <IncompleteDonutSegment incompletePercentage={incompletePercentage} />
@@ -62,8 +69,13 @@ const CompletionDonutChart = ({ intl }) => {
   );
 };
 
+CompletionDonutChart.defaultProps = {
+  optional: false,
+};
+
 CompletionDonutChart.propTypes = {
   intl: intlShape.isRequired,
+  optional: PropTypes.bool,
 };
 
 export default injectIntl(CompletionDonutChart);

--- a/src/course-home/progress-tab/course-completion/CourseCompletion.jsx
+++ b/src/course-home/progress-tab/course-completion/CourseCompletion.jsx
@@ -14,7 +14,8 @@ const CourseCompletion = ({ intl }) => (
         </p>
       </div>
       <div className="col-12 col-sm-6 col-md-5 mt-sm-n3 p-0 text-center">
-        <CompletionDonutChart />
+        <CompletionDonutChart optional={false} />
+        <CompletionDonutChart optional />
       </div>
     </div>
   </section>

--- a/src/course-home/progress-tab/course-completion/messages.js
+++ b/src/course-home/progress-tab/course-completion/messages.js
@@ -6,6 +6,11 @@ const messages = defineMessages({
     defaultMessage: 'completed',
     description: 'Label text for progress donut chart',
   },
+  optionalDonutLabel: {
+    id: 'progress.completion.optionalDonut.label',
+    defaultMessage: 'optional',
+    description: 'Label text for optional progress donut chart',
+  },
   completionBody: {
     id: 'progress.completion.body',
     defaultMessage: 'This represents how much of the course content you have completed. Note that some content may not yet be released.',

--- a/src/courseware/course/sequence/Unit.jsx
+++ b/src/courseware/course/sequence/Unit.jsx
@@ -1,7 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { AppContext, ErrorPage } from '@edx/frontend-platform/react';
-import { Modal } from '@edx/paragon';
+import { Modal, Badge } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import React, {
   Suspense, useCallback, useContext, useEffect, useLayoutEffect, useState,
@@ -155,6 +155,7 @@ const Unit = ({
   return (
     <div className="unit">
       <h1 className="mb-0 h3">{unit.title}</h1>
+      <Badge className="ml-2" variant="light" hidden={!unit.optional}>{intl.formatMessage(messages.optionalContent)}</Badge>
       <h2 className="sr-only">{intl.formatMessage(messages.headerPlaceholder)}</h2>
       <BookmarkButton
         unitId={unit.id}

--- a/src/courseware/course/sequence/messages.js
+++ b/src/courseware/course/sequence/messages.js
@@ -31,6 +31,11 @@ const messages = defineMessages({
     defaultMessage: 'There is no content here.',
     description: 'Message shown when there is no content to show a user inside a learning sequence.',
   },
+  optionalContent: {
+    id: 'learn.sequence.optionalBlock',
+    defaultMessage: 'Optional',
+    description: 'Used as a label to indicate that a section, sequence, or unit is optional.',
+  },
 });
 
 export default messages;

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -169,6 +169,7 @@ function normalizeSequenceMetadata(sequence) {
       contentType: unit.type,
       graded: unit.graded,
       containsContentTypeGatedContent: unit.contains_content_type_gated_content,
+      optional: unit.optional_content,
     })),
   };
 }


### PR DESCRIPTION
# Description

This PR implements separating optional progress from normal progress, and also displaying optional chapters and sequences in the outline.

# Testing instructions

follow the instructions from this PR: https://github.com/openedx/edx-platform/pull/34275

Private-ref: [BB-8586](https://tasks.opencraft.com/browse/BB-8586)