### PR TITLE
feat: update gating for chat component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "1.2.0",
         "@edx/frontend-component-header": "^5.8.0",
-        "@edx/frontend-lib-learning-assistant": "^2.6.0",
+        "@edx/frontend-lib-learning-assistant": "^2.9.0",
         "@edx/frontend-lib-special-exams": "^3.1.3",
         "@edx/frontend-platform": "^8.0.0",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2431,9 +2431,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.6.0.tgz",
-      "integrity": "sha512-73lggfdACTwpz6HA0VbjIetRxpWUMRyz4f79GIrmvHo2DvhICo84jVzbOSrwsvb43H0+52XjbHj6EeaBEDKHPA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.9.0.tgz",
+      "integrity": "sha512-Z85aRiMDv0N/QB8WTywsryJZ7GCtqwimxaW3knQU7dICn4UWRgqccHitoUtwZI6r6R6A57vn0T9Jpg5MZXJy+g==",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@optimizely/react-sdk": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "1.2.0",
     "@edx/frontend-component-header": "^5.8.0",
-    "@edx/frontend-lib-learning-assistant": "^2.6.0",
+    "@edx/frontend-lib-learning-assistant": "^2.9.0",
     "@edx/frontend-lib-special-exams": "^3.1.3",
     "@edx/frontend-platform": "^8.0.0",
     "@edx/openedx-atlas": "^0.6.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,13 @@ export const VERIFIED_MODES = [
   'paid-bootcamp',
 ] as const satisfies readonly string[];
 
