### PR TITLE
fix: update skip nav destination

### DIFF
--- a/src/tab-page/LoadedTabPage.jsx
+++ b/src/tab-page/LoadedTabPage.jsx
@@ -69,7 +69,7 @@ const LoadedTabPage = ({
         streakDiscountCouponEnabled={streakDiscountCouponEnabled}
         verifiedMode={verifiedMode}
       />
-      <main id="main-content" className="d-flex flex-column flex-grow-1">
+      <main className="d-flex flex-column flex-grow-1">
         <AlertList
           topic="outline"
           className="mx-5 mt-3"
@@ -79,7 +79,7 @@ const LoadedTabPage = ({
           }}
         />
         <CourseTabsNavigation tabs={tabs} className="mb-3" activeTabSlug={activeTabSlug} />
-        <div className="container-xl">
+        <div id="main-content" className="container-xl">
           {children}
         </div>
       </main>


### PR DESCRIPTION
## Description

This PR moves the target ID for the skip nav button from the `<main>` tag to the `children` wrapper. This allows the skip nav to skip the secondary navigation of the page tabs.

## Supporting Information

JIRA Ticket: [AU-1333 🔒](https://2u-internal.atlassian.net/browse/AU-1333)

> In the Learning MFE, the skip-nav in the outer most scope (the Learning MFE,) must redirect to the main content of the currently displayed sub-section, when in-courseware.  If in a MFE page (Home, Progress, Grading, etc.) the skip-nav should point to main content for page.
> 
> In most webpages, the SkipNav link jumps keyboard focus over the main header, which typically contains a lot of redundant navigation links or menus.  The SkipNav link is intended to save keystrokes for keyboard-only users (including but not limited to screen reader users).  The gist of this issue is that the Learning MFE is kinda special, in that the top of the `<main>` element – the most common destination for SkipNav links – is not the location of the main content; there is another layer of navigation elements in the Learning MFE (the Course, Progress, Dates etc. tabset).

## Testing

For the outline, progress, and dates tabs and the course content page run the following tests

1. Reload the page to reset keyboard focus to the top of the page.
2. Using your keyboard, navigate through the page until you activate the "Skip to main content" button
3. Click the button
4. Confirm that the page is navigate to the after the pages tabs
