### PR TITLE
fix: Ugly appearance of the Start/Resume Course button at the top of the course outline

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -444,6 +444,22 @@
   height: 56px !important;
 }
 
+@include media-breakpoint-down(xs) {
+  .course-outline-tab .pgn__card {
+    .pgn__card-header {
+      display: block;
+  
+      .pgn__card-header-content {
+        margin-top: 0;
+      }
+    }
+    
+    .pgn__card-header-actions {
+      margin-left: 0;
+    }
+  }
+}
+
 // Import component-specific sass files
 @import "courseware/course/celebration/CelebrationModal.scss";
 @import "courseware/course/sidebar/sidebars/discussions/Discussions.scss";


### PR DESCRIPTION
Fix: Improved Styling of the "Start/Resume Course" Button on Mobile Devices

**Summary**

On mobile devices, the "Start/Resume Course" button had an inconsistent and visually unappealing layout at the top of the course outline. This PR improves its alignment and spacing, ensuring a cleaner and more polished appearance.

**Changes**

Adjusted button positioning for better alignment on mobile screens.
Improved spacing and padding to enhance visual balance.
Before & After (Mobile)

Before:
<img width="1359" alt="Снимок экрана 2025-02-11 в 18 41 45" src="https://github.com/user-attachments/assets/dcbc2e4f-d849-4862-b5fb-18d74cefb33e" />

After:
<img width="1359" alt="Снимок экрана 2025-02-11 в 18 42 10" src="https://github.com/user-attachments/assets/8fd8d49b-3160-4fbc-82df-89b923ad9192" />

Now, the button integrates more seamlessly with the course outline, improving the mobile user experience.







