### PR TITLE
feat: close sidebar on mobile after selecting a unit

### DIFF
--- a/src/courseware/course/sidebar/sidebars/course-outline/hooks.jsx
+++ b/src/courseware/course/sidebar/sidebars/course-outline/hooks.jsx
@@ -85,6 +85,11 @@ export const useCourseOutlineSidebar = () => {
 
     logEvent('edx.ui.lms.sequence.tab_selected', 'left');
     dispatch(checkBlockCompletion(courseId, sequenceId, activeUnitId));
+
+    // Hide the sidebar after selecting a unit on a mobile device.
+    if (shouldDisplayFullScreen) {
+      handleToggleCollapse();
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description

When a user selects a unit on the course outline sidebar, it remains open. This behavior can be confusing on mobile devices because the sidebar is displayed on the entire screen. This PR changes the behavior to close the sidebar once the learner selects the unit.

## Testing instructions
1. Ensure you have enabled the `courseware.enable_navigation_sidebar` Waffle flag.
2. Open any course unit on a mobile device.
3. Open the sidebar on the left side.
4. Select any unit and check that the sidebar was closed afterward.

_Private-ref: [BB-334](https://tasks.opencraft.com/browse/BB-334) (temporary)_ 