### PR TITLE
feat: added the ability to close the hint using the keyboard

### DIFF
--- a/src/course-home/live-tab/LiveTab.test.jsx
+++ b/src/course-home/live-tab/LiveTab.test.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import LiveTab from './LiveTab';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+describe('LiveTab', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('renders iframe from liveModel using dangerouslySetInnerHTML', () => {
+    useSelector.mockImplementation((selector) => selector({
+      courseHome: { courseId: 'course-v1:test+id+2024' },
+      models: {
+        live: {
+          'course-v1:test+id+2024': {
+            iframe: '<iframe id="lti-tab-embed" src="about:blank"></iframe>',
+          },
+        },
+      },
+    }));
+
+    render(<LiveTab />);
+
+    const iframe = document.getElementById('lti-tab-embed');
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.src).toBe('about:blank');
+  });
+
+  it('adds classes to iframe after mount', () => {
+    document.body.innerHTML = `
+      <div id="live_tab">
+        <iframe id="lti-tab-embed" class=""></iframe>
+      </div>
+    `;
+
+    useSelector.mockImplementation((selector) => selector({
+      courseHome: { courseId: 'course-v1:test+id+2024' },
+      models: {
+        live: {
+          'course-v1:test+id+2024': {
+            iframe: '<iframe id="lti-tab-embed"></iframe>',
+          },
+        },
+      },
+    }));
+
+    render(<LiveTab />);
+
+    const iframe = document.getElementById('lti-tab-embed');
+    expect(iframe.className).toContain('vh-100');
+    expect(iframe.className).toContain('w-100');
+    expect(iframe.className).toContain('border-0');
+  });
+
+  it('does not throw if iframe is not found in DOM', () => {
+    useSelector.mockImplementation((selector) => selector({
+      courseHome: { courseId: 'course-v1:test+id+2024' },
+      models: {
+        live: {
+          'course-v1:test+id+2024': {
+            iframe: '<div>No iframe here</div>',
+          },
+        },
+      },
+    }));
+
+    expect(() => render(<LiveTab />)).not.toThrow();
+    const iframe = document.getElementById('lti-tab-embed');
+    expect(iframe).toBeNull();
+  });
+});

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx
@@ -10,8 +10,8 @@ import {
   IconButton,
 } from '@openedx/paragon';
 import { InfoOutline, Locked } from '@openedx/paragon/icons';
-import { useContextId } from '../../../../data/hooks';
 
+import { useContextId } from '../../../../data/hooks';
 import messages from '../messages';
 import { useModel } from '../../../../generic/model-store';
 
@@ -35,8 +35,9 @@ const GradeSummaryHeader = ({ allOfSomeAssignmentTypeIsLocked }) => {
       <Stack direction="horizontal" gap={2}>
         <h3 className="h4 m-0">{intl.formatMessage(messages.gradeSummary)}</h3>
         <OverlayTrigger
-          trigger="hover"
+          trigger="click"
           placement="top"
+          show={showTooltip}
           overlay={(
             <Tooltip>
               {intl.formatMessage(messages.gradeSummaryTooltipBody)}
@@ -48,9 +49,9 @@ const GradeSummaryHeader = ({ allOfSomeAssignmentTypeIsLocked }) => {
             onBlur={() => { setShowTooltip(false); }}
             onKeyDown={handleKeyDown}
             alt={intl.formatMessage(messages.gradeSummaryTooltipAlt)}
-            src={InfoOutline}
-            className="mb-3"
+            iconAs={InfoOutline}
             size="sm"
+            disabled={gradesFeatureIsFullyLocked}
           />
         </OverlayTrigger>
       </Stack>

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
@@ -6,6 +7,7 @@ import {
   OverlayTrigger,
   Stack,
   Tooltip,
+  IconButton,
 } from '@openedx/paragon';
 import { InfoOutline, Locked } from '@openedx/paragon/icons';
 import { useContextId } from '../../../../data/hooks';
@@ -20,6 +22,13 @@ const GradeSummaryHeader = ({ allOfSomeAssignmentTypeIsLocked }) => {
     verifiedMode,
     gradesFeatureIsFullyLocked,
   } = useModel('progress', courseId);
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      setShowTooltip(false);
+    }
+  };
 
   return (
     <Stack gap={2} className="mb-3">
@@ -34,9 +43,13 @@ const GradeSummaryHeader = ({ allOfSomeAssignmentTypeIsLocked }) => {
             </Tooltip>
           )}
         >
-          <Icon
+          <IconButton
+            onClick={() => { setShowTooltip(!showTooltip); }}
+            onBlur={() => { setShowTooltip(false); }}
+            onKeyDown={handleKeyDown}
             alt={intl.formatMessage(messages.gradeSummaryTooltipAlt)}
             src={InfoOutline}
+            className="mb-3"
             size="sm"
           />
         </OverlayTrigger>

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.test.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {
+  render, screen, waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelector } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+
+import GradeSummaryHeader from './GradeSummaryHeader';
+import { useModel } from '../../../../generic/model-store';
+import messages from '../messages';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../generic/model-store', () => ({
+  useModel: jest.fn(),
+}));
+
+describe('GradeSummaryHeader', () => {
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      courseHome: { courseId: 'test-course-id' },
+    }));
+    useModel.mockReturnValue({ gradesFeatureIsFullyLocked: false });
+  });
+
+  const renderComponent = (props = {}) => {
+    render(
+      <IntlProvider locale="en" messages={messages}>
+        <GradeSummaryHeader
+          intl={{ formatMessage: jest.fn((msg) => msg.defaultMessage) }}
+          allOfSomeAssignmentTypeIsLocked={false}
+          {...props}
+        />
+      </IntlProvider>,
+    );
+  };
+
+  it('visible the tooltip when Escape is pressed', async () => {
+    renderComponent();
+
+    const iconButton = screen.getByRole('button', {
+      name: messages.gradeSummaryTooltipAlt.defaultMessage,
+    });
+
+    userEvent.click(iconButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeVisible();
+    });
+  });
+});

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.test.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.test.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import {
-  render, screen, waitFor,
-} from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useSelector } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 
+import { fireEvent } from '@testing-library/dom';
 import GradeSummaryHeader from './GradeSummaryHeader';
 import { useModel } from '../../../../generic/model-store';
 import messages from '../messages';
