### PR TITLE
fix: Fixes the auto_advance feature for video XBlock

### DIFF
--- a/src/courseware/course/sequence/Unit/constants.js
+++ b/src/courseware/course/sequence/Unit/constants.js
@@ -16,6 +16,7 @@ export const messageTypes = StrictDict({
   modal: 'plugin.modal',
   resize: 'plugin.resize',
   videoFullScreen: 'plugin.videoFullScreen',
+  autoAdvance: 'plugin.autoAdvance',
 });
 
 export default StrictDict({


### PR DESCRIPTION
## Description

We are adding an event listener, which listens to the  `autoAdvance` message and triggers the next sequence.

## Supporting information

This PR works in addition to https://github.com/openedx/edx-platform/pull/35200

## Testing instructions

1. Get a working tutor devstack; Learning MFE should be using this branch, and edx-platform should be using https://github.com/openedx/edx-platform/pull/35200.

2. Make the following changes:
```diff
diff --git a/cms/envs/common.py b/cms/envs/common.py
index 85af0063d4..7df99c24ba 100644
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -228,7 +228,7 @@ FEATURES = {
 
     # Move the course author to next page when a video finishes. Set to True to
     # show an auto-advance button in videos. If False, videos never auto-advance.
-    'ENABLE_AUTOADVANCE_VIDEOS': False,
+    'ENABLE_AUTOADVANCE_VIDEOS': True,
 
     # If set to True, new Studio users won't be able to author courses unless
     # an Open edX admin has added them to the course creator group.
diff --git a/lms/envs/common.py b/lms/envs/common.py
index 68dda72b69..d6944ced8e 100644
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -303,7 +303,7 @@ FEATURES = {
 
     # Move the student to next page when a video finishes. Set to True to show
     # an auto-advance button in videos. If False, videos never auto-advance.
-    'ENABLE_AUTOADVANCE_VIDEOS': False,
+    'ENABLE_AUTOADVANCE_VIDEOS': True,
 
     # Enable instructor dash to submit background tasks
     'ENABLE_INSTRUCTOR_BACKGROUND_TASKS': True,
````
3. Once the above changes are done, it will be good to restart CMS and LMS `tutor dev restart cms and lms`
4. It will also be good to run the JS build, so exec in cms `tutor dev exec cms bash` and run `npm run build and npm run postinstall` repeat the same for lms; `tutor dev exec cms bash` and run `npm run build and npm run postinstall`
5. Once that is done, go to the course where there is a video unit and go to Settings --> Advance Settings
![image](https://github.com/user-attachments/assets/085d60fd-93df-4cbe-a700-b4ac73303b91)

6. Go to the video unit on the learning MFE, and the video should have the AUTO ADVANCE OPTION at the bottom.

![image](https://github.com/user-attachments/assets/8f8f97e1-82f8-43c6-9349-22a54991b4b6)

7. Play the video, and if the option is on, then the unit should move to the next unit automatically.

## Deadline

~~"None" if there's no rush, or provide a specific date or event (and reason) if there is one.~~

## Other information
