### PR TITLE
feat: Updated Xpert component to be lazy loaded

### DIFF
--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -1,12 +1,14 @@
+import { Suspense, lazy } from 'react';
 import { createPortal } from 'react-dom';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Xpert } from '@edx/frontend-lib-learning-assistant';
 import { injectIntl } from '@edx/frontend-platform/i18n';
 
 import { VERIFIED_MODES } from '@src/constants';
 import { useModel } from '../../../generic/model-store';
+
+const Xpert = lazy(async () => ({ default: (await import('@edx/frontend-lib-learning-assistant')).Xpert }));
 
 const Chat = ({
   enabled,
@@ -54,7 +56,11 @@ const Chat = ({
     <>
       {/* Use a portal to ensure that component overlay does not compete with learning MFE styles. */}
       {shouldDisplayChat && (createPortal(
-        <Xpert courseId={courseId} contentToolsEnabled={contentToolsEnabled} unitId={unitId} />,
+        <div data-testid="xpert-portal">
+          <Suspense fallback={null}>
+            <Xpert courseId={courseId} contentToolsEnabled={contentToolsEnabled} unitId={unitId} />
+          </Suspense>
+        </div>,
         document.body,
       ))}
     </>

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -78,11 +78,13 @@ describe('Chat', () => {
           { store },
         );
 
-        const chat = screen.queryByTestId(mockXpertTestId);
+        const portal = screen.queryByTestId('xpert-portal');
+
         if (test.isVisible) {
-          expect(chat).toBeInTheDocument();
+          expect(portal).toBeInTheDocument();
+          expect(await screen.findByTestId(mockXpertTestId)).toBeInTheDocument();
         } else {
-          expect(chat).not.toBeInTheDocument();
+          expect(portal).not.toBeInTheDocument();
         }
       },
     );


### PR DESCRIPTION
Related issues: https://github.com/openedx/frontend-app-learning/issues/1482

To improve bundle size we are lazy loading Xpert from `frontend-lib-learning-assistant`.

## Bundlewatch before
```
PASS dist/108.js: 1.57KB < 1.27MB (gzip)
PASS dist/15.js: 995B < 1.27MB (gzip)
PASS dist/2.js: 772B < 1.27MB (gzip)
PASS dist/312.js: 1.25MB < 1.27MB (gzip)
PASS dist/329.js: 1.99KB < 1.27MB (gzip)
PASS dist/35.js: 1.01KB < 1.27MB (gzip)
PASS dist/550.js: 628B < 1.27MB (gzip)
PASS dist/750.js: 1.1KB < 1.27MB (gzip)
PASS dist/775.js: 858B < 1.27MB (gzip)
PASS dist/824.js: 1.65KB < 1.27MB (gzip)
PASS dist/885.js: 1.21KB < 1.27MB (gzip)
PASS dist/938.js: 663B < 1.27MB (gzip)
PASS dist/app.js: 94.3KB < 1.27MB (gzip)
PASS dist/runtime.js: 1.93KB < 1.27MB (gzip)

bundlewatch PASS
Everything is in check (+1.35MB, -0B)
```
Result breakdown at: https://ja2r7.app.goo.gl/5iYm4CybudWXSUSF6


## Bundlewatch after
```
PASS dist/108.js: 1.57KB < 1.27MB (gzip)
PASS dist/15.js: 995B < 1.27MB (gzip)
PASS dist/2.js: 770B < 1.27MB (gzip)
PASS dist/312.js: 1.25MB < 1.27MB (gzip)
PASS dist/329.js: 1.99KB < 1.27MB (gzip)
PASS dist/35.js: 1.01KB < 1.27MB (gzip)
PASS dist/550.js: 627B < 1.27MB (gzip)
PASS dist/750.js: 1.11KB < 1.27MB (gzip)
PASS dist/775.js: 859B < 1.27MB (gzip)
PASS dist/824.js: 1.65KB < 1.27MB (gzip)
PASS dist/885.js: 1.21KB < 1.27MB (gzip)
PASS dist/938.js: 662B < 1.27MB (gzip)
PASS dist/app.js: 94.39KB < 1.27MB (gzip)
PASS dist/runtime.js: 1.93KB < 1.27MB (gzip)

bundlewatch PASS
Everything is in check (+1.35MB, -0B)
```
Result breakdown at: https://ja2r7.app.goo.gl/TXEwuYtUvirAdYFL8

There seem to be no evident improvement on the bundle size according to Bundlewatch.
