### PR TITLE
fix: accessibility issues on outline and unit pages

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { AlertList } from '../../generic/user-messages';
@@ -29,7 +29,8 @@ import WelcomeMessage from './widgets/WelcomeMessage';
 import ProctoringInfoPanel from './widgets/ProctoringInfoPanel';
 import AccountActivationAlert from '../../alerts/logistration-alert/AccountActivationAlert';
 
-const OutlineTab = ({ intl }) => {
+const OutlineTab = () => {
+  const intl = useIntl();
   const {
     courseId,
     proctoringPanelStatus,
@@ -41,6 +42,8 @@ const OutlineTab = ({ intl }) => {
     title,
     userTimezone,
   } = useModel('courseHomeMeta', courseId);
+
+  const expandButtonRef = useRef();
 
   const {
     accessExpiration,
@@ -159,12 +162,12 @@ const OutlineTab = ({ intl }) => {
             </>
           )}
           <StartOrResumeCourseCard />
-          <WelcomeMessage courseId={courseId} />
+          <WelcomeMessage courseId={courseId} nextElementRef={expandButtonRef} />
           {rootCourseId && (
             <>
               <div className="row w-100 m-0 mb-3 justify-content-end">
                 <div className="col-12 col-md-auto p-0">
-                  <Button variant="outline-primary" block onClick={() => { setExpandAll(!expandAll); }}>
+                  <Button ref={expandButtonRef} variant="outline-primary" block onClick={() => { setExpandAll(!expandAll); }}>
                     {expandAll ? intl.formatMessage(messages.collapseAll) : intl.formatMessage(messages.expandAll)}
                   </Button>
                 </div>
@@ -225,8 +228,4 @@ const OutlineTab = ({ intl }) => {
   );
 };
 
-OutlineTab.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(OutlineTab);
+export default OutlineTab;

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -292,6 +292,18 @@ describe('Outline Tab', () => {
         showMoreButton = screen.getByRole('button', { name: 'Show More' });
         expect(showMoreButton).toBeInTheDocument();
       });
+
+      fit('dismisses message', async () => {
+        expect(screen.getByTestId('alert-container-welcome')).toBeInTheDocument();
+        const dismissButton = screen.queryByRole('button', { name: 'Dismiss' });
+        const expandButton = screen.queryByRole('button', { name: 'Expand all' });
+
+        fireEvent.click(dismissButton);
+
+        expect(expandButton).toHaveFocus();
+
+        expect(screen.queryByText('Welcome Message')).toBeNull();
+      });
     });
 
     it('ignores comments and misformatted HTML', async () => {

--- a/src/course-home/outline-tab/widgets/WelcomeMessage.jsx
+++ b/src/course-home/outline-tab/widgets/WelcomeMessage.jsx
@@ -59,8 +59,8 @@ const WelcomeMessage = ({ courseId, nextElementRef }) => {
       actions={messageCanBeShortened ? [
         <Button
           onClick={() => {
-            if (showShortMessage && messageBodyRef.current) {
-              messageBodyRef.current.focus();
+            if (showShortMessage) {
+              messageBodyRef.current?.focus();
             }
 
             setShowShortMessage(!showShortMessage);

--- a/src/course-home/outline-tab/widgets/WelcomeMessage.jsx
+++ b/src/course-home/outline-tab/widgets/WelcomeMessage.jsx
@@ -72,8 +72,7 @@ const WelcomeMessage = ({ courseId, nextElementRef }) => {
         </Button>,
       ] : []}
     >
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-      <div ref={messageBodyRef} tabIndex={0}>
+      <div ref={messageBodyRef} tabIndex="-1">
         <TransitionReplace className="mb-3" enterDuration={400} exitDuration={200}>
           {showShortMessage ? (
             <LmsHtmlFragment

--- a/src/courseware/course/bookmark/BookmarkButton.jsx
+++ b/src/courseware/course/bookmark/BookmarkButton.jsx
@@ -1,10 +1,9 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { StatefulButton } from '@openedx/paragon';
+import { Icon, StatefulButton } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { useDispatch } from 'react-redux';
-import BookmarkOutlineIcon from './BookmarkOutlineIcon';
-import BookmarkFilledIcon from './BookmarkFilledIcon';
+import { Bookmark, BookmarkBorder } from '@openedx/paragon/icons';
 import { removeBookmark, addBookmark } from './data/thunks';
 
 const addBookmarkLabel = (
@@ -45,7 +44,8 @@ const BookmarkButton = ({
       className="px-1 ml-n1 btn-sm text-primary-500"
       onClick={toggleBookmark}
       state={state}
-      disabledStates={['defaultProcessing', 'bookmarkedProcessing']}
+      aria-busy={isProcessing}
+      disabled={isProcessing}
       labels={{
         default: addBookmarkLabel,
         defaultProcessing: addBookmarkLabel,
@@ -53,10 +53,10 @@ const BookmarkButton = ({
         bookmarkedProcessing: hasBookmarkLabel,
       }}
       icons={{
-        default: <BookmarkOutlineIcon className="text-primary" />,
-        defaultProcessing: <BookmarkOutlineIcon className="text-primary" />,
-        bookmarked: <BookmarkFilledIcon className="text-primary" />,
-        bookmarkedProcessing: <BookmarkFilledIcon className="text-primary" />,
+        default: <Icon src={BookmarkBorder} className="text-primary" />,
+        defaultProcessing: <Icon src={BookmarkBorder} className="text-primary" />,
+        bookmarked: <Icon src={Bookmark} className="text-primary" />,
+        bookmarkedProcessing: <Icon src={Bookmark} className="text-primary" />,
       }}
     />
   );

--- a/src/courseware/course/bookmark/BookmarkButton.jsx
+++ b/src/courseware/course/bookmark/BookmarkButton.jsx
@@ -41,7 +41,7 @@ const BookmarkButton = ({
   return (
     <StatefulButton
       variant="link"
-      className="px-1 ml-n1 btn-sm text-primary-500"
+      className={`px-1 ml-n1 btn-sm text-primary-500 ${isProcessing && 'disabled'}`}
       onClick={toggleBookmark}
       state={state}
       aria-busy={isProcessing}

--- a/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
+++ b/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBookmark } from '@fortawesome/free-solid-svg-icons';
-
-const BookmarkFilledIcon = (props) => <FontAwesomeIcon icon={faBookmark} {...props} />;
-
-export default BookmarkFilledIcon;

--- a/src/courseware/course/bookmark/BookmarkOutlineIcon.jsx
+++ b/src/courseware/course/bookmark/BookmarkOutlineIcon.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBookmark } from '@fortawesome/free-regular-svg-icons';
-
-const BookmarkOutlineIcon = (props) => <FontAwesomeIcon icon={faBookmark} {...props} />;
-
-export default BookmarkOutlineIcon;

--- a/src/courseware/course/bookmark/index.js
+++ b/src/courseware/course/bookmark/index.js
@@ -1,3 +1,1 @@
 export { default as BookmarkButton } from './BookmarkButton';
-export { default as BookmarkFilledIcon } from './BookmarkFilledIcon';
-export { default as BookmarkOutlineIcon } from './BookmarkFilledIcon';

--- a/src/courseware/course/sequence/Unit/__snapshots__/index.test.jsx.snap
+++ b/src/courseware/course/sequence/Unit/__snapshots__/index.test.jsx.snap
@@ -34,11 +34,11 @@ exports[`Unit component output snapshot: not bookmarked, do not show content 1`]
       unitTitle="unit-title"
     />
   </div>
-  <h2
+  <p
     className="sr-only"
   >
     Level 2 headings may be created by course providers in the future.
-  </h2>
+  </p>
   <BookmarkButton
     isBookmarked={false}
     isProcessing={false}

--- a/src/courseware/course/sequence/Unit/index.jsx
+++ b/src/courseware/course/sequence/Unit/index.jsx
@@ -52,7 +52,7 @@ const Unit = ({
         <h3 className="h3">{unit.title}</h3>
         <UnitTitleSlot courseId={courseId} unitId={id} unitTitle={unit.title} />
       </div>
-      <h2 className="sr-only">{formatMessage(messages.headerPlaceholder)}</h2>
+      <p className="sr-only">{formatMessage(messages.headerPlaceholder)}</p>
       <BookmarkButton
         unitId={unit.id}
         isBookmarked={unit.bookmarked}

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
@@ -47,6 +47,7 @@ const UnitButton = ({
       {showCompletion && complete ? <CompleteIcon size="sm" className="text-success ml-2" /> : null}
       {bookmarked ? (
         <Icon
+          data-testid="bookmark-icon"
           src={Bookmark}
           className="text-primary small position-absolute"
           style={{ top: '-3px', right: '5px' }}

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
@@ -1,13 +1,13 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 import classNames from 'classnames';
-import { Button } from '@openedx/paragon';
+import { Button, Icon } from '@openedx/paragon';
+import { Bookmark } from '@openedx/paragon/icons';
 
 import UnitIcon from './UnitIcon';
 import CompleteIcon from './CompleteIcon';
-import BookmarkFilledIcon from '../../bookmark/BookmarkFilledIcon';
 
 const UnitButton = ({
   onClick,
@@ -46,7 +46,8 @@ const UnitButton = ({
       {showTitle && <span className="unit-title">{title}</span>}
       {showCompletion && complete ? <CompleteIcon size="sm" className="text-success ml-2" /> : null}
       {bookmarked ? (
-        <BookmarkFilledIcon
+        <Icon
+          src={Bookmark}
           className="text-primary small position-absolute"
           style={{ top: '-3px', right: '5px' }}
         />

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
@@ -63,17 +63,17 @@ describe('Unit Button', () => {
   });
 
   it('does not show bookmark', () => {
-    const { container } = render(<UnitButton {...mockData} />);
-    container.querySelectorAll('svg').forEach(icon => {
-      expect(icon).not.toHaveClass('fa-bookmark');
-    });
+    const { queryByTestId } = render(<UnitButton {...mockData} />);
+    expect(queryByTestId('bookmark-icon')).toBeNull();
   });
 
   it('shows bookmark', () => {
     const { container } = render(<UnitButton {...mockData} unitId={bookmarkedUnit.id} />, { wrapWithRouter: true });
     const buttonIcons = container.querySelectorAll('svg');
     expect(buttonIcons).toHaveLength(3);
-    expect(buttonIcons[2]).toHaveClass('fa-bookmark');
+
+    const bookmarkIcon = buttonIcons[2].closest('span');
+    expect(bookmarkIcon.getAttribute('data-testid')).toBe('bookmark-icon');
   });
 
   it('handles the click', () => {


### PR DESCRIPTION
## Description

This PR fixes the following accessibility issues:

1. Header used for screenreader only text
2. Element focus when expanding and dismissing welcome message
3. Bookmark button using wrong ARIA attributing while processing bookmark status

## Supporting Information
JIRA Tickets: [AU-2368 🔒](https://2u-internal.atlassian.net/browse/AU-2368), [AU-2369 🔒](https://2u-internal.atlassian.net/browse/AU-2369), and [AU-2370 🔒](https://2u-internal.atlassian.net/browse/AU-2370)

AU-2368
> The visually hidden heading "Level 2 headings may be created by course providers in the future." acts as a
hint and does not qualify as a heading.
>
> Text that does not have the purpose of a heading either visually or structurally must not use heading markup, otherwise this will create a confusing heading structure for screen reader users. This is a failure of [WCAG 1.3.1 Info and Relationships](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html).

AU-2369
>  In course updates, the “Show More” and “Dismiss” buttons dynamically add or remove content from the course home. Dynamically-added content needs to be added to the focus order directly after the element that exposed the content, or keyboard focus needs to be moved to the new content.
> 
> When keyboard users select the “Show More” button, the keyboard focus moves to the "Show Less" control instead of moving to the newly added content. Please move the keyboard focus to the newly added content on activating "Show More" control.
>
> When the “Dismiss” button is pressed, the keyboard focus returns to the body/top of the page, which is not a logical order. This can make the user interface difficult to navigate and understand. Ensure that the order in which elements receive keyboard focus follows a meaningful and logical sequence. For example, if the “Dismiss” button removes content, the keyboard focus could move to the previous interactive element.

AU-2370
> The “Bookmark this page” button toggles the aria-disabled attribute very quickly, which can be confusing to screen reader users if they are given delayed information about the button’s availability. Please remove the aria-disabled attribute and use an aria-busy attribute when the button is updating to avoid confusion for the screen reader users.

## Testing

AU-2369
1. Navigate to a course outline that has a welcome message
4. Using a keyboard, click on the "Show more" button
5. Press the tab button on the keyboard, confirm that the focus is not on the "Show less" button
6. Confirm that if there is a interactive element in the welcome message, it received the focus
7. Click the "Show less" button
8. Confirm that the focus remains on the button
9. Click on the "Dismiss" button and confirm that the focus moved to the "Expand all" button

AU-2370
1. Open the first unit in course
2. Confirm that the bookmark is outlined
3. Open browser dev tools
4. Confirm that `aria-busy=false` for the bookmark button
5. Click on the bookmark
6. Confirm that `aria-busy` was updated quickly
7. Confirm that the bookmark is filled