### PR TITLE
feat: hide studio button for limited staff [BB-9082]

### DIFF
--- a/src/course-home/data/pact-tests/lmsPact.test.jsx
+++ b/src/course-home/data/pact-tests/lmsPact.test.jsx
@@ -89,6 +89,7 @@ describe('Course Home Service', () => {
               }),
               title: string('Demonstration Course'),
               username: string('edx'),
+              has_course_author_access: boolean(true),
             },
           },
         });
@@ -133,6 +134,7 @@ describe('Course Home Service', () => {
           ],
           title: 'Demonstration Course',
           username: 'edx',
+          hasCourseAuthorAccess: true,
         };
         const response = getCourseHomeCourseMetadata(courseId, 'outline');
         expect(response).toBeTruthy();

--- a/src/instructor-toolbar/InstructorToolbar.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.jsx
@@ -57,6 +57,7 @@ const InstructorToolbar = (props) => {
   const {
     courseId,
     unitId,
+    isStudioButtonVisible,
     tab,
   } = props;
 
@@ -74,13 +75,13 @@ const InstructorToolbar = (props) => {
           <div className="align-items-center flex-grow-1 d-md-flex mx-1 my-1">
             <MasqueradeWidget courseId={courseId} onError={showMasqueradeError} />
           </div>
-          {(urlStudio || urlInsights) && (
+          {((urlStudio && isStudioButtonVisible) || urlInsights) && (
             <>
               <hr className="border-light" />
               <span className="mr-2 mt-1 col-form-label"><FormattedMessage {...messages.titleViewCourseIn} /></span>
             </>
           )}
-          {urlStudio && (
+          {urlStudio && isStudioButtonVisible && (
             <span className="mx-1 my-1">
               <a className="btn btn-inverse-outline-primary" href={urlStudio}>{formatMessage(messages.titleStudio)}</a>
             </span>
@@ -116,12 +117,14 @@ const InstructorToolbar = (props) => {
 InstructorToolbar.propTypes = {
   courseId: PropTypes.string,
   unitId: PropTypes.string,
+  isStudioButtonVisible: PropTypes.bool,
   tab: PropTypes.string,
 };
 
 InstructorToolbar.defaultProps = {
   courseId: undefined,
   unitId: undefined,
+  isStudioButtonVisible: true,
   tab: '',
 };
 

--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -29,6 +29,7 @@ const LoadedTabPage = ({
     tabs,
     title,
     verifiedMode,
+    hasCourseAuthorAccess,
   } = useModel('courseHomeMeta', courseId);
 
   // Logistration and enrollment alerts are only really used for the outline tab, but loaded here to put them above
@@ -58,6 +59,7 @@ const LoadedTabPage = ({
           courseId={courseId}
           unitId={unitId}
           tab={activeTabSlug}
+          isStudioButtonVisible={hasCourseAuthorAccess}
         />
       )}
       <StreakModal


### PR DESCRIPTION
## Description

Partially addresses https://github.com/openedx/platform-roadmap/issues/361 issue, by implementing the second suggestion from [here](https://github.com/openedx/platform-roadmap/issues/361#issuecomment-2159328651):
>Limited Staff should not see the button to "view this course in Studio" from the LMS. This will reduce chances for Limited Staff to land on Studio pages.

This fix relies on https://github.com/openedx/edx-platform/pull/35313.

## Testing

1. Create two users, `staff@example.com` and `limited_staff@example.com`.
2. In the instructor's dashboard, assign `staff@example.com` user to the staff course access role, and `limited_staff@example.com` to the limited staff course access role.
3. Verify that the limited staff user doesn't see "View in Studio" button. Cycle through different roles in "View this course as:" dropdown and verify that none can see this button.
4. The same as №3, but staff user should see this button always.