### PR TITLE
fix: remove redundant form-control in masquerade user input

### DIFF
--- a/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
+++ b/src/instructor-toolbar/masquerade-widget/MasqueradeWidget.jsx
@@ -135,7 +135,7 @@ class MasqueradeWidget extends Component {
             <span className="col-auto col-form-label pl-3" id="masquerade-search-label">{`${specificLearnerInputText}:`}</span>
             <MasqueradeUserNameInput
               id="masquerade-search"
-              className="col-4 form-control"
+              className="col-4"
               autoFocus={autoFocus}
               defaultValue={masqueradeUsername}
               onError={(errorMessage) => this.onError(errorMessage)}


### PR DESCRIPTION
## Description

This PR just removes a redundant class from the code. There are no UI changes in the master version as the same class is applied to twice. This was causing an issue in the previous versions which are using the `@edx/paragon` and `FormControl` in the `MasqueradeUserNameInput` (Ref: see https://github.com/open-craft/frontend-app-learning/pull/24).

Since master branch uses `@openedx/paragon` and `Input` in the `MasqueradeUserNameInput` component, the styles don't really cause any UI issues and it is just a minor improvement in code quality.

## Changes

### Before

![image](https://github.com/openedx/frontend-app-learning/assets/383862/b4dda0bd-2e00-4bab-9a60-6514a1d091f2)

### After

![image](https://github.com/openedx/frontend-app-learning/assets/383862/cfbaf7bd-ae30-4139-b584-8005190d3e86)
