### PR TITLE
fix: rollback exams lib to unblock pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@edx/frontend-component-footer": "12.7.1",
         "@edx/frontend-component-header": "4.11.1",
         "@edx/frontend-lib-learning-assistant": "^1.24.0",
-        "@edx/frontend-lib-special-exams": "2.29.2",
+        "@edx/frontend-lib-special-exams": "2.29.1",
         "@edx/frontend-platform": "5.6.1",
         "@edx/openedx-atlas": "^0.6.0",
         "@edx/react-unit-test-utils": "npm:@edx/react-unit-test-utils@1.7.1",
@@ -3536,9 +3536,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.29.2.tgz",
-      "integrity": "sha512-mpeTEQSmGMqlVY9blX6apeal5tp7Ozs75SNlyHZs5/toY+/oR2iGEmQb856rkO85c8dcm5mAng4cJ3fm2TnsjA==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-2.29.1.tgz",
+      "integrity": "sha512-A6nvGfHUAq74pCWVRUcDezqC4HyaShIPU+qdAUwyr43Aat5lSCXNDMnTdXbQS2uZOtA/rQVRLNul4T3u0mywVA==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-component-footer": "12.7.1",
     "@edx/frontend-component-header": "4.11.1",
-    "@edx/frontend-lib-special-exams": "2.29.2",
+    "@edx/frontend-lib-special-exams": "2.29.1",
     "@edx/frontend-lib-learning-assistant": "^1.24.0",
     "@edx/frontend-platform": "5.6.1",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
Changes in v2.29.2 of frontend-lib-special-exams broke things, rolling back until we can fix that forward