### PR TITLE
fix: iframe height for discussions sidebar

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
+++ b/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
@@ -1,0 +1,5 @@
+.discussions-sidebar-frame {
+    @media (max-width: -1 + map-get($grid-breakpoints, "lg")) {
+        max-height: calc(100vh - 65px);
+    }
+}

--- a/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
+++ b/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
@@ -1,5 +1,5 @@
 .discussions-sidebar-frame {
-    @media (max-width: -1 + map-get($grid-breakpoints, "lg")) {
+    @media (max-width: -1 + map-get($grid-breakpoints, "xl")) {
         max-height: calc(100vh - 65px);
     }
 }

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -32,7 +32,7 @@ const DiscussionsSidebar = ({ intl }) => {
     >
       <iframe
         src={`${discussionsUrl}?inContextSidebar`}
-        className="d-flex w-100 h-100 border-0"
+        className="d-flex w-100 h-100 border-0 discussions-sidebar-frame"
         title={intl.formatMessage(messages.discussionsTitle)}
         allow="clipboard-write"
         loading="lazy"

--- a/src/index.scss
+++ b/src/index.scss
@@ -393,6 +393,7 @@
 
 // Import component-specific sass files
 @import "courseware/course/celebration/CelebrationModal.scss";
+@import "courseware/course/sidebar/sidebars/discussions/Discussions.scss";
 @import "courseware/course/sidebar/sidebars/notifications/NotificationIcon.scss";
 @import "courseware/course/sequence/lock-paywall/LockPaywall.scss";
 @import "shared/streak-celebration/StreakCelebrationModal.scss";
@@ -402,7 +403,7 @@
 @import "generic/upgrade-notification/UpgradeNotification.scss";
 @import "generic/upsell-bullets/UpsellBullets.scss";
 @import "course-home/outline-tab/widgets/ProctoringInfoPanel.scss";
-@import "src/course-home/outline-tab/widgets/FlagButton.scss";
+@import "course-home/outline-tab/widgets/FlagButton.scss";
 @import "course-home/progress-tab/course-completion/CompletionDonutChart.scss";
 @import "course-home/progress-tab/grades/course-grade/GradeBar.scss";
 @import "courseware/course/course-exit/CourseRecommendations";


### PR DESCRIPTION
### Description

This merge request contains a height fix to avoid clipping the content of the iframe for discussions sidebar on mobile devices.

### Related PR 
- master branch: https://github.com/openedx/frontend-app-learning/pull/1393
- redwood branch: https://github.com/openedx/frontend-app-learning/pull/1404

#### Screenshots:

|Before|After|
|-------|-----|
|  <img width="565" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/a164d8e4-48bf-4e8b-8620-849344c18690">    |    <img width="586" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/25b039ef-8e85-4fec-9532-d4a432c2c1b8">  |