### PR TITLE
chore: lock test util to version 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@edx/frontend-lib-special-exams": "^3.0.1",
         "@edx/frontend-platform": "^7.1.2",
         "@edx/openedx-atlas": "^0.6.0",
-        "@edx/react-unit-test-utils": "^2.0.0",
+        "@edx/react-unit-test-utils": "2.0.0",
         "@fortawesome/fontawesome-svg-core": "1.3.0",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
         "@fortawesome/free-regular-svg-icons": "5.15.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/frontend-lib-special-exams": "^3.0.1",
     "@edx/frontend-platform": "^7.1.2",
     "@edx/openedx-atlas": "^0.6.0",
-    "@edx/react-unit-test-utils": "^2.0.0",
+    "@edx/react-unit-test-utils": "2.0.0",
     "@fortawesome/fontawesome-svg-core": "1.3.0",
     "@fortawesome/free-brands-svg-icons": "5.15.4",
     "@fortawesome/free-regular-svg-icons": "5.15.4",


### PR DESCRIPTION
`@edx/react-unit-test-utils@2.1.0` is having a breaking change dependency.

https://github.com/openedx/react-unit-test-utils/pull/22