### PR TITLE
fix: optimize scroll position observer after video fullscreen exit

### DIFF
--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.js
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.js
@@ -50,12 +50,6 @@ const useIFrameBehavior = ({
     if (type === messageTypes.resize) {
       setIframeHeight(payload.height);
 
-      // We observe exit from the video xblock fullscreen mode
-      // and scroll to the previously saved scroll position
-      if (windowTopOffset !== null) {
-        window.scrollTo(0, Number(windowTopOffset));
-      }
-
       if (!hasLoaded && iframeHeight === 0 && payload.height > 0) {
         setHasLoaded(true);
         if (onLoaded) {
@@ -63,6 +57,12 @@ const useIFrameBehavior = ({
         }
       }
     } else if (type === messageTypes.videoFullScreen) {
+      // We observe exit from the video xblock fullscreen mode
+      // and scroll to the previously saved scroll position
+      if (!payload.open && windowTopOffset !== null) {
+        window.scrollTo(0, Number(windowTopOffset));
+      }
+
       // We listen for this message from LMS to know when we need to
       // save or reset scroll position on toggle video xblock fullscreen mode
       setWindowTopOffset(payload.open ? window.scrollY : null);

--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
@@ -154,6 +154,9 @@ describe('useIFrameBehavior hook', () => {
         const resizeMessage = (height = 23) => ({
           data: { type: messageTypes.resize, payload: { height } },
         });
+        const videoFullScreenMessage = (open = false) => ({
+          data: { type: messageTypes.videoFullScreen, payload: { open } },
+        });
         const testSetIFrameHeight = (height = 23) => {
           const { cb } = useEventListener.mock.calls[0][1];
           cb(resizeMessage(height));
@@ -209,7 +212,7 @@ describe('useIFrameBehavior hook', () => {
           state.mockVals({ ...defaultStateVals, windowTopOffset });
           hook = useIFrameBehavior(props);
           const { cb } = useEventListener.mock.calls[0][1];
-          cb(resizeMessage());
+          cb(videoFullScreenMessage());
           expect(window.scrollTo).toHaveBeenCalledWith(0, windowTopOffset);
         });
         it('does not scroll if towverticalp offset is not set', () => {


### PR DESCRIPTION
This merge request contains an optimization for toggling video xblock full-screen mode and saving the previous window top offset position on exit from the full-screen state.

With this refactor, we call `scroll` after exit full-screen mode only and not depends on xblock resize because sometimes the resize event comes before exiting full screen mode, and we don't need to call scroll every time on resize.

**Related PR to master branch:** https://github.com/openedx/frontend-app-learning/pull/1371
**Related PR to redwood branch:** https://github.com/openedx/frontend-app-learning/pull/1405