### PR TITLE
feat: Updated frontend-lib-learning-assistant to v2.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "1.2.0",
         "@edx/frontend-component-header": "^5.8.0",
-        "@edx/frontend-lib-learning-assistant": "^2.13.0",
+        "@edx/frontend-lib-learning-assistant": "^2.14.1",
         "@edx/frontend-lib-special-exams": "^3.1.3",
         "@edx/frontend-platform": "^8.0.0",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2431,9 +2431,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.13.0.tgz",
-      "integrity": "sha512-vSsy2+qi6imjCgoInzYKb7WtnE73VFoA5Q6doARM8adj/ODk+FwopChS3vw3gDRFna45jKZu4whvmkpy3WuItg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.14.1.tgz",
+      "integrity": "sha512-BXYfJQyjK/Vr5pV1ca+AWeS7JjVklCy7SPy/zsf1fbMTH2af9VvuMYvDHVWCfKrxX30H1wMHS2SYL4Vm1oVbfw==",
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
         "@optimizely/react-sdk": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "1.2.0",
     "@edx/frontend-component-header": "^5.8.0",
-    "@edx/frontend-lib-learning-assistant": "^2.13.0",
+    "@edx/frontend-lib-learning-assistant": "^2.14.1",
     "@edx/frontend-lib-special-exams": "^3.1.3",
     "@edx/frontend-platform": "^8.0.0",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
Updated [frontend-lib-learning-assistant](https://github.com/edx/frontend-lib-learning-assistant) from v2.13.0 to v2.14.1 ([see changes](https://github.com/edx/frontend-lib-learning-assistant/compare/v2.13.0...v2.14.1)).

Feature updates:
- [Update to scroll behavior and UX tweaks](https://github.com/edx/frontend-lib-learning-assistant/pull/77)