### PR TITLE
feat: update version of frontend-lib-special-exams library from 3.2.0 to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2457,10 +2457,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-3.2.0.tgz",
-      "integrity": "sha512-2eaqx3o7z/qagP52cHbDkBZ0WrPLzZNf3y7uJnLzVbG3hdAEx83Z1LMlxkGXxPo4eY6GDWN4hxfyBYYxiFL6sQ==",
-      "license": "AGPL-3.0",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-3.2.1.tgz",
+      "integrity": "sha512-NDS3QF2HeHii5XnNziK0GdZ9IiqYjfxVMCmDbz79jLTSVtR0BVlMCo5QkD6kLu0WG8jaNBgjlb1InbnsKn7mCA==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",
         "@fortawesome/free-brands-svg-icons": "5.11.2",


### PR DESCRIPTION
**Description**

This commit updates the version of the `frontend-lib-special-exams` library from `3.2.0` to `3.2.1`. The full changelog is available openedx/frontend-lib-special-exams@3.2.0...3.2.1: https://github.com/openedx/frontend-lib-special-exams/compare/v3.2.0...v3.2.1.

The changes in this new version are summarized below.
* Update exam message for submitted proctored exams with more accurate language.