### PR TITLE
fix(AU-2174): Fix left sidebar throwing 404

### DIFF
--- a/src/courseware/course/sidebar/sidebars/course-outline/hooks.jsx
+++ b/src/courseware/course/sidebar/sidebars/course-outline/hooks.jsx
@@ -1,8 +1,10 @@
 import { useContext, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { useModel } from '@src/generic/model-store';
-import SidebarContext from '@src/courseware/course/sidebar/SidebarContext';
+import OldSidebarContext from '@src/courseware/course/sidebar/SidebarContext';
+import NewSidebarContext from '@src/courseware/course/new-sidebar/SidebarContext';
 import { getCoursewareOutlineSidebarSettings } from '@src/courseware/data/selectors';
 import { ID } from './constants';
 
@@ -10,9 +12,13 @@ import { ID } from './constants';
 export const useCourseOutlineSidebar = () => {
   const isCollapsedOutlineSidebar = window.sessionStorage.getItem('hideCourseOutlineSidebar');
   const { enableNavigationSidebar: isEnabledSidebar } = useSelector(getCoursewareOutlineSidebarSettings);
+  const { courseId } = useParams();
+  const course = useModel('coursewareMeta', courseId);
+  const { isNewDiscussionSidebarViewEnabled } = useModel('courseHomeMeta', courseId);
+  const SidebarContext = isNewDiscussionSidebarViewEnabled ? NewSidebarContext : OldSidebarContext;
+
   const {
     unitId,
-    courseId,
     initialSidebar,
     currentSidebar,
     toggleSidebar,
@@ -22,7 +28,6 @@ export const useCourseOutlineSidebar = () => {
   const isOpenSidebar = !initialSidebar && isEnabledSidebar && !isCollapsedOutlineSidebar;
   const [isOpen, setIsOpen] = useState(true);
 
-  const course = useModel('coursewareMeta', courseId);
   const {
     entranceExamEnabled,
     entranceExamPassed,


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/AU-2174
https://github.com/openedx/frontend-app-learning/issues/1437

**Issue:**

[useCourseOutlineSidebar hook](https://github.com/openedx/frontend-app-learning/blob/master/src/courseware/course/sidebar/sidebars/course-outline/hooks.jsx#L20) needs to use the `NewSidebarContext` if `isNewDiscussionSidebarViewEnabled` is `true`. At the time we set the SidebarProvider in the [Course file](https://github.com/openedx/frontend-app-learning/blob/master/src/courseware/course/Course.jsx#L79) we use the old side bar (SidebarProvider) or the new one (NewSidebarProvider) depending on the `isNewDiscussionSidebarViewEnabled` value. We are not taking that into account when calling `useContext` in the mentioned hook, so all values returned from it are `undefined` since we try to get values from a provider that was not set previously.

New Discussion Sidebar enabled and New Left Sidebar enabled
Result: Error

New Discussion Sidebar enabled and New Left Sidebar disabled
Result: No error

New Discussion Sidebar disabled and New Left Sidebar enabled
Result: No error

New Discussion Sidebar disabled and New Left Sidebar disabled
Result: No error

**Fix:**

Depending on `isNewDiscussionSidebarViewEnabled` use `SidebarContext` or `NewSidebarContext` inside of `useCourseOutlineSidebar` hook.

https://www.loom.com/share/901c05d5dc024d9da4d07da020701213?sid=cce15834-2aeb-4ed6-8225-dedbf24e4137

