### PR TITLE
fix: Updated search modal to match Bootstrap's z-index.

### DIFF
--- a/src/course-home/courseware-search/courseware-search.scss
+++ b/src/course-home/courseware-search/courseware-search.scss
@@ -6,7 +6,7 @@
   right: 0;
   bottom: 0;
   border-top: 1px solid $light-300;
-  z-index: 200;
+  z-index: $zindex-modal; // Bootstrap's z-index layer for Modals.
 
   &__close {
     position: absolute !important; // For some reason it gets overridden


### PR DESCRIPTION
# Description
Ticket: [COSMO-207 🔒](https://2u-internal.atlassian.net/browse/COSMO-207)

The Courseware search was using `z-index: 200` for the modal overlay. This modal was a bit particular so it was created as a custom modal, but we overlooked that we are using bootstrap classes in some components which, in the case of discussions for example, adds a `.sticky-top` class to the component made it use bootstrap's z-index layers which were higher than the ones we were using, making the discussions panel get on top of the search modal.

![discussions-overflow](https://github.com/openedx/frontend-app-learning/assets/12736783/c60cb62c-74c1-44f1-9661-54ec66bfe81c)

We've updated the z-index to stick to Bootstrap's `z-index` layer values instead of arbitrary ones.

![discussions-fix](https://github.com/openedx/frontend-app-learning/assets/12736783/53f3692d-f6fb-4f2b-a36b-38ee3c90ff33)


