### PR TITLE
feat: Updated frontend-lib-learning-assistant to v2.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "1.2.0",
         "@edx/frontend-component-header": "^5.8.0",
-        "@edx/frontend-lib-learning-assistant": "^2.10.0",
+        "@edx/frontend-lib-learning-assistant": "^2.13.0",
         "@edx/frontend-lib-special-exams": "^3.1.3",
         "@edx/frontend-platform": "^8.0.0",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2431,9 +2431,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.10.0.tgz",
-      "integrity": "sha512-Kaz6mPUuyXz7WU9GLsxD9UIxwgSZfZixUBniFSNOzIs+pCykEDx70HgSrQ5gGZQ1+y2Hszivcwj9/kONhYhDrQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.13.0.tgz",
+      "integrity": "sha512-vSsy2+qi6imjCgoInzYKb7WtnE73VFoA5Q6doARM8adj/ODk+FwopChS3vw3gDRFna45jKZu4whvmkpy3WuItg==",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@optimizely/react-sdk": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "1.2.0",
     "@edx/frontend-component-header": "^5.8.0",
-    "@edx/frontend-lib-learning-assistant": "^2.10.0",
+    "@edx/frontend-lib-learning-assistant": "^2.13.0",
     "@edx/frontend-lib-special-exams": "^3.1.3",
     "@edx/frontend-platform": "^8.0.0",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
Updated [frontend-lib-learning-assistant](https://github.com/edx/frontend-lib-learning-assistant) from v2.10.0 to v2.13.0 ([see changes](https://github.com/edx/frontend-lib-learning-assistant/compare/v2.10.0...v2.13.0)).