### PR TITLE
fix: reset initialsidebar after shouldDisplaySidebarOpen

### DIFF
--- a/src/courseware/course/new-sidebar/Sidebar.jsx
+++ b/src/courseware/course/new-sidebar/Sidebar.jsx
@@ -6,7 +6,8 @@ import { SIDEBARS } from './sidebars';
 const Sidebar = () => {
   const { currentSidebar, isDiscussionbarAvailable, isNotificationbarAvailable } = useContext(SidebarContext);
 
-  if (currentSidebar === null || (!isDiscussionbarAvailable && !isNotificationbarAvailable)) { return null; }
+  if (currentSidebar === null || (!isDiscussionbarAvailable && !isNotificationbarAvailable)
+    || !SIDEBARS[currentSidebar]) { return null; }
   const SidebarToRender = SIDEBARS[currentSidebar].Sidebar;
 
   return (

--- a/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/new-sidebar/SidebarContextProvider.jsx
@@ -61,6 +61,10 @@ const SidebarProvider = ({
     }
   }, [hideDiscussionbar, hideNotificationbar]);
 
+  useEffect(() => {
+    setCurrentSidebar(initialSidebar);
+  }, [shouldDisplaySidebarOpen, initialSidebar]);
+
   const handleWidgetToggle = useCallback((widgetId, sidebarId) => {
     setHideDiscussionbar(prevWidgetId => (widgetId === WIDGETS.DISCUSSIONS ? true : prevWidgetId));
     setHideNotificationbar(prevWidgetId => (widgetId === WIDGETS.NOTIFICATIONS ? true : prevWidgetId));


### PR DESCRIPTION
[INF-1478](https://2u-internal.atlassian.net/browse/INF-1478)

**Description**
The sidebar state should maintain based on local storage state, when moving from subsection instead of opening each time. 