### PR TITLE
fix: iframe height for discussions sidebar

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
+++ b/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
@@ -1,0 +1,5 @@
+.discussions-sidebar-frame {
+    @media (max-width: -1 + map-get($grid-breakpoints, "lg")) {
+        max-height: calc(100vh - 65px);
+    }
+}

--- a/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
+++ b/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
@@ -1,5 +1,5 @@
 .discussions-sidebar-frame {
-    @media (max-width: -1 + map-get($grid-breakpoints, "lg")) {
+    @media (max-width: -1 + map-get($grid-breakpoints, "xl")) {
         max-height: calc(100vh - 65px);
     }
 }

--- a/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
+++ b/src/courseware/course/sidebar/sidebars/discussions/DiscussionsSidebar.jsx
@@ -38,7 +38,7 @@ const DiscussionsSidebar = ({ intl }) => {
     >
       <iframe
         src={`${discussionsUrl}?inContextSidebar`}
-        className="d-flex sticky-top vh-100 w-100 border-0"
+        className="d-flex sticky-top vh-100 w-100 border-0 discussions-sidebar-frame"
         title={intl.formatMessage(messages.discussionsTitle)}
         allow="clipboard-write"
         loading="lazy"

--- a/src/index.scss
+++ b/src/index.scss
@@ -407,6 +407,7 @@
 
 // Import component-specific sass files
 @import "courseware/course/celebration/CelebrationModal.scss";
+@import "courseware/course/sidebar/sidebars/discussions/Discussions.scss";
 @import "courseware/course/sidebar/sidebars/notifications/NotificationIcon.scss";
 @import "courseware/course/sequence/lock-paywall/LockPaywall.scss";
 @import "shared/streak-celebration/StreakCelebrationModal.scss";


### PR DESCRIPTION
### Description

This merge request contains a height fix to avoid clipping the content of the iframe for discussions sidebar on mobile devices.

### Related PR 
- quince branch: https://github.com/openedx/frontend-app-learning/pull/1392
- redwood branch: https://github.com/openedx/frontend-app-learning/pull/1404

#### Screenshots:

|Before|After|
|-------|-----|
|  <img width="565" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/a164d8e4-48bf-4e8b-8620-849344c18690">    |    <img width="586" alt="image" src="https://github.com/openedx/frontend-app-learning/assets/17108583/25b039ef-8e85-4fec-9532-d4a432c2c1b8">  |