### PR TITLE
fix: Fixes expandAll button functionality

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -106,6 +106,14 @@ const OutlineTab = ({ intl }) => {
 
   const location = useLocation();
 
+  const getSectionsExpandStatus = (status = false) => courses[rootCourseId].sectionIds.reduce((obj, sectionId) => {
+    // eslint-disable-next-line no-param-reassign
+    obj[sectionId] = status;
+    return obj;
+  }, {});
+
+  const [expandedSections, setExpandedSections] = useState(() => getSectionsExpandStatus());
+
   useEffect(() => {
     const currentParams = new URLSearchParams(location.search);
     const startCourse = currentParams.get('start_course');
@@ -122,6 +130,15 @@ const OutlineTab = ({ intl }) => {
       });
     }
   }, [location.search]);
+
+  useEffect(() => {
+    const allSectionsExpanded = Object.values(expandedSections);
+    const isAllExpanded = allSectionsExpanded.every(Boolean);
+    if (isAllExpanded) { setExpandAll(true); }
+
+    const isAllCollapsed = allSectionsExpanded.every(val => val === false);
+    if (isAllCollapsed) { setExpandAll(false); }
+  }, [expandedSections]);
 
   return (
     <>
@@ -163,7 +180,14 @@ const OutlineTab = ({ intl }) => {
             <>
               <div className="row w-100 m-0 mb-3 justify-content-end">
                 <div className="col-12 col-md-auto p-0">
-                  <Button variant="outline-primary" block onClick={() => { setExpandAll(!expandAll); }}>
+                  <Button
+                    variant="outline-primary"
+                    block
+                    onClick={() => {
+                      setExpandAll(!expandAll);
+                      setExpandedSections(() => getSectionsExpandStatus(!expandAll));
+                    }}
+                  >
                     {expandAll ? intl.formatMessage(messages.collapseAll) : intl.formatMessage(messages.expandAll)}
                   </Button>
                 </div>
@@ -176,6 +200,7 @@ const OutlineTab = ({ intl }) => {
                     defaultOpen={sections[sectionId].resumeBlock}
                     expand={expandAll}
                     section={sections[sectionId]}
+                    setExpandedSections={setExpandedSections}
                   />
                 ))}
               </ol>

--- a/src/course-home/outline-tab/Section.jsx
+++ b/src/course-home/outline-tab/Section.jsx
@@ -33,13 +33,17 @@ const Section = ({
 
   const [open, setOpen] = useState(defaultOpen);
 
+  const updateExpandedSection = (status) => {
+    setOpen(status);
+    setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: status }));
+  };
+
   useEffect(() => {
     setOpen(expand);
   }, [expand]);
 
   useEffect(() => {
-    setOpen(defaultOpen);
-    setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: defaultOpen }));
+    updateExpandedSection(defaultOpen);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -80,12 +84,12 @@ const Section = ({
         styling="card-lg"
         title={sectionTitle}
         open={open}
-        onToggle={() => { setOpen(!open); setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: !open })); }}
+        onToggle={() => updateExpandedSection(!open)}
         iconWhenClosed={(
           <IconButton
             alt={intl.formatMessage(messages.openSection)}
             icon={faPlus}
-            onClick={() => { setOpen(true); setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: true })); }}
+            onClick={() => updateExpandedSection(true)}
             size="sm"
           />
         )}
@@ -93,7 +97,7 @@ const Section = ({
           <IconButton
             alt={intl.formatMessage(genericMessages.close)}
             icon={faMinus}
-            onClick={() => { setOpen(false); setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: false })); }}
+            onClick={() => updateExpandedSection(false)}
             size="sm"
           />
         )}

--- a/src/course-home/outline-tab/Section.jsx
+++ b/src/course-home/outline-tab/Section.jsx
@@ -18,6 +18,7 @@ const Section = ({
   expand,
   intl,
   section,
+  setExpandedSections,
 }) => {
   const {
     complete,
@@ -38,6 +39,7 @@ const Section = ({
 
   useEffect(() => {
     setOpen(defaultOpen);
+    setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: defaultOpen }));
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -78,12 +80,12 @@ const Section = ({
         styling="card-lg"
         title={sectionTitle}
         open={open}
-        onToggle={() => { setOpen(!open); }}
+        onToggle={() => { setOpen(!open); setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: !open })); }}
         iconWhenClosed={(
           <IconButton
             alt={intl.formatMessage(messages.openSection)}
             icon={faPlus}
-            onClick={() => { setOpen(true); }}
+            onClick={() => { setOpen(true); setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: true })); }}
             size="sm"
           />
         )}
@@ -91,7 +93,7 @@ const Section = ({
           <IconButton
             alt={intl.formatMessage(genericMessages.close)}
             icon={faMinus}
-            onClick={() => { setOpen(false); }}
+            onClick={() => { setOpen(false); setExpandedSections((prevObj) => ({ ...prevObj, [section.id]: false })); }}
             size="sm"
           />
         )}
@@ -118,6 +120,7 @@ Section.propTypes = {
   expand: PropTypes.bool.isRequired,
   intl: intlShape.isRequired,
   section: PropTypes.shape().isRequired,
+  setExpandedSections: PropTypes.func.isRequired,
 };
 
 export default injectIntl(Section);


### PR DESCRIPTION
On collapsing all the sections, the button now automatically show 'Expand All'. Similar in case of vice versa. Fixes #1311 

Before: 
<img width="1081" alt="Screenshot 2024-03-04 at 4 07 53 PM" src="https://github.com/openedx/frontend-app-learning/assets/112946189/ff094a28-4c7b-4f95-8cdf-ff320fe301cc">

After:
<img width="1081" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/112946189/ee5602b1-eec8-4bd9-befe-aa18bca215ff">
