### PR TITLE
fix: fixed sidebar width issue

### DIFF
--- a/src/courseware/course/new-sidebar/common/SidebarBase.jsx
+++ b/src/courseware/course/new-sidebar/common/SidebarBase.jsx
@@ -104,7 +104,7 @@ SidebarBase.propTypes = {
 
 SidebarBase.defaultProps = {
   title: '',
-  width: '50rem',
+  width: '45rem',
   allowFullHeight: false,
   showTitleBar: true,
   className: '',

--- a/src/courseware/course/sidebar/common/SidebarBase.jsx
+++ b/src/courseware/course/sidebar/common/SidebarBase.jsx
@@ -42,7 +42,7 @@ const SidebarBase = ({
         'd-none': currentSidebar !== sidebarId,
       }, className)}
       data-testid={`sidebar-${sidebarId}`}
-      style={{ minWidth: shouldDisplayFullScreen ? '100%' : width }}
+      style={{ width: shouldDisplayFullScreen ? '100%' : width }}
       aria-label={ariaLabel}
       id="course-sidebar"
     >
@@ -98,7 +98,7 @@ SidebarBase.propTypes = {
 };
 
 SidebarBase.defaultProps = {
-  width: '410px',
+  width: '31rem',
   showTitleBar: true,
 };
 

--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationTray.jsx
@@ -71,6 +71,7 @@ const NotificationTray = ({ intl }) => {
       title={intl.formatMessage(messages.notificationTitle)}
       ariaLabel={intl.formatMessage(messages.notificationTray)}
       sidebarId={ID}
+      width="45rem"
       className={classNames({
         'h-100': !verifiedMode && !shouldDisplayFullScreen,
         'ml-4': !shouldDisplayFullScreen,


### PR DESCRIPTION
[INF-1409](https://2u-internal.atlassian.net/browse/INF-1409)

**Description**
The in-context sidebar is taking up too much space after merging this [PR](https://github.com/openedx/frontend-app-learning/pull/1375/files#diff-0cb7a8ccf08310f737b1bfa786e5af9347f717a7aa9e4f13b591b591100ec09c); it should only occupy half of the area allocated for course updates.

**Screenshots**

**Before**
<img width="1785" alt="Screenshot 2024-05-22 at 4 05 01 PM" src="https://github.com/openedx/frontend-app-learning/assets/72802712/9694ec07-ead7-4c88-b0a2-157cfe47d756">

**After**
<img width="1661" alt="Screenshot 2024-05-28 at 1 52 20 PM" src="https://github.com/openedx/frontend-app-learning/assets/72802712/7f3d3709-990c-4441-9eca-152ce7c65bb2">


