### PR TITLE
fix: course certficate status after requesting

### DIFF
--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -432,7 +432,16 @@ export async function postDismissWelcomeMessage(courseId) {
 
 export async function postRequestCert(courseId) {
   const url = new URL(`${getConfig().LMS_BASE_URL}/courses/${courseId}/generate_user_cert`);
-  await getAuthenticatedHttpClient().post(url.href);
+  try {
+    const { data } = await getAuthenticatedHttpClient().post(url.href);
+    return camelCaseObject(data);
+  } catch (error) {
+    // The request will faild when the status is 400
+    // Which can be because of:
+    // 1. The certificate has been requested and it's still in the porcess of generation
+    // 2. The certificate was was generated even before user/learner request it.
+    return {};
+  }
 }
 
 export async function executePostFromPostEvent(postData, researchEventData) {

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -110,7 +110,30 @@ export function dismissWelcomeMessage(courseId) {
 }
 
 export function requestCert(courseId) {
-  return async () => postRequestCert(courseId);
+  return async (dispatch) => {
+    const { certificateData } = await postRequestCert(courseId);
+
+    // This action could be triggerd, from either course home
+    // or course progress page, each of which has it's own model
+    // and need to be update.
+    // Hence the CertficateStatus compoenent is important by both.
+
+    dispatch(updateModel({
+      modelType: 'progress',
+      model: {
+        id: courseId,
+        certificateData,
+      },
+    }));
+
+    dispatch(updateModel({
+      modelType: 'outline',
+      model: {
+        id: courseId,
+        certData: certificateData,
+      },
+    }));
+  };
 }
 
 export function resetDeadlines(courseId, model, getTabData) {


### PR DESCRIPTION
  This change fixes the scinario when a learner can request a
  certificate to be generated. Before this MFE/App would stick to
  same button status, but after this change it would reflect the
  status as sent from the LMS.

  This is possible due this change openedx/edx-platform/pull/34491 
  by making the monolith responding with cert data if ( the cert
  was generated by time the request).

  This should be merged in hand in hand with: 
  - openedx/edx-platform/pull/34491 
    
  ## Todo list:
   - [ ] Open the PR in edx-platform and link it here
   - [ ] update typo in code comments, at least **important** to **imported**
   - [ ] update the commit message 