### PR TITLE
fix: Fix discussions and notifications sidebars visibility with big amount of units

### DIFF
--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -155,7 +155,7 @@ const Sequence = ({
             <SequenceNavigation
               sequenceId={sequenceId}
               unitId={unitId}
-              className="mb-4"
+              className="mb-4 w-100"
               nextHandler={() => {
                 logEvent('edx.ui.lms.sequence.next_selected', 'top');
                 handleNext();

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,7 +6,6 @@
 @import "~@edx/frontend-component-footer/dist/footer";
 @import "~@edx/frontend-component-header/dist/index";
 
-
 #root {
   display: flex;
   flex-direction: column;
@@ -75,6 +74,8 @@
 }
 
 .sequence {
+  min-width: 0;
+
   @media (min-width: map-get($grid-breakpoints, "sm")) {
     border: solid 1px #eaeaea;
     border-radius: 4px;


### PR DESCRIPTION
## Description

When we have too many units in a section, the course content significantly compresses the sidebar with Discussions and Notifications. It becomes impossible to interact with them. Our proposal is to add horizontal scrolling to the unit navigation if there are too many units. To be more precise, horizontal scrolling for unit navigation is already provided, but it does not work because the sidebar with Discussions and Notifications simply compresses.

## Demo

Before fix

https://github.com/openedx/frontend-app-learning/assets/19806032/9a56ea5e-caff-4c9f-83a9-e704cd15412f

After fix

https://github.com/openedx/frontend-app-learning/assets/19806032/d8d8ccee-4bae-44d9-a01c-2bf875ccfa5e
