### PR TITLE
chore: make sidebar less intrusive for mobile

### DIFF
--- a/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
@@ -20,16 +20,17 @@ const SidebarProvider = ({
 }) => {
   const { verifiedMode } = useModel('courseHomeMeta', courseId);
   const topic = useModel('discussionTopics', unitId);
-  const isUnitHasDiscussionTopics = topic?.id && topic?.enabledInContext;
   const shouldDisplayFullScreen = useWindowSize().width < breakpoints.large.minWidth;
   const shouldDisplaySidebarOpen = useWindowSize().width > breakpoints.medium.minWidth;
   const query = new URLSearchParams(window.location.search);
   const isInitiallySidebarOpen = shouldDisplaySidebarOpen || query.get('sidebar') === 'true';
+  const sidebarKey = `sidebar.${courseId}`;
+  const keyExists = sidebarKey in localStorage;
 
-  let initialSidebar = shouldDisplayFullScreen ? getLocalStorage(`sidebar.${courseId}`) : null;
+  let initialSidebar = shouldDisplayFullScreen && keyExists ? getLocalStorage(`sidebar.${courseId}`) : SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID;
 
   if (!shouldDisplayFullScreen && isInitiallySidebarOpen) {
-    initialSidebar = verifiedMode ? WIDGETS.NOTIFICATIONS : isUnitHasDiscussionTopics && WIDGETS.DISCUSSIONS;
+    initialSidebar = SIDEBARS.DISCUSSIONS_NOTIFICATIONS.ID;
   }
   const [currentSidebar, setCurrentSidebar] = useState(initialSidebar);
   const [notificationStatus, setNotificationStatus] = useState(getLocalStorage(`notificationStatus.${courseId}`));


### PR DESCRIPTION
[INF-1479](https://2u-internal.atlassian.net/browse/INF-1479)

**Description**

Mobile users should only need to close the sidebar widget once, and it should not reopen automatically when switching between units.

**Screenshot**
https://www.loom.com/share/46773322d572481abc3bd16926847ffd?sid=cb55e381-d895-425d-9301-4111036f314c