### PR TITLE
feat: generic sidebar notification plugin

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -196,7 +196,7 @@ const OutlineTab = ({ intl }) => {
             )}
             <CourseTools />
             <PluginSlot
-              id="outline_tab_notifications"
+              id="outline_tab_notifications_plugin"
               pluginProps={{ courseId }}
             >
               <UpgradeNotification

--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -124,20 +124,6 @@ const OutlineTab = ({ intl }) => {
     }
   }, [location.search]);
 
-  const upgradeNotificationProps = {
-    offer,
-    verifiedMode,
-    accessExpiration,
-    contentTypeGatingEnabled: datesBannerInfo.contentTypeGatingEnabled,
-    marketingUrl,
-    upsellPageName: 'course_home',
-    userTimezone,
-    timeOffsetMillis,
-    courseId,
-    org,
-    shouldDisplayBorder: true,
-  };
-
   return (
     <>
       <div data-learner-type={learnerType} className="row w-100 mx-0 my-3 justify-content-between">
@@ -210,11 +196,22 @@ const OutlineTab = ({ intl }) => {
             )}
             <CourseTools />
             <PluginSlot
-              id="outline_tab"
-              pluginProps={upgradeNotificationProps}
-              testId="outline-tab-slot"
+              id="outline_tab_notifications"
+              pluginProps={{ courseId }}
             >
