### PR TITLE
style: use brand style for search button border

### DIFF
--- a/src/course-home/courseware-search/CoursewareSearchToggle.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchToggle.jsx
@@ -29,7 +29,7 @@ const CoursewareSearchToggle = ({
       <Button
         variant="outline-primary"
         size="sm"
-        className="p-1 mt-2 mr-2 rounded-lg"
+        className="p-1 mt-2 mr-2"
         aria-label={intl.formatMessage(messages.searchOpenAction)}
         onClick={handleSearchOpenClick}
         data-testid="courseware-search-open-button"


### PR DESCRIPTION
The default theme uses rounded boarders but the edx.org theme does not. Not setting anything here will use the appropriate border styling based on the site theme.