### PR TITLE
fix: updated notifications preferences url

### DIFF
--- a/src/preferences-unsubscribe/index.jsx
+++ b/src/preferences-unsubscribe/index.jsx
@@ -69,7 +69,7 @@ const PreferencesUnsubscribe = () => {
                     values={{
                       preferenceCenterUrl: (
                         <Hyperlink
-                          destination={`${getConfig().ACCOUNT_SETTINGS_URL}/notifications`}
+                          destination={`${getConfig().ACCOUNT_SETTINGS_URL}/#notifications`}
                         >
                           {intl.formatMessage(messages.preferenceCenterUrl)}
                         </Hyperlink>


### PR DESCRIPTION
Description
Updated the notifications preferences section URL which is used on different MFEs to redirect the user to the notifications preferences center.

Old URL: https://account.edx.org/notifications
New URL: https://account.edx.org/#notifications