-              <UpgradeNotification {...upgradeNotificationProps} />
+              <UpgradeNotification
+                offer={offer}
+                verifiedMode={verifiedMode}
+                accessExpiration={accessExpiration}
+                contentTypeGatingEnabled={datesBannerInfo.contentTypeGatingEnabled}
+                marketingUrl={marketingUrl}
+                upsellPageName="course_home"
+                userTimezone={userTimezone}
+                shouldDisplayBorder
+                timeOffsetMillis={timeOffsetMillis}
+                courseId={courseId}
+                org={org}
+              />
             </PluginSlot>
             <CourseDates />
             <CourseHandouts />

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -132,19 +132,14 @@ describe('Outline Tab', () => {
       expect(expandedSectionNode).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it('renders the Notification wrapper', async () => {
+    it('includes outline_tab_notifications_plugin slot', async () => {
       const { courseBlocks } = await buildMinimalCourseBlocks(courseId, 'Title', { resumeBlock: true });
       setTabData({
         course_blocks: { blocks: courseBlocks.blocks },
       });
       await fetchAndRender();
 
-      const pluginSlot = screen.getByTestId('outline-tab-slot');
-      expect(pluginSlot).toBeInTheDocument();
-
-      // The Upgrade Notification should be inside the PluginSlot.
-      const UpgradeNotification = pluginSlot.querySelector('.upgrade-notification');
-      expect(UpgradeNotification).toBeInTheDocument();
+      expect(screen.getByTestId('outline_tab_notifications_plugin')).toBeInTheDocument();
     });
 
     it('handles expand/collapse all button click', async () => {

--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.jsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.jsx
@@ -59,6 +59,10 @@ const NotificationsWidget = () => {
     verification_status: verificationStatus,
   };
 
+  const onToggleSidebar = () => {
+    toggleSidebar(currentSidebar, WIDGETS.NOTIFICATIONS);
+  };
+
   // After three seconds, update notificationSeen (to hide red dot)
   useEffect(() => {
     setTimeout(onNotificationSeen, 3000);
@@ -75,7 +79,7 @@ const NotificationsWidget = () => {
           courseId,
           notificationCurrentState: upgradeNotificationCurrentState,
           setNotificationCurrentState: setUpgradeNotificationCurrentState,
-          toggleSidebar: () => toggleSidebar(currentSidebar, WIDGETS.NOTIFICATIONS),
+          toggleSidebar: onToggleSidebar,
         }}
       >
         <UpgradeNotification
@@ -92,7 +96,7 @@ const NotificationsWidget = () => {
           org={org}
           upgradeNotificationCurrentState={upgradeNotificationCurrentState}
           setupgradeNotificationCurrentState={setUpgradeNotificationCurrentState}
-          toggleSidebar={() => toggleSidebar(currentSidebar, WIDGETS.NOTIFICATIONS)}
+          toggleSidebar={onToggleSidebar}
         />
       </PluginSlot>
     </div>

--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.jsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.jsx
@@ -67,31 +67,33 @@ const NotificationsWidget = () => {
 
   if (hideNotificationbar || !isNotificationbarAvailable) { return null; }
 
-  const upgradeNotificationProps = {
-    offer,
-    verifiedMode,
-    accessExpiration,
-    contentTypeGatingEnabled,
-    marketingUrl,
-    upsellPageName: 'in_course',
-    userTimezone,
-    timeOffsetMillis,
-    courseId,
-    org,
-    upgradeNotificationCurrentState,
-    setupgradeNotificationCurrentState: setUpgradeNotificationCurrentState, // TODO: Check typo in component?
-    shouldDisplayBorder: false,
-    toggleSidebar: () => toggleSidebar(currentSidebar, WIDGETS.NOTIFICATIONS),
-  };
-
   return (
     <div className="border border-light-400 rounded-sm" data-testid="notification-widget">
       <PluginSlot
-        id="notification_widget"
-        pluginProps={upgradeNotificationProps}
-        testId="notification-widget-slot"
+        id="notification_widget_plugin"
+        pluginProps={{
+          courseId,
+          notificationCurrentState: upgradeNotificationCurrentState,
+          setNotificationCurrentState: setUpgradeNotificationCurrentState,
+          toggleSidebar: () => toggleSidebar(currentSidebar, WIDGETS.NOTIFICATIONS),
+        }}
       >
-        <UpgradeNotification {...upgradeNotificationProps} />
+        <UpgradeNotification
+          offer={offer}
+          verifiedMode={verifiedMode}
+          accessExpiration={accessExpiration}
+          contentTypeGatingEnabled={contentTypeGatingEnabled}
+          marketingUrl={marketingUrl}
+          upsellPageName="in_course"
+          userTimezone={userTimezone}
+          shouldDisplayBorder={false}
+          timeOffsetMillis={timeOffsetMillis}
+          courseId={courseId}
+          org={org}
+          upgradeNotificationCurrentState={upgradeNotificationCurrentState}
+          setupgradeNotificationCurrentState={setUpgradeNotificationCurrentState}
+          toggleSidebar={() => toggleSidebar(currentSidebar, WIDGETS.NOTIFICATIONS)}
+        />
       </PluginSlot>
     </div>
   );

--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.test.jsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/notifications/NotificationsWidget.test.jsx
@@ -80,6 +80,21 @@ describe('NotificationsWidget', () => {
     });
   });
 
+  it('includes notification_widget_plugin slot', async () => {
+    await fetchAndRender(
+      <SidebarContext.Provider value={{
+        currentSidebar: ID,
+        courseId,
+        hideNotificationbar: false,
+        isNotificationbarAvailable: true,
+      }}
+      >
+        <NotificationsWidget />
+      </SidebarContext.Provider>,
+    );
+    expect(screen.getByTestId('notification_widget_plugin')).toBeInTheDocument();
+  });
+
   it('renders upgrade card', async () => {
     await fetchAndRender(
       <SidebarContext.Provider value={{
@@ -93,11 +108,8 @@ describe('NotificationsWidget', () => {
       </SidebarContext.Provider>,
     );
 
-    const pluginSlot = screen.getByTestId('notification-widget-slot');
-    expect(pluginSlot).toBeInTheDocument();
-
     // The Upgrade Notification should be inside the PluginSlot.
-    const UpgradeNotification = pluginSlot.querySelector('.upgrade-notification');
+    const UpgradeNotification = document.querySelector('.upgrade-notification');
     expect(UpgradeNotification).toBeInTheDocument();
 
     expect(screen.getByRole('link', { name: 'Upgrade for $149' })).toBeInTheDocument();

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
@@ -77,7 +77,7 @@ const NotificationTray = ({ intl }) => {
       <div>{verifiedMode
         ? (
           <PluginSlot
-            id="notification_tray"
+            id="notification_tray_plugin"
             pluginProps={{
               courseId,
               notificationCurrentState: upgradeNotificationCurrentState,

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
@@ -66,22 +66,6 @@ const NotificationTray = ({ intl }) => {
     sendTrackEvent('edx.ui.course.upgrade.old_sidebar.notifications', notificationTrayEventProperties);
   }, []);
 
-  const upgradeNotificationProps = {
-    offer,
-    verifiedMode,
-    accessExpiration,
-    contentTypeGatingEnabled,
-    marketingUrl,
-    upsellPageName: 'in_course',
-    userTimezone,
-    shouldDisplayBorder: false,
-    timeOffsetMillis,
-    courseId,
-    org,
-    upgradeNotificationCurrentState,
-    setupgradeNotificationCurrentState: setUpgradeNotificationCurrentState, // TODO: Check typo in component?
-  };
-
   return (
     <SidebarBase
       title={intl.formatMessage(messages.notificationTitle)}
@@ -94,10 +78,27 @@ const NotificationTray = ({ intl }) => {
         ? (
           <PluginSlot
             id="notification_tray"
-            pluginProps={upgradeNotificationProps}
-            testId="notification-tray-slot"
+            pluginProps={{
+              courseId,
+              notificationCurrentState: upgradeNotificationCurrentState,
+              setNotificationCurrentState: setUpgradeNotificationCurrentState,
+            }}
           >
-            <UpgradeNotification {...upgradeNotificationProps} />
+            <UpgradeNotification
+              offer={offer}
+              verifiedMode={verifiedMode}
+              accessExpiration={accessExpiration}
+              contentTypeGatingEnabled={contentTypeGatingEnabled}
+              marketingUrl={marketingUrl}
+              upsellPageName="in_course"
+              userTimezone={userTimezone}
+              shouldDisplayBorder={false}
+              timeOffsetMillis={timeOffsetMillis}
+              courseId={courseId}
+              org={org}
+              upgradeNotificationCurrentState={upgradeNotificationCurrentState}
+              setupgradeNotificationCurrentState={setUpgradeNotificationCurrentState}
+            />
           </PluginSlot>
         ) : (
           <p className="p-3 small">{intl.formatMessage(messages.noNotificationsMessage)}</p>

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.test.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.test.jsx
@@ -81,6 +81,19 @@ describe('NotificationTray', () => {
       .toBeInTheDocument();
   });
 
+  it('includes notification_tray_plugin slot', async () => {
+    await fetchAndRender(
+      <SidebarContext.Provider value={{
+        currentSidebar: ID,
+        courseId,
+      }}
+      >
+        <NotificationTray />
+      </SidebarContext.Provider>,
+    );
+    expect(screen.getByTestId('notification_tray_plugin')).toBeInTheDocument();
+  });
+
   it('renders upgrade card', async () => {
     await fetchAndRender(
       <SidebarContext.Provider value={{
@@ -92,12 +105,7 @@ describe('NotificationTray', () => {
       </SidebarContext.Provider>,
     );
 
-    const pluginSlot = screen.getByTestId('notification-tray-slot');
-    expect(pluginSlot).toBeInTheDocument();
-
-    // The Upgrade Notification should be inside the PluginSlot.
-    const UpgradeNotification = pluginSlot.querySelector('.upgrade-notification');
-    expect(UpgradeNotification).toBeInTheDocument();
+    expect(document.querySelector('.upgrade-notification')).toBeInTheDocument();
 
     expect(screen.getByRole('link', { name: 'Upgrade for $149' }))
       .toBeInTheDocument();

--- a/src/tests/MockedPluginSlot.jsx
+++ b/src/tests/MockedPluginSlot.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const MockedPluginSlot = ({ children, testId }) => {
-  if (!testId) { return children ?? 'PluginSlot'; } // Return its content if PluginSlot slot is wrapping any.
-
-  return <div data-testid={testId}>{children}</div>;
-};
+const MockedPluginSlot = ({ children, id }) => (
+  <div data-testid={id}>
+    PluginSlot_{id}
+    { children && <div>{children}</div> }
+  </div>
+);
 
 MockedPluginSlot.displayName = 'PluginSlot';
 
@@ -14,12 +15,12 @@ MockedPluginSlot.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  testId: PropTypes.string,
+  id: PropTypes.string,
 };
 
 MockedPluginSlot.defaultProps = {
   children: undefined,
-  testId: undefined,
+  id: undefined,
 };
 
 export default MockedPluginSlot;

--- a/src/tests/MockedPluginSlot.test.jsx
+++ b/src/tests/MockedPluginSlot.test.jsx
@@ -3,14 +3,14 @@ import { render, screen } from '@testing-library/react';
 import MockedPluginSlot from './MockedPluginSlot';
 
 describe('MockedPluginSlot', () => {
-  it('renders as plain "PluginSlot" text node if no clildren nor testId is', () => {
-    render(<MockedPluginSlot />);
+  it('renders mock plugin with "PluginSlot" text', () => {
+    render(<MockedPluginSlot id="test_plugin" />);
 
-    const component = screen.getByText('PluginSlot');
+    const component = screen.getByText('PluginSlot_test_plugin');
     expect(component).toBeInTheDocument();
   });
 
-  it('renders as the slot children directly if there is content within and no testId', () => {
+  it('renders as the slot children directly if there is content within', () => {
     render(
       <div role="article">
         <MockedPluginSlot>
@@ -27,9 +27,9 @@ describe('MockedPluginSlot', () => {
     expect(quote.getAttribute('role')).toBe('note');
   });
 
-  it('renders a div when a testId is provided ', () => {
+  it('renders mock plugin with a data-testid ', () => {
     render(
-      <MockedPluginSlot testId="guybrush">
+      <MockedPluginSlot id="guybrush">
         <q role="note">I am selling these fine leather jackets.</q>
       </MockedPluginSlot>,
     );


### PR DESCRIPTION
~This is just a POC to prove out the API of params we're passing I didn't touch the new sidebar or write any tests.~

Removes upgrade component specific properties from sidebar/notification plugin slots.

Since we're merging into the feature branch this would be the resulting diff against main: https://github.com/openedx/frontend-app-learning/compare/master...zhancock/generic-notification-plugin


**Risks/Concerns**
This component is still highly coupled with the state of the learning MFE that detail is just hidden into the component now. If the redux store changes structure it could break our plugin. Once this is working it would be good to evaluate the component code we've copied over, there's probably a lot of conditions we can carve out if the upgrade component is 2U specific.

Pairs with https://github.com/edx/frontend-plugin-advertisements/pull/10
^^ in case this isn't publicly visible the approach is to useModel and get all of these fields rather than passing them over a pluggable API.

eg
```
  const {
    accessExpiration,
    marketingUrl,
    offer,
    timeOffsetMillis,
  } = useModel('coursewareMeta', courseId);
```