### PR TITLE
fix: corrects typo in IFRAME_FEATURE_POLICY

### DIFF
--- a/src/courseware/course/sequence/Unit/ContentIFrame.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.jsx
@@ -20,7 +20,7 @@ import * as hooks from './hooks';
  * Changes to it should be vetted by them (security@edx.org).
  */
 export const IFRAME_FEATURE_POLICY = (
-  'microphone *; camera *; midi *; geolocation *; encrypted-media *, clipboard-write *'
+  'microphone *; camera *; midi *; geolocation *; encrypted-media *; clipboard-write *'
 );
 
 export const testIDs = StrictDict({


### PR DESCRIPTION
This is a simple fix to the IFRAME_FEATURE_POLICY, wherein a comma was used instead of a semi-colon.

Refer to the following screencap of the console for the warnings:
<img width="664" alt="Screenshot 2024-10-21 at 11 50 54 AM" src="https://github.com/user-attachments/assets/1a585ef8-8ec0-4b70-af26-8c56e37cd723">
