### PR TITLE
fix: Removed PluginSlot prop scoping for UpgradeNotification

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -211,7 +211,7 @@ const OutlineTab = ({ intl }) => {
             <CourseTools />
             <PluginSlot
               id="outline_tab"
-              pluginProps={{ upgradeNotificationProps }}
+              pluginProps={upgradeNotificationProps}
               testId="outline-tab-slot"
             >
               <UpgradeNotification {...upgradeNotificationProps} />

--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.jsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.jsx
@@ -88,7 +88,7 @@ const NotificationsWidget = () => {
     <div className="border border-light-400 rounded-sm" data-testid="notification-widget">
       <PluginSlot
         id="notification_widget"
-        pluginProps={{ upgradeNotificationProps }}
+        pluginProps={upgradeNotificationProps}
         testId="notification-widget-slot"
       >
         <UpgradeNotification {...upgradeNotificationProps} />

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
@@ -94,7 +94,7 @@ const NotificationTray = ({ intl }) => {
         ? (
           <PluginSlot
             id="notification_tray"
-            pluginProps={{ upgradeNotificationProps }}
+            pluginProps={upgradeNotificationProps}
             testId="notification-tray-slot"
           >
             <UpgradeNotification {...upgradeNotificationProps} />


### PR DESCRIPTION
# Description
Ticket: [COSMO-246 🔒](https://2u-internal.atlassian.net/browse/COSMO-246)

This removes a prop scoping I was using in the `PluginSlot`. Now the props are passed on directly.