### PR TITLE
[Backport] fix: make progress graph respect course settings

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -18,7 +18,7 @@ const ProgressTab = () => {
   } = useSelector(state => state.courseHome);
 
   const {
-    gradesFeatureIsFullyLocked,
+    gradesFeatureIsFullyLocked, disableProgressGraph,
   } = useModel('progress', courseId);
 
   const applyLockedOverlay = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
@@ -38,7 +38,7 @@ const ProgressTab = () => {
       <div className="row w-100 m-0">
         {/* Main body */}
         <div className="col-12 col-md-8 p-0">
-          <CourseCompletion />
+          {!disableProgressGraph && <CourseCompletion />}
           {!wideScreen && <CertificateStatus />}
           <CourseGrade />
           <div className={`grades my-4 p-4 rounded raised-card ${applyLockedOverlay}`} aria-hidden={gradesFeatureIsFullyLocked}>


### PR DESCRIPTION
## Description
**This is a backport from the master branch: https://github.com/openedx/frontend-app-learning/pull/1194**

Fix an issue when the Progress Graph toggle change in the studio has no effect on the Learning MFE.

Related backport for the edx-platform: https://github.com/openedx/edx-platform/pull/34324

Please check the original PRs for more details.