@@ -16,6 +15,10 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../../../../generic/model-store', () => ({
   useModel: jest.fn(),
+}));
+
+jest.mock('../../../../data/hooks', () => ({
+  useContextId: () => 'test-course-id',
 }));
 
 describe('GradeSummaryHeader', () => {
@@ -30,7 +33,6 @@ describe('GradeSummaryHeader', () => {
     render(
       <IntlProvider locale="en" messages={messages}>
         <GradeSummaryHeader
-          intl={{ formatMessage: jest.fn((msg) => msg.defaultMessage) }}
           allOfSomeAssignmentTypeIsLocked={false}
           {...props}
         />
@@ -38,17 +40,88 @@ describe('GradeSummaryHeader', () => {
     );
   };
 
-  it('visible the tooltip when Escape is pressed', async () => {
+  it('shows tooltip on icon button click', async () => {
     renderComponent();
 
     const iconButton = screen.getByRole('button', {
       name: messages.gradeSummaryTooltipAlt.defaultMessage,
     });
 
-    userEvent.click(iconButton);
+    await userEvent.click(iconButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeInTheDocument();
+    });
+  });
+
+  it('hides tooltip on mouse out', async () => {
+    renderComponent();
+
+    const iconButton = screen.getByRole('button', {
+      name: messages.gradeSummaryTooltipAlt.defaultMessage,
+    });
+
+    fireEvent.mouseOver(iconButton);
 
     await waitFor(() => {
       expect(screen.getByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeVisible();
+    });
+
+    fireEvent.mouseOut(iconButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeNull();
+    });
+  });
+
+  it('hides tooltip on blur', async () => {
+    renderComponent();
+
+    const iconButton = screen.getByRole('button', {
+      name: messages.gradeSummaryTooltipAlt.defaultMessage,
+    });
+
+    await userEvent.hover(iconButton);
+    await userEvent.click(iconButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeInTheDocument();
+    });
+
+    const blurTarget = document.createElement('button');
+    blurTarget.textContent = 'Outside';
+    document.body.appendChild(blurTarget);
+    blurTarget.focus();
+
+    await userEvent.unhover(iconButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText(messages.gradeSummaryTooltipBody.defaultMessage)).not.toBeInTheDocument();
+    });
+
+    document.body.removeChild(blurTarget);
+  });
+
+  it('hides tooltip when Escape is pressed (covers handleKeyDown)', async () => {
+    renderComponent();
+
+    const iconButton = screen.getByRole('button', {
+      name: messages.gradeSummaryTooltipAlt.defaultMessage,
+    });
+
+    await userEvent.hover(iconButton);
+    await userEvent.click(iconButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(iconButton, { key: 'Escape', code: 'Escape' });
+
+    await userEvent.unhover(iconButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText(messages.gradeSummaryTooltipBody.defaultMessage)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.test.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.test.jsx
@@ -54,20 +54,20 @@ describe('GradeSummaryHeader', () => {
     });
   });
 
-  it('hides tooltip on mouse out', async () => {
+  it('hides tooltip on click', async () => {
     renderComponent();
 
     const iconButton = screen.getByRole('button', {
       name: messages.gradeSummaryTooltipAlt.defaultMessage,
     });
 
-    fireEvent.mouseOver(iconButton);
+    fireEvent.click(iconButton);
 
     await waitFor(() => {
       expect(screen.getByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeVisible();
     });
 
-    fireEvent.mouseOut(iconButton);
+    fireEvent.click(iconButton);
 
     await waitFor(() => {
       expect(screen.queryByText(messages.gradeSummaryTooltipBody.defaultMessage)).toBeNull();


### PR DESCRIPTION
### Description 
This PR provides a mechanism to close the tooltip using the keyboard. The escape key is recommended

### Testing instructions
1. Create new course
2. Go to Progress page
3. Place focus on tooltip content when the tooltip button is activated.
4. Close tooltip with Escape key
5. Ensure focus is trapped within the tooltip until it is close.


https://github.com/user-attachments/assets/b7dc9608-61d9-4bcb-a2c4-b729ff369098

