### PR TITLE
feat: add configurable robots meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
     <% if (htmlWebpackPlugin.options.OPTIMIZELY_PROJECT_ID) { %>
       <script src="https://www.edx.org/optimizelyjs/<%= htmlWebpackPlugin.options.OPTIMIZELY_PROJECT_ID %>.js"></script>
     <% } %>
-    <% if (htmlWebpackPlugin.options.ROBOTS_CONTENT_TAG) { %>
-      <meta name="robots" content="<%= htmlWebpackPlugin.options.ROBOT_CONTENT_TAG %>">
+    <% if (htmlWebpackPlugin.options.META_TAG_ROBOTS_CONTENT_ATTR) { %>
+      <meta name="robots" content="<%= htmlWebpackPlugin.options.META_TAG_ROBOTS_CONTENT_ATTR %>">
     <% } %>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,9 @@
     <% if (htmlWebpackPlugin.options.OPTIMIZELY_PROJECT_ID) { %>
       <script src="https://www.edx.org/optimizelyjs/<%= htmlWebpackPlugin.options.OPTIMIZELY_PROJECT_ID %>.js"></script>
     <% } %>
+    <% if (htmlWebpackPlugin.options.ROBOTS_CONTENT_TAG) { %>
+      <meta name="robots" content="<%= htmlWebpackPlugin.options.ROBOT_CONTENT_TAG %>">
+    <% } %>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Enable config-based setting of `<meta name="robots" content="{value}">` tag to allow Learning MFE to instruct search crawlers / indexers how to handle its content.

Related PRs:
- https://github.com/openedx/frontend-build/pull/611

See also:
- [Robots meta tag reference](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)
- [AU-2285](https://2u-internal.atlassian.net/browse/AU-2285)