### PR TITLE
Revert "fix: show studio button if user has access"

### DIFF
--- a/src/instructor-toolbar/InstructorToolbar.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.jsx
@@ -23,10 +23,10 @@ function getInsightsUrl(courseId) {
   return urlFull;
 }
 
-function getStudioUrl(courseId, unitId, hasStudioAccess) {
+function getStudioUrl(courseId, unitId) {
   const urlBase = getConfig().STUDIO_BASE_URL;
   let urlFull;
-  if (urlBase && hasStudioAccess) {
+  if (urlBase) {
     if (unitId) {
       urlFull = `${urlBase}/container/${unitId}`;
     } else if (courseId) {
@@ -56,11 +56,10 @@ const InstructorToolbar = (props) => {
     courseId,
     unitId,
     tab,
-    hasStudioAccess,
   } = props;
 
   const urlInsights = getInsightsUrl(courseId);
-  const urlStudio = getStudioUrl(courseId, unitId, hasStudioAccess);
+  const urlStudio = getStudioUrl(courseId, unitId);
   const [masqueradeErrorMessage, showMasqueradeError] = useState(null);
 
   const accessExpirationMasqueradeBanner = useAccessExpirationMasqueradeBanner(courseId, tab);
@@ -116,14 +115,12 @@ InstructorToolbar.propTypes = {
   courseId: PropTypes.string,
   unitId: PropTypes.string,
   tab: PropTypes.string,
-  hasStudioAccess: PropTypes.bool,
 };
 
 InstructorToolbar.defaultProps = {
   courseId: undefined,
   unitId: undefined,
   tab: '',
-  hasStudioAccess: false,
 };
 
 export default InstructorToolbar;

--- a/src/instructor-toolbar/InstructorToolbar.test.jsx
+++ b/src/instructor-toolbar/InstructorToolbar.test.jsx
@@ -34,7 +34,6 @@ describe('Instructor Toolbar', () => {
     mockData = {
       courseId: courseware.courseId,
       unitId: Object.values(models.units)[0].id,
-      hasStudioAccess: true,
     };
     axiosMock.reset();
     axiosMock.onGet(masqueradeUrl).reply(200, { success: true });
@@ -76,17 +75,5 @@ describe('Instructor Toolbar', () => {
     render(<InstructorToolbar {...mockData} unitId={null} />);
 
     expect(screen.queryByText('View course in:')).not.toBeInTheDocument();
-  });
-
-  it('does not display Studio link if user does not have studio access', () => {
-    const config = { ...originalConfig };
-    const data = { ...mockData, hasStudioAccess: false };
-    config.INSIGHTS_BASE_URL = 'http://localhost:18100';
-    getConfig.mockImplementation(() => config);
-    render(<InstructorToolbar {...data} />);
-
-    const linksContainer = screen.getByText('View course in:').parentElement;
-    expect(screen.queryByText(linksContainer, 'Studio')).toBeNull();
-    expect(getByText(linksContainer, 'Insights').getAttribute('href')).toMatch(/http.*/);
   });
 });

--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -26,7 +26,6 @@ const LoadedTabPage = ({
     celebrations,
     org,
     originalUserIsStaff,
-    studioAccess,
     tabs,
     title,
     verifiedMode,
@@ -59,7 +58,6 @@ const LoadedTabPage = ({
           courseId={courseId}
           unitId={unitId}
           tab={activeTabSlug}
-          hasStudioAccess={studioAccess}
         />
       )}
       <StreakModal


### PR DESCRIPTION
Reverts openedx/frontend-app-learning#1452

This change works as expected for superusers and users with the "Staff" and "Limited Staff" roles. However, users with the "Admin" role are not seeing the Studio button even though they should have the permission to see it. Additional check will need to be added to the backend before this can be added back.