### PR TITLE
fix: incorrectly named plugin slots

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -196,7 +196,7 @@ const OutlineTab = ({ intl }) => {
             )}
             <CourseTools />
             <PluginSlot
-              id="outline_tab_notifications_plugin"
+              id="outline_tab_notifications_slot"
               pluginProps={{ courseId }}
             >
               <UpgradeNotification

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -132,14 +132,14 @@ describe('Outline Tab', () => {
       expect(expandedSectionNode).toHaveAttribute('aria-expanded', 'true');
     });
 
-    it('includes outline_tab_notifications_plugin slot', async () => {
+    it('includes outline_tab_notifications_slot', async () => {
       const { courseBlocks } = await buildMinimalCourseBlocks(courseId, 'Title', { resumeBlock: true });
       setTabData({
         course_blocks: { blocks: courseBlocks.blocks },
       });
       await fetchAndRender();
 
-      expect(screen.getByTestId('outline_tab_notifications_plugin')).toBeInTheDocument();
+      expect(screen.getByTestId('outline_tab_notifications_slot')).toBeInTheDocument();
     });
 
     it('handles expand/collapse all button click', async () => {

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
@@ -79,7 +79,7 @@ const NotificationTray = ({ intl }) => {
       <div>{verifiedMode
         ? (
           <PluginSlot
-            id="notification_tray_plugin"
+            id="notification_tray_slot"
             pluginProps={{
               courseId,
               notificationCurrentState: upgradeNotificationCurrentState,

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.test.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.test.jsx
@@ -81,7 +81,7 @@ describe('NotificationTray', () => {
       .toBeInTheDocument();
   });
 
-  it('includes notification_tray_plugin slot', async () => {
+  it('includes notification_tray_slot', async () => {
     await fetchAndRender(
       <SidebarContext.Provider value={{
         currentSidebar: ID,
@@ -91,7 +91,7 @@ describe('NotificationTray', () => {
         <NotificationTray />
       </SidebarContext.Provider>,
     );
-    expect(screen.getByTestId('notification_tray_plugin')).toBeInTheDocument();
+    expect(screen.getByTestId('notification_tray_slot')).toBeInTheDocument();
   });
 
   it('renders upgrade card', async () => {


### PR DESCRIPTION
In my haste to merge #1368 I missed staging some files for the requested changes to align us with https://github.com/openedx/wg-frontend/issues/178. This _is_ a breaking change but no one is using these slots yet.