### PR TITLE
Bump paragon to v22.13.0, fix minor TypeScript warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4180,9 +4180,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "22.10.0",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.10.0.tgz",
-      "integrity": "sha512-uwH/vN6PM9v77NIJ0MUyREdF+3LY/kXIVaOAN+TJKi6JexKoqM7jR30wGuI83YGymwthXDc8T4J54O/wXDoxrQ==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.13.0.tgz",
+      "integrity": "sha512-yCbAYGQzpVQj65nFvnqDRU4V6MhZN2LAO/qzFJUV+RW2Riudef7KI1No/+nePI4tYAMhnuPwZ1EDiJQ2lBNYew==",
       "license": "Apache-2.0",
       "workspaces": [
         "example",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "files": [
       {
         "path": "dist/*.js",
-        "maxSize": "1300kB"
+        "maxSize": "1350kB"
       }
     ],
     "normalizeFilenames": "^.+?(\\..+?)\\.\\w+$"

--- a/src/courseware/course/new-sidebar/SidebarContextProvider.tsx
+++ b/src/courseware/course/new-sidebar/SidebarContextProvider.tsx
@@ -25,8 +25,9 @@ const SidebarProvider: React.FC<Props> = ({
 }) => {
   const { verifiedMode } = useModel('courseHomeMeta', courseId);
   const topic = useModel('discussionTopics', unitId);
-  const shouldDisplayFullScreen = useWindowSize().width < breakpoints.large.minWidth;
-  const shouldDisplaySidebarOpen = useWindowSize().width > breakpoints.medium.minWidth;
+  const windowWidth = useWindowSize().width ?? window.innerWidth;
+  const shouldDisplayFullScreen = windowWidth < breakpoints.large.minWidth;
+  const shouldDisplaySidebarOpen = windowWidth > breakpoints.medium.minWidth;
   const query = new URLSearchParams(window.location.search);
   const isInitiallySidebarOpen = shouldDisplaySidebarOpen || query.get('sidebar') === 'true';
   const sidebarKey = `sidebar.${courseId}`;


### PR DESCRIPTION
The PR https://github.com/openedx/frontend-app-learning/pull/1571 was failing its type checks, so this PR includes the same version bump but also fixes the type issue (on first render, the window size from Paragon's can be `undefined`, in order to avoid hydration errors if using SSR).