### PR TITLE
feat: add functionality to see unit draft preview

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export const DECODE_ROUTES = {
     '/course/:courseId/:sequenceId',
     '/course/:courseId',
     '/preview/course/:courseId/:sequenceId/:unitId',
+    '/preview/course/:courseId/:sequenceId',
   ],
   REDIRECT_HOME: 'home/:courseId',
   REDIRECT_SURVEY: 'survey/:courseId',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,7 @@ export const DECODE_ROUTES = {
     '/course/:courseId/:sequenceId/:unitId',
     '/course/:courseId/:sequenceId',
     '/course/:courseId',
+    '/preview/course/:courseId/:sequenceId/:unitId',
   ],
   REDIRECT_HOME: 'home/:courseId',
   REDIRECT_SURVEY: 'survey/:courseId',

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -19,24 +19,26 @@ import { handleNextSectionCelebration } from './course/celebration';
 import withParamsAndNavigation from './utils';
 
 // Look at where this is called in componentDidUpdate for more info about its usage
-const checkResumeRedirect = memoize((courseStatus, courseId, sequenceId, firstSequenceId, navigate, isPreview) => {
-  if (courseStatus === 'loaded' && !sequenceId) {
-    // Note that getResumeBlock is just an API call, not a redux thunk.
-    getResumeBlock(courseId).then((data) => {
-      // This is a replace because we don't want this change saved in the browser's history.
-      if (data.sectionId && data.unitId) {
-        const baseUrl = `/course/${courseId}/${data.sectionId}`;
-        const sequenceUrl = isPreview ? `/preview${baseUrl}` : baseUrl;
-        navigate(`${sequenceUrl}/${data.unitId}`, { replace: true });
-      } else if (firstSequenceId) {
-        navigate(`/course/${courseId}/${firstSequenceId}`, { replace: true });
-      }
-    });
-  }
-});
+export const checkResumeRedirect = memoize(
+  (courseStatus, courseId, sequenceId, firstSequenceId, navigate, isPreview) => {
+    if (courseStatus === 'loaded' && !sequenceId) {
+      // Note that getResumeBlock is just an API call, not a redux thunk.
+      getResumeBlock(courseId).then((data) => {
+        // This is a replace because we don't want this change saved in the browser's history.
+        if (data.sectionId && data.unitId) {
+          const baseUrl = `/course/${courseId}/${data.sectionId}`;
+          const sequenceUrl = isPreview ? `/preview${baseUrl}` : baseUrl;
+          navigate(`${sequenceUrl}/${data.unitId}`, { replace: true });
+        } else if (firstSequenceId) {
+          navigate(`/course/${courseId}/${firstSequenceId}`, { replace: true });
+        }
+      }, () => {});
+    }
+  },
+);
 
 // Look at where this is called in componentDidUpdate for more info about its usage
