### PR TITLE
chore: make sure links point to MFE not legacy

### DIFF
--- a/src/shared/links.jsx
+++ b/src/shared/links.jsx
@@ -46,7 +46,7 @@ const IntlProfileLink = ({ intl }) => {
     <Hyperlink
       variant="muted"
       isInline
-      destination={`${getConfig().LMS_BASE_URL}/u/${username}`}
+      destination={`${getConfig().ACCOUNT_PROFILE_URL}/u/${username}`}
     >
       {intl.formatMessage(messages.profileLink)}
     </Hyperlink>


### PR DESCRIPTION
Something happened on @deborahgu 's PR https://github.com/openedx/frontend-app-learning/pull/1584 that confused GitHub and prevented us from merging it.

This PR is identical.