### PR TITLE
fix: show studio button if user has access

### DIFF
--- a/src/instructor-toolbar/InstructorToolbar.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.jsx
@@ -23,10 +23,10 @@ function getInsightsUrl(courseId) {
   return urlFull;
 }
 
-function getStudioUrl(courseId, unitId) {
+function getStudioUrl(courseId, unitId, hasStudioAccess) {
   const urlBase = getConfig().STUDIO_BASE_URL;
   let urlFull;
-  if (urlBase) {
+  if (urlBase && hasStudioAccess) {
     if (unitId) {
       urlFull = `${urlBase}/container/${unitId}`;
     } else if (courseId) {
@@ -56,10 +56,11 @@ const InstructorToolbar = (props) => {
     courseId,
     unitId,
     tab,
+    hasStudioAccess,
   } = props;
 
   const urlInsights = getInsightsUrl(courseId);
-  const urlStudio = getStudioUrl(courseId, unitId);
+  const urlStudio = getStudioUrl(courseId, unitId, hasStudioAccess);
   const [masqueradeErrorMessage, showMasqueradeError] = useState(null);
 
   const accessExpirationMasqueradeBanner = useAccessExpirationMasqueradeBanner(courseId, tab);
@@ -115,12 +116,14 @@ InstructorToolbar.propTypes = {
   courseId: PropTypes.string,
   unitId: PropTypes.string,
   tab: PropTypes.string,
+  hasStudioAccess: PropTypes.bool,
 };
 
 InstructorToolbar.defaultProps = {
   courseId: undefined,
   unitId: undefined,
   tab: '',
+  hasStudioAccess: false,
 };
 
 export default InstructorToolbar;

--- a/src/instructor-toolbar/InstructorToolbar.test.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.test.jsx
@@ -34,6 +34,7 @@ describe('Instructor Toolbar', () => {
     mockData = {
       courseId: courseware.courseId,
       unitId: Object.values(models.units)[0].id,
+      hasStudioAccess: true,
     };
     axiosMock.reset();
     axiosMock.onGet(masqueradeUrl).reply(200, { success: true });
@@ -75,5 +76,17 @@ describe('Instructor Toolbar', () => {
     render(<InstructorToolbar {...mockData} unitId={null} />);
 
     expect(screen.queryByText('View course in:')).not.toBeInTheDocument();
+  });
+
+  it('does not display Studio link if user does not have studio access', () => {
+    const config = { ...originalConfig };
+    const data = { ...mockData, hasStudioAccess: false };
+    config.INSIGHTS_BASE_URL = 'http://localhost:18100';
+    getConfig.mockImplementation(() => config);
+    render(<InstructorToolbar {...data} />);
+
+    const linksContainer = screen.getByText('View course in:').parentElement;
+    expect(screen.queryByText(linksContainer, 'Studio')).toBeNull();
+    expect(getByText(linksContainer, 'Insights').getAttribute('href')).toMatch(/http.*/);
   });
 });

--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -26,6 +26,7 @@ const LoadedTabPage = ({
     celebrations,
     org,
     originalUserIsStaff,
+    studioAccess,
     tabs,
     title,
     verifiedMode,
@@ -58,6 +59,7 @@ const LoadedTabPage = ({
           courseId={courseId}
           unitId={unitId}
           tab={activeTabSlug}
+          hasStudioAccess={studioAccess}
         />
       )}
       <StreakModal


### PR DESCRIPTION
<!--

Note: Please refer to the Support Development Guidelines on the wiki page to consider backporting to active releases:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/4248436737/Support+Guidelines+for+active+releases

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly readable.
If the linked information must be private (because it contains secrets), clearly label the link as private.

-->

## Description

This PR adds `studio_access` attribute to a courses metadata for LMS requests. This field is used when determining is the "View in Studio" button is showed in the Instructors Toolbar. Currently the button appears for all staff members regardless of their studio permissions. However, the "Limited Staff" role does not have access to Studio, but is shown the Studio button and sees a 403 error when trying to load the Studio page. This change impacts Authors.

## Supporting information

JIRA Ticket: [AU-2055 🔒](https://2u-internal.atlassian.net/browse/AU-2055)

> Expected behavior
>
> The Studio button should not be visible since this role doesn’t have permission to view content in Studio.
> 
> Studio will not load because this role doesn’t grant access to it. 
> 
> Actual behavior
> The Studio button is visible even though this role doesn’t have permission to view content in Studio.
> 
> Studio does not load. Instead, an error message displays:
> 
>  > 403 Forbidden

## Testing instructions

Using `KristinAoki/add-cms-access-check-for-lms` branch

1. Go to Instructor > Membership > “Course Team Management”.
2. Select “Limited Staff” from the dropdown. 
3. Add a test account of yours to this role.
4. Save your changes.
5. As this test account, sign in.. 
6. Go to the course you added yourself to. 
7. See the Banner bar that contains the masquerade (“View this course as:”) toolbar.
8. Confirm that the Studio button is not present.
9. Log back into instructor account
10. Confirm that the Studio button is present.

## Deadline

None

## Other information

This is dependent on openedx/edx-platform PR [#35444](https://github.com/openedx/edx-platform/pull/35444)