+export const AUDIT_MODES = [
+  'audit',
+  'honor',
+  'unpaid-executive-education',
+  'unpaid-bootcamp',
+] as const satisfies readonly string[];
+
 export const WIDGETS = {
   DISCUSSIONS: 'DISCUSSIONS',
   NOTIFICATIONS: 'NOTIFICATIONS',

--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -3,9 +3,10 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { Xpert } from '@edx/frontend-lib-learning-assistant';
+import { getConfig } from '@edx/frontend-platform';
 import { injectIntl } from '@edx/frontend-platform/i18n';
 
-import { VERIFIED_MODES } from '@src/constants';
+import { AUDIT_MODES, VERIFIED_MODES } from '@src/constants';
 import { useModel } from '../../../generic/model-store';
 
 const Chat = ({
@@ -21,10 +22,14 @@ const Chat = ({
   } = useSelector(state => state.specialExams);
   const course = useModel('coursewareMeta', courseId);
 
-  const hasVerifiedEnrollment = (
+  const hasValidEnrollment = (
     enrollmentMode !== null
     && enrollmentMode !== undefined
-    && VERIFIED_MODES.includes(enrollmentMode)
+    && (
+      VERIFIED_MODES.includes(enrollmentMode)
+      // audit learners are only eligible if Xpert has been explicitly enabled for audit
+      || (AUDIT_MODES.includes(enrollmentMode) && getConfig().ENABLE_XPERT_AUDIT)
+    )
   );
 
   const validDates = () => {
@@ -42,7 +47,7 @@ const Chat = ({
 
   const shouldDisplayChat = (
     enabled
-    && (hasVerifiedEnrollment || isStaff) // display only to verified learners or staff
+    && (hasValidEnrollment || isStaff)
     && validDates()
     // it is necessary to check both whether the user is in an exam, and whether or not they are viewing an exam
     // this will prevent the learner from interacting with the tool at any point of the exam flow, even at the
@@ -50,11 +55,22 @@ const Chat = ({
     && !(activeAttempt?.attempt_id || exam?.id)
   );
 
+  const isUpgradeEligible = (
+    enrollmentMode !== null
+    && enrollmentMode !== undefined
+    && AUDIT_MODES.includes(enrollmentMode)
+  );
+
   return (
     <>
       {/* Use a portal to ensure that component overlay does not compete with learning MFE styles. */}
       {shouldDisplayChat && (createPortal(
-        <Xpert courseId={courseId} contentToolsEnabled={contentToolsEnabled} unitId={unitId} />,
+        <Xpert
+          courseId={courseId}
+          contentToolsEnabled={contentToolsEnabled}
+          unitId={unitId}
+          isUpgradEligible={isUpgradeEligible}
+        />,
         document.body,
       ))}
     </>

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -235,6 +235,12 @@ describe('Chat', () => {
   it('displays component for audit learner if explicitly enabled', async () => {
     getConfig.mockImplementation(() => ({ ENABLE_XPERT_AUDIT: true }));
 
+    store = await initializeTestStore({
+      courseMetadata: Factory.build('courseMetadata', {
+        access_expiration: { expiration_date: '' },
+      }),
+    });
+
     render(
       <BrowserRouter>
         <Chat
@@ -250,5 +256,31 @@ describe('Chat', () => {
 
     const chat = screen.queryByTestId(mockXpertTestId);
     expect(chat).toBeInTheDocument();
+  });
+
+  it('does not display component for audit learner if access deadline has passed', async () => {
+    getConfig.mockImplementation(() => ({ ENABLE_XPERT_AUDIT: true }));
+
+    store = await initializeTestStore({
+      courseMetadata: Factory.build('courseMetadata', {
+        access_expiration: { expiration_date: '2014-02-03T05:00:00Z' },
+      }),
+    });
+
+    render(
+      <BrowserRouter>
+        <Chat
+          enrollmentMode="audit"
+          isStaff={false}
+          enabled
+          courseId={courseId}
+          contentToolsEnabled={false}
+        />
+      </BrowserRouter>,
+      { store },
+    );
+
+    const chat = screen.queryByTestId(mockXpertTestId);
+    expect(chat).not.toBeInTheDocument();
   });
 });

--- a/src/courseware/course/chat/Chat.test.jsx
+++ b/src/courseware/course/chat/Chat.test.jsx
@@ -2,6 +2,8 @@ import { BrowserRouter } from 'react-router-dom';
 import React from 'react';
 import { Factory } from 'rosie';
 
+import { getConfig } from '@edx/frontend-platform';
+
 import {
   initializeMockApp,
   initializeTestStore,
@@ -27,6 +29,10 @@ jest.mock('@edx/frontend-lib-learning-assistant', () => {
     Xpert: () => (<div data-testid={mockXpertTestId}>mocked Xpert</div>),
   };
 });
+
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn().mockReturnValue({ ENABLE_XPERT_AUDIT: false }),
+}));
 
 initializeMockApp();
 
@@ -214,6 +220,26 @@ describe('Chat', () => {
         <Chat
           enrollmentMode="verified"
           isStaff
+          enabled
+          courseId={courseId}
+          contentToolsEnabled={false}
+        />
+      </BrowserRouter>,
+      { store },
+    );
+
+    const chat = screen.queryByTestId(mockXpertTestId);
+    expect(chat).toBeInTheDocument();
+  });
+
+  it('displays component for audit learner if explicitly enabled', async () => {
+    getConfig.mockImplementation(() => ({ ENABLE_XPERT_AUDIT: true }));
+
+    render(
+      <BrowserRouter>
+        <Chat
+          enrollmentMode="audit"
+          isStaff={false}
           enabled
           courseId={courseId}
           contentToolsEnabled={false}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -175,6 +175,7 @@ initialize({
         CHAT_RESPONSE_URL: process.env.CHAT_RESPONSE_URL || null,
         PRIVACY_POLICY_URL: process.env.PRIVACY_POLICY_URL || null,
         SHOW_UNGRADED_ASSIGNMENT_PROGRESS: process.env.SHOW_UNGRADED_ASSIGNMENT_PROGRESS || false,
+        ENABLE_XPERT_AUDIT: process.env.ENABLE_XPERT_AUDIT || false,
       }, 'LearnerAppConfig');
     },
   },


### PR DESCRIPTION
## [COSMO-574](https://2u-internal.atlassian.net/browse/COSMO-574)

Enrollment based gating for the chat feature should be toggle-able by a frontend setting. This PR introduces the `ENABLE_XPERT_AUDIT` setting which is used to determine whether or not audit learners should have access to the chat tool. 

Additionally, a new prop should be passed to the `Xpert` component, which can be used to determine whether or not a given learner is eligible to upgrade in a specific course.

This PR should not be merged until after https://github.com/edx/frontend-lib-learning-assistant/pull/71 has been merged and a new version of the library has been released.