### PR TITLE
feat: improved accessibility skipping to main content

### DIFF
--- a/src/course-home/dates-tab/DatesTab.jsx
+++ b/src/course-home/dates-tab/DatesTab.jsx
@@ -13,11 +13,16 @@ import SuggestedScheduleHeader from '../suggested-schedule-messaging/SuggestedSc
 import ShiftDatesAlert from '../suggested-schedule-messaging/ShiftDatesAlert';
 import UpgradeToCompleteAlert from '../suggested-schedule-messaging/UpgradeToCompleteAlert';
 import UpgradeToShiftDatesAlert from '../suggested-schedule-messaging/UpgradeToShiftDatesAlert';
+import { useScrollToContent } from '../../generic/hooks';
+
+const MAIN_CONTENT_ID = 'main-content-heading';
 
 const DatesTab = ({ intl }) => {
   const {
     courseId,
   } = useSelector(state => state.courseHome);
+
+  useScrollToContent(MAIN_CONTENT_ID);
 
   const {
     isSelfPaced,
@@ -43,7 +48,7 @@ const DatesTab = ({ intl }) => {
 
   return (
     <>
-      <div role="heading" aria-level="1" className="h2 my-3">
+      <div id={MAIN_CONTENT_ID} tabIndex="-1" role="heading" aria-level="1" className="h2 my-3">
         {intl.formatMessage(messages.title)}
       </div>
       {isSelfPaced && hasDeadlines && (

--- a/src/course-home/progress-tab/ProgressHeader.jsx
+++ b/src/course-home/progress-tab/ProgressHeader.jsx
@@ -1,11 +1,16 @@
+import React from 'react';
+
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { useSelector } from 'react-redux';
 
 import { useModel } from '../../generic/model-store';
+import { useScrollToContent } from '../../generic/hooks';
 
 import messages from './messages';
+
+const MAIN_CONTENT_ID = 'main-content-heading';
 
 const ProgressHeader = () => {
   const intl = useIntl();
@@ -13,6 +18,8 @@ const ProgressHeader = () => {
     courseId,
     targetUserId,
   } = useSelector(state => state.courseHome);
+
+  useScrollToContent(MAIN_CONTENT_ID);
 
   const { administrator, userId } = getAuthenticatedUser();
 
@@ -26,7 +33,7 @@ const ProgressHeader = () => {
 
   return (
     <div className="row w-100 m-0 mt-3 mb-4 justify-content-between">
-      <h1>{pageTitle}</h1>
+      <h1 id={MAIN_CONTENT_ID} tabIndex="-1">{pageTitle}</h1>
       {administrator && studioUrl && (
       <Button variant="outline-primary" size="sm" className="align-self-center" href={studioUrl}>
         {intl.formatMessage(messages.studioLink)}

--- a/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
+++ b/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Icon } from '@openedx/paragon';
+import { Bookmark } from '@openedx/paragon/icons';
+
+const BookmarkFilledIcon = (props) => <Icon src={Bookmark} screenReaderText="Bookmark" {...props} />;
+
+export default BookmarkFilledIcon;

--- a/src/courseware/course/bookmark/index.js
+++ b/src/courseware/course/bookmark/index.js
@@ -1,1 +1,2 @@
 export { default as BookmarkButton } from './BookmarkButton';
+export { default as BookmarkFilledIcon } from './BookmarkFilledIcon';

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -76,7 +76,7 @@ describe('Sequence Navigation', () => {
     const onNavigate = jest.fn();
     render(<SequenceNavigation {...mockData} {...{ onNavigate }} />, { wrapWithRouter: true });
 
-    const unitButtons = screen.getAllByRole('link', { name: /\d+/ });
+    const unitButtons = screen.getAllByRole('tabpanel', { name: /\d+/ });
     expect(unitButtons).toHaveLength(unitButtons.length);
     unitButtons.forEach(button => fireEvent.click(button));
     expect(onNavigate).toHaveBeenCalledTimes(unitButtons.length);

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
@@ -50,7 +50,7 @@ describe('Sequence Navigation Dropdown', () => {
       });
       const dropdownMenu = container.querySelector('.dropdown-menu');
       // Only the current unit should be marked as active.
-      getAllByRole(dropdownMenu, 'link', { hidden: true }).forEach(button => {
+      getAllByRole(dropdownMenu, 'tabpanel', { hidden: true }).forEach(button => {
         if (button.textContent === unit.display_name) {
           expect(button).toHaveClass('active');
         } else {
@@ -72,7 +72,7 @@ describe('Sequence Navigation Dropdown', () => {
       fireEvent.click(dropdownToggle);
     });
     const dropdownMenu = container.querySelector('.dropdown-menu');
-    getAllByRole(dropdownMenu, 'link', { hidden: true }).forEach(button => fireEvent.click(button));
+    getAllByRole(dropdownMenu, 'tabpanel', { hidden: true }).forEach(button => fireEvent.click(button));
     expect(onNavigate).toHaveBeenCalledTimes(unitBlocks.length);
     unitBlocks.forEach((unit, index) => {
       expect(onNavigate).toHaveBeenNthCalledWith(index + 1, unit.id);

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.jsx
@@ -40,13 +40,14 @@ const SequenceNavigationTabs = ({
           style={shouldDisplayDropdown ? invisibleStyle : null}
           ref={containerRef}
         >
-          {unitIds.map(buttonUnitId => (
+          {unitIds.map((buttonUnitId, idx) => (
             <UnitButton
               key={buttonUnitId}
               unitId={buttonUnitId}
               isActive={unitId === buttonUnitId}
               showCompletion={showCompletion}
               onClick={onNavigate}
+              unitIndex={idx}
             />
           ))}
         </div>

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.test.jsx
@@ -44,7 +44,7 @@ describe('Sequence Navigation Tabs', () => {
     useIndexOfLastVisibleChild.mockReturnValue([0, null, null]);
     render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
 
-    expect(screen.getAllByRole('link')).toHaveLength(unitBlocks.length);
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(unitBlocks.length);
   });
 
   it('renders unit buttons and dropdown button', async () => {
@@ -54,7 +54,7 @@ describe('Sequence Navigation Tabs', () => {
     const booyah = render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
 
     // wait for links to appear so we aren't testing an empty div
-    await screen.findAllByRole('link');
+    await screen.findAllByRole('tabpanel');
 
     container = booyah.container;
 
@@ -62,7 +62,7 @@ describe('Sequence Navigation Tabs', () => {
     await userEvent.click(dropdownToggle);
 
     const dropdownMenu = container.querySelector('.dropdown');
-    const dropdownButtons = getAllByRole(dropdownMenu, 'link');
+    const dropdownButtons = getAllByRole(dropdownMenu, 'tabpanel');
     expect(dropdownButtons).toHaveLength(unitBlocks.length);
     expect(screen.getByRole('button', { name: `${activeBlockNumber} of ${unitBlocks.length}` }))
       .toHaveClass('dropdown-toggle');

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
@@ -3,11 +3,12 @@ import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 import classNames from 'classnames';
-import { Button, Icon } from '@openedx/paragon';
-import { Bookmark } from '@openedx/paragon/icons';
+import { Button } from '@openedx/paragon';
 
 import UnitIcon from './UnitIcon';
 import CompleteIcon from './CompleteIcon';
+import BookmarkFilledIcon from '../../bookmark/BookmarkFilledIcon';
+import { useScrollToContent } from '../../../../generic/hooks';
 
 const UnitButton = ({
   onClick,
@@ -20,7 +21,10 @@ const UnitButton = ({
   unitId,
   className,
   showTitle,
+  unitIndex,
 }) => {
+  useScrollToContent(isActive ? `${title}-${unitIndex}` : null);
+
   const { courseId, sequenceId } = useSelector(state => state.courseware);
   const { pathname } = useLocation();
   const basePath = `/course/${courseId}/${sequenceId}/${unitId}`;
@@ -29,6 +33,23 @@ const UnitButton = ({
   const handleClick = useCallback(() => {
     onClick(unitId);
   }, [onClick, unitId]);
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      onClick(unitId);
+
+      const performFocus = () => {
+        const targetElement = document.getElementById('bookmark-button');
+        if (targetElement) {
+          targetElement.focus();
+        }
+      };
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(performFocus);
+      });
+    }
+  };
 
   return (
     <Button
@@ -39,6 +60,12 @@ const UnitButton = ({
       variant="link"
       onClick={handleClick}
       title={title}
+      role="tabpanel"
+      tabIndex={isActive ? 0 : -1}
+      aria-controls={title}
+      id={`${title}-${unitIndex}`}
+      aria-labelledby={title}
+      onKeyDown={handleKeyDown}
       as={Link}
       to={unitPath}
     >
@@ -46,11 +73,12 @@ const UnitButton = ({
       {showTitle && <span className="unit-title">{title}</span>}
       {showCompletion && complete ? <CompleteIcon size="sm" className="text-success ml-2" /> : null}
       {bookmarked ? (
-        <Icon
+        <BookmarkFilledIcon
+          className="unit-filled-bookmark text-primary small position-absolute"
           data-testid="bookmark-icon"
-          src={Bookmark}
-          className="text-primary small position-absolute"
-          style={{ top: '-3px', right: '5px' }}
+          style={{
+            top: '-3px', right: '2px', height: '20px', width: '20px',
+          }}
         />
       ) : null}
     </Button>
@@ -68,6 +96,7 @@ UnitButton.propTypes = {
   showTitle: PropTypes.bool,
   title: PropTypes.string.isRequired,
   unitId: PropTypes.string.isRequired,
+  unitIndex: PropTypes.number.isRequired,
 };
 
 UnitButton.defaultProps = {

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Factory } from 'rosie';
+import { act, waitFor } from '@testing-library/react';
 import {
   fireEvent, initializeTestStore, render, screen,
 } from '../../../../setupTest';
@@ -28,17 +29,35 @@ describe('Unit Button', () => {
     mockData = {
       unitId: unit.id,
       onClick: () => {},
+      unitIndex: courseMetadata.id,
     };
+
+    global.requestAnimationFrame = jest.fn((cb) => {
+      setImmediate(cb);
+    });
   });
 
   it('hides title by default', () => {
     render(<UnitButton {...mockData} />, { wrapWithRouter: true });
-    expect(screen.getByRole('link')).not.toHaveTextContent(unit.display_name);
+    expect(screen.getByRole('tabpanel')).not.toHaveTextContent(unit.display_name);
   });
 
   it('shows title', () => {
     render(<UnitButton {...mockData} showTitle />, { wrapWithRouter: true });
-    expect(screen.getByRole('link')).toHaveTextContent(unit.display_name);
+    expect(screen.getByRole('tabpanel')).toHaveTextContent(unit.display_name);
+  });
+
+  it('check button attributes', () => {
+    render(<UnitButton {...mockData} showTitle />, { wrapWithRouter: true });
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', `${unit.display_name}-${courseMetadata.id}`);
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-controls', unit.display_name);
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', unit.display_name);
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('button with isActive prop has tabindex 0', () => {
+    render(<UnitButton {...mockData} isActive />, { wrapWithRouter: true });
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('tabindex', '0');
   });
 
   it('does not show completion for non-completed unit', () => {
@@ -79,7 +98,65 @@ describe('Unit Button', () => {
   it('handles the click', () => {
     const onClick = jest.fn();
     render(<UnitButton {...mockData} onClick={onClick} />, { wrapWithRouter: true });
-    fireEvent.click(screen.getByRole('link'));
+    fireEvent.click(screen.getByRole('tabpanel'));
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses the bookmark button after key press', async () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <>
+        <UnitButton {...mockData} />
+        <button id="bookmark-button" type="button">Bookmark</button>
+      </>,
+      { wrapWithRouter: true },
+    );
+    const unitButton = container.querySelector('[role="tabpanel"]');
+
+    fireEvent.keyDown(unitButton, { key: 'Enter' });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(document.getElementById('bookmark-button'));
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('calls onClick and focuses bookmark button on Enter or Space key press', async () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <>
+        <UnitButton {...mockData} onClick={onClick} />
+        <button id="bookmark-button" type="button">Bookmark</button>
+      </>,
+      { wrapWithRouter: true },
+    );
+
+    const unitButton = container.querySelector('[role="tabpanel"]');
+
+    await act(async () => {
+      fireEvent.keyDown(unitButton, { key: 'Enter' });
+    });
+
+    await waitFor(() => {
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(2);
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(document.getElementById('bookmark-button'));
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(unitButton, { key: ' ' });
+    });
+
+    await waitFor(() => {
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(4);
+      expect(onClick).toHaveBeenCalledTimes(2);
+      expect(document.activeElement).toBe(document.getElementById('bookmark-button'));
+    });
   });
 });

--- a/src/generic/hooks.test.jsx
+++ b/src/generic/hooks.test.jsx
@@ -1,5 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { useEventListener, useIFrameHeight } from './hooks';
+import userEvent from '@testing-library/user-event';
+import { useScrollToContent, useEventListener, useIFrameHeight } from './hooks';
+
+global.scrollTo = jest.fn();
+global.console.warn = jest.fn();
 
 describe('Hooks', () => {
   test('useEventListener', async () => {
@@ -41,5 +45,81 @@ describe('Hooks', () => {
     await waitFor(() => expect(onLoaded).toHaveBeenCalled());
     await waitFor(() => expect(screen.getByTestId('loaded')).toHaveTextContent('true'));
     expect(screen.getByTestId('height')).toHaveTextContent('1234');
+  });
+  describe('useScrollToContent', () => {
+    const TestComponent = () => {
+      useScrollToContent();
+      return (
+        <>
+          <a href="#main-content" data-testid="skip-link">Skip to content</a>
+          <div id="main-content" tabIndex={-1} data-testid="target-content">Main Content</div>
+        </>
+      );
+    };
+
+    test('should scroll to target element and focus', async () => {
+      render(<TestComponent />);
+
+      const skipLink = screen.getByRole('link', { name: /skip to content/i });
+      const targetContent = screen.getByTestId('target-content');
+
+      targetContent.focus = jest.fn();
+
+      userEvent.click(skipLink);
+
+      await waitFor(() => {
+        expect(global.scrollTo).toHaveBeenCalledWith({
+          top: expect.any(Number), behavior: 'smooth',
+        });
+      });
+      expect(targetContent.focus).toHaveBeenCalled();
+    });
+
+    test('should warn if element is not focusable', async () => {
+      render(<TestComponent />);
+
+      const skipLink = screen.getByTestId('skip-link');
+      const targetContent = screen.getByTestId('target-content');
+
+      Object.defineProperty(targetContent, 'focus', {
+        value: undefined,
+        configurable: true,
+      });
+
+      await userEvent.click(skipLink);
+
+      await waitFor(() => {
+        expect(global.scrollTo).toHaveBeenCalledWith({
+          top: expect.any(Number),
+          behavior: 'smooth',
+        });
+      });
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith('Element with ID "main-content" exists but is not focusable.');
+    });
+
+    test('should warn if target element is not found', async () => {
+      const ComponentWithoutTarget = () => {
+        useScrollToContent();
+        return (
+          <>
+            <a href="#main-content" data-testid="skip-link">Skip to content</a>
+            {/* Нет #main-content */}
+          </>
+        );
+      };
+
+      render(<ComponentWithoutTarget />);
+
+      const skipLink = screen.getByRole('link', { name: /skip to content/i });
+
+      await userEvent.click(skipLink);
+
+      await waitFor(() => {
+        // eslint-disable-next-line no-console
+        expect(console.warn).toHaveBeenCalledWith('Element with ID "main-content" not found.');
+      });
+    });
   });
 });


### PR DESCRIPTION
### Description

Jump user's focus skipping two navigation menus above it
- Progress page
- Course unit
- Dates page

### Testing instructions
**Progress Page**
1. Go to Progress
2. Using the Tab key (Shift+Tab) get to the Skip to main content element above the header.
3. When user press the Enter or Space key, the focus should move to the Your progress heading.

**Course Unit Page**
1. Go to Course unit page.
2. Using the Tab key (Shift+Tab) get to the Skip to main content element above the header.
3. When user press the Enter or Space key, the focus should move to the active unit.

**Dates Page**
1. Go to Dates page.
2. Using the Tab key (Shift+Tab) get to the Skip to main content element above the header.
3. When user press the Enter or Space key, the focus should move to the Important dates heading.

![363789603-42d7d1e1-f026-4596-a65d-8197aa4a366c](https://github.com/user-attachments/assets/ea74aae6-c2c1-4f3d-81c4-ce0bdefdaed6)

https://github.com/user-attachments/assets/82a7be9a-5d4f-41c3-b348-e6a7b3baf57b


