### PR TITLE
feat: update courseware search api name

### DIFF
--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -449,7 +449,7 @@ export async function unsubscribeFromCourseGoal(token) {
     .then(res => camelCaseObject(res));
 }
 
-export async function getCoursewareSearchEnabledFlag(courseId) {
+export async function getCoursewareSearchEnabled(courseId) {
   const url = new URL(`${getConfig().LMS_BASE_URL}/courses/${courseId}/courseware-search/enabled/`);
   const { data } = await getAuthenticatedHttpClient().get(url.href);
   return { enabled: data.enabled || false };

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -12,7 +12,7 @@ import {
   postDismissWelcomeMessage,
   postRequestCert,
   getLiveTabIframe,
-  getCoursewareSearchEnabledFlag,
+  getCoursewareSearchEnabled,
   searchCourseContentFromAPI,
 } from './api';
 
@@ -159,7 +159,7 @@ export function processEvent(eventData, getTabData) {
 
 export async function fetchCoursewareSearchSettings(courseId) {
   try {
-    const { enabled } = await getCoursewareSearchEnabledFlag(courseId);
+    const { enabled } = await getCoursewareSearchEnabled(courseId);
     return { enabled };
   } catch (e) {
     return { enabled: false };


### PR DESCRIPTION
## [COSMO-309](https://2u-internal.atlassian.net/browse/COSMO-309)

Courseware search is not explicitly enabled by a flag on the backend, so the function should be renamed on the frontend.