### PR TITLE
fix: Replace WatchOutline with Notifications #1509

### DIFF
--- a/src/courseware/course/sidebar/sidebars/notifications/NotificationIcon.jsx
+++ b/src/courseware/course/sidebar/sidebars/notifications/NotificationIcon.jsx
@@ -1,6 +1,6 @@
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Icon } from '@openedx/paragon';
-import { WatchOutline } from '@openedx/paragon/icons';
+import { Notifications } from '@openedx/paragon/icons';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -13,7 +13,7 @@ const NotificationIcon = ({
   notificationColor,
 }) => (
   <>
-    <Icon src={WatchOutline} className="m-0 m-auto" alt={intl.formatMessage(messages.openNotificationTrigger)} />
+    <Icon src={Notifications} className="m-0 m-auto" alt={intl.formatMessage(messages.openNotificationTrigger)} />
     {status === 'active'
       ? (
         <span


### PR DESCRIPTION
[#1509](https://github.com/openedx/frontend-app-learning/issues/1509)

What changed?
Replace WathOutline icon with notifications
it looks more aesthetic

![image](https://github.com/user-attachments/assets/99a3788e-9bc4-4c2a-99b2-f9b297dd5d6e)


![Screenshot from 2024-11-01 15-43-47](https://github.com/user-attachments/assets/67e6c8cf-6498-4480-8d30-81193ab56fcd)

And Testing OK

If something needs to be modified, let me know, thank you!!!
Atte
Juan Carlos (Aulasneo)

Developer Checklist

Test suites passing
Documentation and test plan updated, if applicable
Received code-owner approving review