### PR TITLE
fix: sass deprecation warning in GradeBar.scss

### DIFF
--- a/src/course-home/progress-tab/grades/course-grade/GradeBar.scss
+++ b/src/course-home/progress-tab/grades/course-grade/GradeBar.scss
@@ -36,17 +36,17 @@
 }
 
 #passing-grade-tooltip {
+  background: $success-500;
+
   .arrow::after {
     border-top-color: $success-500;
   }
-
-  background: $success-500;
 }
 
 #non-passing-grade-tooltip {
+  background: $accent-b;
+
   .arrow::after {
     border-top-color: $accent-b;
   }
-
-  background: $accent-b;
 }


### PR DESCRIPTION
A warning was appearing when building this with `npm run start`:

```
Deprecation Warning on line 42, column 2 of file:///Users/opencraft/Documents/tutor-devstack/frontend-app-learning/src/course-home/progress-tab/grades/course-grade/GradeBar.scss:42:2:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

42 |   background: $success-500;
```

See https://sass-lang.com/d/mixed-decls

This fix is quite simple in this case.