-const checkSectionUnitToUnitRedirect = memoize((
+export const checkSectionUnitToUnitRedirect = memoize((
   courseStatus,
   courseId,
   sequenceStatus,
@@ -53,20 +55,22 @@ const checkSectionUnitToUnitRedirect = memoize((
 });
 
 // Look at where this is called in componentDidUpdate for more info about its usage
-const checkSectionToSequenceRedirect = memoize((courseStatus, courseId, sequenceStatus, section, unitId, navigate) => {
-  if (courseStatus === 'loaded' && sequenceStatus === 'failed' && section && !unitId) {
-    // If the section is non-empty, redirect to its first sequence.
-    if (section.sequenceIds && section.sequenceIds[0]) {
-      navigate(`/course/${courseId}/${section.sequenceIds[0]}`, { replace: true });
-    // Otherwise, just go to the course root, letting the resume redirect take care of things.
-    } else {
-      navigate(`/course/${courseId}`, { replace: true });
+export const checkSectionToSequenceRedirect = memoize(
+  (courseStatus, courseId, sequenceStatus, section, unitId, navigate) => {
+    if (courseStatus === 'loaded' && sequenceStatus === 'failed' && section && !unitId) {
+      // If the section is non-empty, redirect to its first sequence.
+      if (section.sequenceIds && section.sequenceIds[0]) {
+        navigate(`/course/${courseId}/${section.sequenceIds[0]}`, { replace: true });
+      // Otherwise, just go to the course root, letting the resume redirect take care of things.
+      } else {
+        navigate(`/course/${courseId}`, { replace: true });
+      }
     }
-  }
-});
+  },
+);
 
 // Look at where this is called in componentDidUpdate for more info about its usage
-const checkUnitToSequenceUnitRedirect = memoize((
+export const checkUnitToSequenceUnitRedirect = memoize((
   courseStatus,
   courseId,
   sequenceStatus,
@@ -104,7 +108,7 @@ const checkUnitToSequenceUnitRedirect = memoize((
 });
 
 // Look at where this is called in componentDidUpdate for more info about its usage
-const checkSequenceToSequenceUnitRedirect = memoize(
+export const checkSequenceToSequenceUnitRedirect = memoize(
   (courseId, sequenceStatus, sequence, unitId, navigate, isPreview) => {
     if (sequenceStatus === 'loaded' && sequence.id && !unitId) {
       if (sequence.unitIds !== undefined && sequence.unitIds.length > 0) {
@@ -119,32 +123,27 @@ const checkSequenceToSequenceUnitRedirect = memoize(
 );
 
 // Look at where this is called in componentDidUpdate for more info about its usage
-const checkSequenceUnitMarkerToSequenceUnitRedirect = memoize(
+export const checkSequenceUnitMarkerToSequenceUnitRedirect = memoize(
   (courseId, sequenceStatus, sequence, unitId, navigate, isPreview) => {
     if (sequenceStatus !== 'loaded' || !sequence.id) {
       return;
     }
 
     const baseUrl = `/course/${courseId}/${sequence.id}`;
-    const sequenceUrl = isPreview ? `/preview${baseUrl}` : baseUrl;
     const hasUnits = sequence.unitIds?.length > 0;
 
-    if (unitId === 'first') {
-      if (hasUnits) {
+    if (hasUnits) {
+      const sequenceUrl = isPreview ? `/preview${baseUrl}` : baseUrl;
+      if (unitId === 'first') {
         const firstUnitId = sequence.unitIds[0];
         navigate(`${sequenceUrl}/${firstUnitId}`, { replace: true });
-      } else {
-      // No units... go to general sequence page
-        navigate(baseUrl, { replace: true });
-      }
-    } else if (unitId === 'last') {
-      if (hasUnits) {
+      } else if (unitId === 'last') {
         const lastUnitId = sequence.unitIds[sequence.unitIds.length - 1];
         navigate(`${sequenceUrl}/${lastUnitId}`, { replace: true });
-      } else {
-      // No units... go to general sequence page
-        navigate(baseUrl, { replace: true });
       }
+    } else {
+      // No units... go to general sequence page
+      navigate(baseUrl, { replace: true });
     }
   },
 );

--- a/src/courseware/CoursewareContainer.test.jsx
+++ b/src/courseware/CoursewareContainer.test.jsx
@@ -673,8 +673,13 @@ describe('Course redirect functions', () => {
 
       it('calls navigate with parentId and sequenceId', () => {
         axiosMock.onGet(apiUrl).reply(200, {
-          parent: { id: 'sequence_1' },
+          blocks: {
+            id: 'sequence_1',
+            type: 'seuenctial',
+            children: ['unit_1'],
+          },
         });
+
         checkUnitToSequenceUnitRedirect(
           'loaded',
           'courseId',
@@ -696,6 +701,7 @@ describe('Course redirect functions', () => {
       it('calls navigate to course page when getSequenceForUnitDeprecated errors', () => {
         const getSequenceForUnitDeprecated = jest.fn();
         axiosMock.onGet(apiUrl).reply(404);
+
         checkUnitToSequenceUnitRedirect(
           'loaded',
           'courseId',
@@ -718,8 +724,9 @@ describe('Course redirect functions', () => {
       it('calls navigate to course page when no parent id is returned', () => {
         const getSequenceForUnitDeprecated = jest.fn();
         axiosMock.onGet(apiUrl).reply(200, {
-          parent: { children: ['block_1'] },
+          block: { type: 'sequential', children: ['block_1'] },
         });
+
         checkUnitToSequenceUnitRedirect(
           'loaded',
           'courseId',
@@ -735,6 +742,28 @@ describe('Course redirect functions', () => {
 
         waitFor(() => {
           expect(getSequenceForUnitDeprecated).toHaveBeenCalled();
+          expect(navigate).toHaveBeenCalledWith(expectedUrl, { replace: true });
+        });
+      });
+
+      it('calls navigate to course page when sequnce is not unit', () => {
+        const getSequenceForUnitDeprecated = jest.fn();
+
+        checkUnitToSequenceUnitRedirect(
+          'loaded',
+          'courseId',
+          'failed',
+          false,
+          'unit_1',
+          false,
+          null,
+          navigate,
+          true,
+        );
+        const expectedUrl = '/course/courseId';
+
+        waitFor(() => {
+          expect(getSequenceForUnitDeprecated).not.toHaveBeenCalled();
           expect(navigate).toHaveBeenCalledWith(expectedUrl, { replace: true });
         });
       });

--- a/src/courseware/CoursewareContainer.test.jsx
+++ b/src/courseware/CoursewareContainer.test.jsx
@@ -669,15 +669,16 @@ describe('Course redirect functions', () => {
     });
 
     describe('checkUnitToSequenceUnitRedirect', () => {
-      const apiUrl = getSequenceForUnitDeprecatedUrl('courseId');
+      const { href: apiUrl } = getSequenceForUnitDeprecatedUrl('courseId');
 
       it('calls navigate with parentId and sequenceId', () => {
+        const getSequenceForUnitDeprecated = jest.fn();
         axiosMock.onGet(apiUrl).reply(200, {
-          blocks: {
+          blocks: [{
             id: 'sequence_1',
-            type: 'seuenctial',
+            type: 'sequential',
             children: ['unit_1'],
-          },
+          }],
         });
 
         checkUnitToSequenceUnitRedirect(
@@ -694,6 +695,7 @@ describe('Course redirect functions', () => {
         const expectedUrl = '/course/courseId/sequence_1';
 
         waitFor(() => {
+          expect(getSequenceForUnitDeprecated).toHaveBeenCalled();
           expect(navigate).toHaveBeenCalledWith(expectedUrl, { replace: true });
         });
       });
@@ -724,7 +726,11 @@ describe('Course redirect functions', () => {
       it('calls navigate to course page when no parent id is returned', () => {
         const getSequenceForUnitDeprecated = jest.fn();
         axiosMock.onGet(apiUrl).reply(200, {
-          block: { type: 'sequential', children: ['block_1'] },
+          blocks: [{
+            id: 'sequence_1',
+            type: 'sequential',
+            children: ['block_1'],
+          }],
         });
 
         checkUnitToSequenceUnitRedirect(

--- a/src/courseware/course/Course.jsx
+++ b/src/courseware/course/Course.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { useDispatch, useSelector } from 'react-redux';
 import { getConfig } from '@edx/frontend-platform';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { breakpoints, useWindowSize } from '@openedx/paragon';
 
 import { AlertList } from '@src/generic/user-messages';
@@ -38,6 +39,13 @@ const Course = ({
   const section = useModel('sections', sequence ? sequence.sectionId : null);
   const { enableNavigationSidebar } = useSelector(getCoursewareOutlineSidebarSettings);
   const navigationDisabled = enableNavigationSidebar || (sequence?.navigationDisabled ?? false);
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  if (!isStaff && pathname.startsWith('/preview')) {
+    const courseUrl = pathname.replace('/preview', '');
+    navigate(courseUrl, { replace: true });
+  }
 
   const pageTitleBreadCrumbs = [
     sequence,

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -204,6 +204,7 @@ const Sequence = ({
               sequenceId={sequenceId}
               unitId={unitId}
               unitLoadedHandler={handleUnitLoaded}
+              isStaff={isStaff}
             />
             {unitHasLoaded && renderUnitNavigation(false)}
           </div>

--- a/src/courseware/course/sequence/SequenceContent.jsx
+++ b/src/courseware/course/sequence/SequenceContent.jsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import PageLoading from '../../../generic/PageLoading';
 import { useModel } from '../../../generic/model-store';
 
@@ -11,12 +11,13 @@ const ContentLock = React.lazy(() => import('./content-lock'));
 
 const SequenceContent = ({
   gated,
-  intl,
   courseId,
   sequenceId,
   unitId,
   unitLoadedHandler,
+  isStaff,
 }) => {
+  const intl = useIntl();
   const sequence = useModel('sequences', sequenceId);
 
   // Go back to the top of the page whenever the unit or sequence changes.
@@ -59,6 +60,7 @@ const SequenceContent = ({
       key={unitId}
       id={unitId}
       onLoaded={unitLoadedHandler}
+      isStaff={isStaff}
     />
   );
 };
@@ -69,11 +71,11 @@ SequenceContent.propTypes = {
   sequenceId: PropTypes.string.isRequired,
   unitId: PropTypes.string,
   unitLoadedHandler: PropTypes.func.isRequired,
-  intl: intlShape.isRequired,
+  isStaff: PropTypes.bool.isRequired,
 };
 
 SequenceContent.defaultProps = {
   unitId: null,
 };
 
-export default injectIntl(SequenceContent);
+export default SequenceContent;

--- a/src/courseware/course/sequence/Unit/index.jsx
+++ b/src/courseware/course/sequence/Unit/index.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useLocation } from 'react-router-dom';
 
 import { AppContext } from '@edx/frontend-platform/react';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -22,15 +22,18 @@ const Unit = ({
   format,
   onLoaded,
   id,
+  isStaff,
 }) => {
   const { formatMessage } = useIntl();
   const [searchParams] = useSearchParams();
+  const { pathname } = useLocation();
   const { authenticatedUser } = React.useContext(AppContext);
   const examAccess = useExamAccess({ id });
   const shouldDisplayHonorCode = useShouldDisplayHonorCode({ courseId, id });
   const unit = useModel(modelKeys.units, id);
   const isProcessing = unit.bookmarkedUpdateState === 'loading';
   const view = authenticatedUser ? views.student : views.public;
+  const shouldDisplayUnitPreview = pathname.startsWith('/preview') && isStaff;
 
   const getUrl = usePluginsCallback('getIFrameUrl', () => getIFrameUrl({
     id,
@@ -38,6 +41,7 @@ const Unit = ({
     format,
     examAccess,
     jumpToId: searchParams.get('jumpToId'),
+    preview: shouldDisplayUnitPreview ? '1' : '0',
   }));
 
   const iframeUrl = getUrl();
@@ -74,6 +78,7 @@ Unit.propTypes = {
   format: PropTypes.string,
   id: PropTypes.string.isRequired,
   onLoaded: PropTypes.func,
+  isStaff: PropTypes.bool.isRequired,
 };
 
 Unit.defaultProps = {

--- a/src/courseware/course/sequence/Unit/index.test.jsx
+++ b/src/courseware/course/sequence/Unit/index.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { when } from 'jest-when';
 import { formatMessage, shallow } from '@edx/react-unit-test-utils/dist';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useLocation } from 'react-router-dom';
 
 import { useModel } from '@src/generic/model-store';
 
@@ -55,6 +55,7 @@ const props = {
   format: 'test-format',
   onLoaded: jest.fn().mockName('props.onLoaded'),
   id: 'test-props-id',
+  isStaff: false,
 };
 
 const context = { authenticatedUser: { test: 'user' } };
@@ -89,6 +90,7 @@ describe('Unit component', () => {
 
   beforeEach(() => {
     useSearchParams.mockImplementation(() => [searchParams, setSearchParams]);
+    useLocation.mockImplementation(() => ({ pathname: `/course/${props.courseId}` }));
     jest.clearAllMocks();
     el = shallow(<Unit {...props} />);
   });

--- a/src/courseware/course/sequence/Unit/urls.js
+++ b/src/courseware/course/sequence/Unit/urls.js
@@ -13,6 +13,7 @@ export const getIFrameUrl = ({
   format,
   examAccess,
   jumpToId,
+  preview,
 }) => {
   const xblockUrl = `${getConfig().LMS_BASE_URL}/xblock/${id}`;
   return stringifyUrl({
@@ -20,6 +21,7 @@ export const getIFrameUrl = ({
     query: {
       ...iframeParams,
       view,
+      preview,
       ...(format && { format }),
       ...(!examAccess.blockAccess && { exam_access: examAccess.accessToken }),
       jumpToId, // Pass jumpToId as query param as fragmentIdentifier is not passed to server.

--- a/src/courseware/course/sequence/Unit/urls.test.js
+++ b/src/courseware/course/sequence/Unit/urls.test.js
@@ -17,6 +17,7 @@ const props = {
   view: 'test-view',
   format: 'test-format',
   examAccess: { blockAccess: false, accessToken: 'test-access-token' },
+  preview: false,
 };
 
 describe('urls module getIFrameUrl', () => {
@@ -28,6 +29,7 @@ describe('urls module getIFrameUrl', () => {
         view: props.view,
         format: props.format,
         exam_access: props.examAccess.accessToken,
+        preview: props.preview,
       },
     });
     expect(getIFrameUrl(props)).toEqual(url);
@@ -35,11 +37,12 @@ describe('urls module getIFrameUrl', () => {
   test('no format provided, exam access blocked', () => {
     const url = stringifyUrl({
       url: `${config.LMS_BASE_URL}/xblock/${props.id}`,
-      query: { ...iframeParams, view: props.view },
+      query: { ...iframeParams, view: props.view, preview: props.preview },
     });
     expect(getIFrameUrl({
       id: props.id,
       view: props.view,
+      preview: props.preview,
       examAccess: { blockAccess: true },
     })).toEqual(url);
   });
@@ -50,6 +53,7 @@ describe('urls module getIFrameUrl', () => {
         ...iframeParams,
         view: props.view,
         format: props.format,
+        preview: props.preview,
         exam_access: props.examAccess.accessToken,
         jumpToId: 'some-xblock-id',
       },
@@ -58,6 +62,22 @@ describe('urls module getIFrameUrl', () => {
     expect(getIFrameUrl({
       ...props,
       jumpToId: 'some-xblock-id',
+    })).toEqual(url);
+  });
+  test('preview is true and url param equals 1', () => {
+    const url = stringifyUrl({
+      url: `${config.LMS_BASE_URL}/xblock/${props.id}`,
+      query: {
+        ...iframeParams,
+        view: props.view,
+        format: props.format,
+        preview: true,
+        exam_access: props.examAccess.accessToken,
+      },
+    });
+    expect(getIFrameUrl({
+      ...props,
+      preview: true,
     })).toEqual(url);
   });
 });

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -1,15 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { breakpoints, Button, useWindowSize } from '@openedx/paragon';
-import { ChevronLeft, ChevronRight } from '@openedx/paragon/icons';
+import { breakpoints, useWindowSize } from '@openedx/paragon';
 import classNames from 'classnames';
-import {
-  injectIntl,
-  intlShape,
-  isRtl,
-  getLocale,
-} from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { useSelector } from 'react-redux';
 
@@ -21,9 +14,10 @@ import { useSequenceNavigationMetadata } from './hooks';
 import { useModel } from '../../../../generic/model-store';
 
 import messages from './messages';
+import PreviousButton from './generic/PreviousButton';
+import NextButton from './generic/NextButton';
 
 const SequenceNavigation = ({
-  intl,
   unitId,
   sequenceId,
   className,
@@ -36,6 +30,7 @@ const SequenceNavigation = ({
   open,
   close,
 }) => {
+  const intl = useIntl();
   const sequence = useModel('sequences', sequenceId);
   const {
     isFirstUnit,
@@ -76,29 +71,21 @@ const SequenceNavigation = ({
     );
   };
 
-  const renderPreviousButton = () => {
-    const disabled = isFirstUnit;
-    const prevArrow = isRtl(getLocale()) ? ChevronRight : ChevronLeft;
-    return navigationDisabledPrevSequence || (
-      <Button
-        variant="link"
-        className="previous-btn"
-        onClick={previousHandler}
-        disabled={disabled}
-        iconBefore={prevArrow}
-        as={disabled ? undefined : Link}
-        to={disabled ? undefined : previousLink}
-      >
-        {shouldDisplayNotificationTriggerInSequence ? null : intl.formatMessage(messages.previousButton)}
-      </Button>
-    );
-  };
+  const renderPreviousButton = () => navigationDisabledPrevSequence || (
+    <PreviousButton
+      variant="link"
+      buttonStyle="previous-btn"
+      onClick={previousHandler}
+      previousLink={previousLink}
+      isFirstUnit={isFirstUnit}
+      buttonLabel={shouldDisplayNotificationTriggerInSequence ? null : intl.formatMessage(messages.previousButton)}
+    />
+  );
 
   const renderNextButton = () => {
     const { exitActive, exitText } = GetCourseExitNavigation(courseId, intl);
     const buttonText = (isLastUnit && exitText) ? exitText : intl.formatMessage(messages.nextButton);
     const disabled = isLastUnit && !exitActive;
-    const nextArrow = isRtl(getLocale()) ? ChevronLeft : ChevronRight;
 
     return navigationDisabledNextSequence || (
       <PluginSlot
@@ -106,10 +93,8 @@ const SequenceNavigation = ({
         pluginProps={{
           courseId,
           disabled,
-          buttonText,
-          nextArrow,
+          buttonText: shouldDisplayNotificationTriggerInSequence ? null : buttonText,
           nextLink,
-          shouldDisplayNotificationTriggerInSequence,
           sequenceId,
           unitId,
           nextSequenceHandler,
@@ -117,20 +102,16 @@ const SequenceNavigation = ({
           isOpen,
           open,
           close,
-          linkComponent: Link,
         }}
       >
-        <Button
+        <NextButton
           variant="link"
-          className="next-btn"
+          buttonStyle="next-btn"
           onClick={nextHandler}
+          nextLink={nextLink}
           disabled={disabled}
-          iconAfter={nextArrow}
-          as={disabled ? undefined : Link}
-          to={disabled ? undefined : nextLink}
-        >
-          {shouldDisplayNotificationTriggerInSequence ? null : buttonText}
-        </Button>
+          buttonLabel={shouldDisplayNotificationTriggerInSequence ? null : buttonText}
+        />
       </PluginSlot>
     );
   };
@@ -145,7 +126,6 @@ const SequenceNavigation = ({
 };
 
 SequenceNavigation.propTypes = {
-  intl: intlShape.isRequired,
   sequenceId: PropTypes.string.isRequired,
   unitId: PropTypes.string,
   className: PropTypes.string,
@@ -169,4 +149,4 @@ SequenceNavigation.defaultProps = {
   nextSequenceHandler: null,
 };
 
-export default injectIntl(SequenceNavigation);
+export default SequenceNavigation;

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 import classNames from 'classnames';
@@ -22,6 +22,9 @@ const UnitButton = ({
   showTitle,
 }) => {
   const { courseId, sequenceId } = useSelector(state => state.courseware);
+  const { pathname } = useLocation();
+  const basePath = `/course/${courseId}/${sequenceId}/${unitId}`;
+  const unitPath = pathname.startsWith('/preview') ? `/preview${basePath}` : basePath;
 
   const handleClick = useCallback(() => {
     onClick(unitId);
@@ -37,7 +40,7 @@ const UnitButton = ({
       onClick={handleClick}
       title={title}
       as={Link}
-      to={`/course/${courseId}/${sequenceId}/${unitId}`}
+      to={unitPath}
     >
       <UnitIcon type={contentType} />
       {showTitle && <span className="unit-title">{title}</span>}

--- a/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
@@ -1,70 +1,53 @@
 import classNames from 'classnames';
-import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Button } from '@openedx/paragon';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import {
-  injectIntl, intlShape, isRtl, getLocale,
-} from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { useSelector } from 'react-redux';
 
 import { GetCourseExitNavigation } from '../../course-exit';
 
-import UnitNavigationEffortEstimate from './UnitNavigationEffortEstimate';
 import { useSequenceNavigationMetadata } from './hooks';
 import messages from './messages';
+import PreviousButton from './generic/PreviousButton';
+import NextButton from './generic/NextButton';
 
 const UnitNavigation = ({
-  intl,
   sequenceId,
   unitId,
   onClickPrevious,
   onClickNext,
   isAtTop,
 }) => {
+  const intl = useIntl();
   const {
     isFirstUnit, isLastUnit, nextLink, previousLink,
   } = useSequenceNavigationMetadata(sequenceId, unitId);
   const { courseId } = useSelector(state => state.courseware);
 
-  const renderPreviousButton = () => {
-    const disabled = isFirstUnit;
-    const prevArrow = isRtl(getLocale()) ? faChevronRight : faChevronLeft;
-    return (
-      <Button
-        variant="outline-secondary"
-        className="previous-button mr-sm-2 d-flex align-items-center justify-content-center"
-        disabled={disabled}
-        onClick={onClickPrevious}
-        as={disabled ? undefined : Link}
-        to={disabled ? undefined : previousLink}
-      >
-        <FontAwesomeIcon icon={prevArrow} className="mr-2" size="sm" />
-        {intl.formatMessage(messages.previousButton)}
-      </Button>
-    );
-  };
+  const renderPreviousButton = () => (
+    <PreviousButton
+      isFirstUnit={isFirstUnit}
+      variant="outline-secondary"
+      buttonLabel={intl.formatMessage(messages.previousButton)}
+      buttonStyle="previous-button justify-content-center"
+      onClick={onClickPrevious}
+      previousLink={previousLink}
+    />
+  );
 
   const renderNextButton = () => {
     const { exitActive, exitText } = GetCourseExitNavigation(courseId, intl);
     const buttonText = (isLastUnit && exitText) ? exitText : intl.formatMessage(messages.nextButton);
     const disabled = isLastUnit && !exitActive;
-    const nextArrow = isRtl(getLocale()) ? faChevronLeft : faChevronRight;
     return (
-      <Button
+      <NextButton
         variant="outline-primary"
-        className="next-button d-flex align-items-center justify-content-center"
+        buttonStyle="next-button justify-content-center"
         onClick={onClickNext}
         disabled={disabled}
-        as={disabled ? undefined : Link}
-        to={disabled ? undefined : nextLink}
-      >
-        <UnitNavigationEffortEstimate sequenceId={sequenceId} unitId={unitId}>
-          {buttonText}
-        </UnitNavigationEffortEstimate>
-        <FontAwesomeIcon icon={nextArrow} className="ml-2" size="sm" />
-      </Button>
+        buttonLabel={buttonText}
+        nextLink={nextLink}
+        hasEffortEstimate
+      />
     );
   };
 
@@ -77,7 +60,6 @@ const UnitNavigation = ({
 };
 
 UnitNavigation.propTypes = {
-  intl: intlShape.isRequired,
   sequenceId: PropTypes.string.isRequired,
   unitId: PropTypes.string,
   onClickPrevious: PropTypes.func.isRequired,
@@ -90,4 +72,4 @@ UnitNavigation.defaultProps = {
   isAtTop: false,
 };
 
-export default injectIntl(UnitNavigation);
+export default UnitNavigation;

--- a/src/courseware/course/sequence/sequence-navigation/generic/NextButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/generic/NextButton.jsx
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types';
+import { Link, useLocation } from 'react-router-dom';
+import { Button } from '@openedx/paragon';
+import { ChevronLeft, ChevronRight } from '@openedx/paragon/icons';
+import { isRtl, getLocale } from '@edx/frontend-platform/i18n';
+
+import UnitNavigationEffortEstimate from '../UnitNavigationEffortEstimate';
+
+const NextButton = ({
+  onClick,
+  buttonLabel,
+  nextLink,
+  variant,
+  buttonStyle,
+  disabled,
+  hasEffortEstimate,
+}) => {
+  const nextArrow = isRtl(getLocale()) ? ChevronLeft : ChevronRight;
+  const { pathname } = useLocation();
+  const navLink = pathname.startsWith('/preview') ? `/preview${nextLink}` : nextLink;
+  const buttonContent = hasEffortEstimate ? (
+    <UnitNavigationEffortEstimate>
+      {buttonLabel}
+    </UnitNavigationEffortEstimate>
+  ) : buttonLabel;
+
+  return (
+    <Button
+      variant={variant}
+      className={buttonStyle}
+      disabled={disabled}
+      onClick={onClick}
+      as={disabled ? undefined : Link}
+      to={disabled ? undefined : navLink}
+      iconAfter={nextArrow}
+    >
+      {buttonContent}
+    </Button>
+  );
+};
+
+NextButton.defaultProps = {
+  hasEffortEstimate: false,
+};
+
+NextButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string.isRequired,
+  nextLink: PropTypes.string.isRequired,
+  variant: PropTypes.string.isRequired,
+  buttonStyle: PropTypes.string.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  hasEffortEstimate: PropTypes.bool,
+};
+
+export default NextButton;

--- a/src/courseware/course/sequence/sequence-navigation/generic/PreviousButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/generic/PreviousButton.jsx
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import { Link, useLocation } from 'react-router-dom';
+import { Button } from '@openedx/paragon';
+import { ChevronLeft, ChevronRight } from '@openedx/paragon/icons';
+import { isRtl, getLocale } from '@edx/frontend-platform/i18n';
+
+const PreviousButton = ({
+  onClick,
+  buttonLabel,
+  previousLink,
+  variant,
+  buttonStyle,
+  isFirstUnit,
+}) => {
+  const disabled = isFirstUnit;
+  const prevArrow = isRtl(getLocale()) ? ChevronRight : ChevronLeft;
+  const { pathname } = useLocation();
+  const navLink = pathname.startsWith('/preview') ? `/preview${previousLink}` : previousLink;
+
+  return (
+    <Button
+      variant={variant}
+      className={buttonStyle}
+      disabled={disabled}
+      onClick={onClick}
+      as={disabled ? undefined : Link}
+      to={disabled ? undefined : navLink}
+      iconBefore={prevArrow}
+    >
+      {buttonLabel}
+    </Button>
+  );
+};
+
+PreviousButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  buttonLabel: PropTypes.string.isRequired,
+  previousLink: PropTypes.string.isRequired,
+  variant: PropTypes.string.isRequired,
+  buttonStyle: PropTypes.string.isRequired,
+  isFirstUnit: PropTypes.bool.isRequired,
+};
+
+export default PreviousButton;

--- a/src/courseware/data/api.js
+++ b/src/courseware/data/api.js
@@ -6,7 +6,7 @@ import {
 } from './utils';
 
 // Do not add further calls to this API - we don't like making use of the modulestore if we can help it
-export async function getSequenceForUnitDeprecated(courseId, unitId) {
+export const getSequenceForUnitDeprecatedUrl = (courseId) => {
   const authenticatedUser = getAuthenticatedUser();
   const url = new URL(`${getConfig().LMS_BASE_URL}/api/courses/v2/blocks/`);
   url.searchParams.append('course_id', courseId);
@@ -14,6 +14,10 @@ export async function getSequenceForUnitDeprecated(courseId, unitId) {
   url.searchParams.append('depth', 3);
   url.searchParams.append('requested_fields', 'children,discussions_url');
 
+  return url;
+};
+export async function getSequenceForUnitDeprecated(courseId, unitId) {
+  const url = getSequenceForUnitDeprecatedUrl(courseId);
   const { data } = await getAuthenticatedHttpClient().get(url.href, {});
   const parent = Object.values(data.blocks).find(block => block.type === 'sequential' && block.children.includes(unitId));
   return parent?.id;

--- a/src/courseware/utils.jsx
+++ b/src/courseware/utils.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 const withParamsAndNavigation = WrappedComponent => {
   const WithParamsNavigationComponent = props => {
     const { courseId, sequenceId, unitId } = useParams();
     const navigate = useNavigate();
+    const { pathname } = useLocation();
+    const isPreview = pathname.startsWith('/preview');
+
     return (
       <WrappedComponent
         routeCourseId={courseId}
         routeSequenceId={sequenceId}
         routeUnitId={unitId}
         navigate={navigate}
+        isPreview={isPreview}
         {...props}
       />
     );


### PR DESCRIPTION
## Description

This PR adds a new route that supports unit preview and updates the iframe url to include a param to tell the backend that the content should be from the draft branch of the unit.

## Supporting information

JIRA Ticket: [AU-1067 🔒](https://2u-internal.atlassian.net/browse/AU-1067)

> The Preview environment has drifted a bit away from the live view. The particular thing I spotted was that all the unit content is in an iframe, and preview doesn’t. There are some visual differences too, like the size of navigation elements, the placement of the bottom-of-page Previous/Next buttons, etc. 
>
> Things still look fairly accurate, but if you’re testing javascript, it can be a big difference.

## Testing instructions

1. Open a course in Studio
2. Publish an existing unit
3. Make a change to the unit so that it is showing a draft version in Studio
4. Click "View live"
5. Confirm that the published version of unit is visible
6. Confirm that preview is not in the URL
7. Go back to the Studio page
8. Click "Preview"
9. Confirm that the draft version of the unit is visible
10. Confirm that "preview" is at the beginning of the URL
## Other information

This PR is dependent on `edx-platform` PR [#35687](https://github.com/openedx/edx-platform/pull/35687)