### PR TITLE
fix: modal iframe height to 100%

### DIFF
--- a/src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
+++ b/src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
@@ -9,7 +9,7 @@ export const stateKeys = StrictDict({
   options: 'options',
 });
 
-export const DEFAULT_HEIGHT = '100vh';
+export const DEFAULT_HEIGHT = '100%';
 
 const useModalIFrameData = () => {
   const [isOpen, setIsOpen] = useKeyedState(stateKeys.isOpen, false);


### PR DESCRIPTION
Proposed Solution for this CR: https://2u-internal.atlassian.net/browse/COSMO-227

The iframe within a modal in the learning MFE was set to a default height of 100vh. It should actually be 100% in order to match the height of the modal it's in, not the view height itself