### PR TITLE
fix: Unify Xpert audit trial eligibility between backend and frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "fedx-scripts webpack-dev-server --progress",
     "dev": "PUBLIC_PATH=/learning/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "fedx-scripts jest --coverage --passWithNoTests",
+    "test:watch": "fedx-scripts jest --watch --passWithNoTests",
     "types": "tsc --noEmit"
   },
   "author": "edX",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,6 +55,13 @@ export const AUDIT_MODES = [
   'unpaid-bootcamp',
 ] as const satisfies readonly string[];
 
+// In sync with CourseMode.UPSELL_TO_VERIFIED_MODES
+// https://github.com/openedx/edx-platform/blob/master/common/djangoapps/course_modes/models.py#L231
+export const ALLOW_UPSELL_MODES = [
+  'audit',
+  'honor',
+] as const satisfies readonly string[];
+
 export const WIDGETS = {
   DISCUSSIONS: 'DISCUSSIONS',
   NOTIFICATIONS: 'NOTIFICATIONS',

--- a/src/courseware/course/chat/Chat.jsx
+++ b/src/courseware/course/chat/Chat.jsx
@@ -25,7 +25,7 @@ const Chat = ({
   // If is disabled or taking an exam, we don't show the chat.
   if (!enabled || activeAttempt?.attempt_id || exam?.id) { return null; }
 
-  // If is not staff and doesn't have an entollment, we don't show the chat.
+  // If is not staff and doesn't have an enrollment, we don't show the chat.
   if (!isStaff && !enrollmentMode) { return null; }
 
   const verifiedMode = VERIFIED_MODES.includes(enrollmentMode); // Enrollment verified


### PR DESCRIPTION
## Description
Ticket: [COSMO-612 🔒](https://2u-internal.atlassian.net/browse/COSMO-612)

These changes improve the definition of the Xpert audit trial eligibility and make consistent between backend and frontend.