### PR TITLE
fix: increase subsection grades rounding precision

### DIFF
--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -782,7 +782,7 @@ exports[`Data layer integration tests Test fetchProgressTab Should fetch, normal
         "gradingPolicy": {
           "assignmentPolicies": [
             {
-              "averageGrade": "1.00",
+              "averageGrade": "1.0000",
               "numDroppable": 1,
               "shortLabel": "HW",
               "type": "Homework",

--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -18,7 +18,7 @@ const calculateAssignmentTypeGrades = (points, assignmentWeight, numDroppable) =
     // Calculate the average grade for the assignment and round it. This rounding is not ideal and does not accurately
     // reflect what a learner's grade would be, however, we must have parity with the current grading behavior that
     // exists in edx-platform.
-    averageGrade = (points.reduce((a, b) => a + b, 0) / points.length).toFixed(2);
+    averageGrade = (points.reduce((a, b) => a + b, 0) / points.length).toFixed(4);
     weightedGrade = averageGrade * assignmentWeight;
   }
   return { averageGrade, weightedGrade };


### PR DESCRIPTION
We used two decimal digits to match the experience from the edx-platform. However, https://github.com/openedx/edx-platform/pull/27788 increased the precision to reduce the impact of double rounding.

See the details and testing instructions at https://github.com/openedx/edx-platform/pull/27788.

_Private-ref: [BB-4210](https://tasks.opencraft.com/browse/BB-4210)_