### PR TITLE
chore: Update @edx/frontend-lib-learning-assistant to v2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "1.2.0",
         "@edx/frontend-component-header": "^5.6.0",
-        "@edx/frontend-lib-learning-assistant": "^2.2.4",
+        "@edx/frontend-lib-learning-assistant": "^2.4.1",
         "@edx/frontend-lib-special-exams": "^3.1.3",
         "@edx/frontend-platform": "^8.0.0",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2438,9 +2438,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.2.4.tgz",
-      "integrity": "sha512-EvN22XhDzzdIYrJY1TKEF/5zXuozC4tlKRo96+dSe9I7UAMg4zsLKC1zqY15oUuyB8rHo1ERYhQBG18uMepXrw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.4.1.tgz",
+      "integrity": "sha512-sq0kS7vE7FKjHFSwAz77nz/E0PmmS0e/AxLGtcit+9xNyYU6b5SrJA8BmH5C7tgvtaeGJER54w0ZTkndPAo5eA==",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -2463,7 +2463,7 @@
         "react-redux": "7.2.9",
         "react-router": "5.2.1 || ^6.0.0",
         "react-router-dom": "5.3.0 || ^6.0.0",
-        "redux": "4.1.2",
+        "redux": "^4",
         "regenerator-runtime": "0.13.11"
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "1.2.0",
     "@edx/frontend-component-header": "^5.6.0",
-    "@edx/frontend-lib-learning-assistant": "^2.2.4",
+    "@edx/frontend-lib-learning-assistant": "^2.4.1",
     "@edx/frontend-lib-special-exams": "^3.1.3",
     "@edx/frontend-platform": "^8.0.0",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
This update incorporates new experimental features for Xpert AI Assistant.

## Updated Features
- Fetches chat history when loading Xpert (https://github.com/edx/frontend-lib-learning-assistant/issues/64) ([bc2e7a1](https://github.com/edx/frontend-lib-learning-assistant/commit/bc2e7a13635e13e23962ddab271336e132ab2654))
- Removed unused gpt 4 experiment code (https://github.com/edx/frontend-lib-learning-assistant/issues/61) ([b89d9ec](https://github.com/edx/frontend-lib-learning-assistant/commit/b89d9ec4158ebc8f05ec5a0995e361ed21f853db))