### PR TITLE
fix: update iframe feature policy

### DIFF
--- a/src/courseware/course/sequence/Unit/ContentIFrame.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.jsx
@@ -20,7 +20,7 @@ import * as hooks from './hooks';
  * Changes to it should be vetted by them (security@edx.org).
  */
 export const IFRAME_FEATURE_POLICY = (
-  'microphone *; camera *; midi *; geolocation *; encrypted-media *; clipboard-write *'
+  'microphone *; camera *; midi *; geolocation *; encrypted-media *; clipboard-write *; autoplay *'
 );
 
 export const testIDs = StrictDict({


### PR DESCRIPTION
## Description

It's a fix for [this issue](https://github.com/openedx/edx-platform/issues/35695). It's needed to fix the Xblock video play button not working on Chrome for youtube videos due to the iframe security policy. Chrome blocks playing a youtube video programmatically when the iframe is not inside the parent window, which in our case is inside the Xblock iframe.

## Testing Instructions

- Check out master/main
- Add a YouTube video to a course unit
- Preview the course in Chrome(or any Chromium-based browser)
- Navigate to the respective video section and play the video using the video player's play button. The video will not play.

Now check out this PR.
- Refresh the page and play the video again. 
- It should start playing this time.

