### PR TITLE
feat: upgrade learning assistant frontend to 2.19.1 optimizely bug fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "1.4.0",
         "@edx/frontend-component-header": "^5.8.0",
-        "@edx/frontend-lib-learning-assistant": "^2.14.2",
+        "@edx/frontend-lib-learning-assistant": "^2.19.1",
         "@edx/frontend-lib-special-exams": "^3.1.3",
         "@edx/frontend-platform": "^8.0.0",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2432,12 +2432,11 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.14.2.tgz",
-      "integrity": "sha512-LKutTmhG+GBxNOYGy5SVQNlJN4bjn2SvNZz0X6Lc4PFv4rZFyGnM+SRj1Lt1Dy8pp46FEsaWxSPItbtI9tkuIQ==",
-      "license": "AGPL-3.0",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.19.1.tgz",
+      "integrity": "sha512-QJvTorP+38gUnP2e7FtIORsPlsrIaMHt6skgHG1MDzsU/Y1JtBxkN2UtAD9banWynPiqXbG/a/E1iEGauKjGfg==",
       "dependencies": {
-        "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@optimizely/react-sdk": "^2.9.2",
         "react-markdown": "^8.0.5",
         "uuid": "9.0.0"
@@ -2456,13 +2455,6 @@
         "react-router-dom": "^6",
         "redux": "^4"
       }
-    },
-    "node_modules/@edx/frontend-lib-learning-assistant/node_modules/@edx/brand": {
-      "name": "@edx/brand-openedx",
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.2.0.tgz",
-      "integrity": "sha512-r4PDN3rCgDsLovW44ayxoNNHgG5I4Rvss6MG5CrQEX4oW8YhQVEod+jJtwR5vi0mFLN2GIaMlDpd7iIy03VqXg==",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/frontend-lib-special-exams": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "1.4.0",
     "@edx/frontend-component-header": "^5.8.0",
-    "@edx/frontend-lib-learning-assistant": "^2.14.2",
+    "@edx/frontend-lib-learning-assistant": "^2.19.1",
     "@edx/frontend-lib-special-exams": "^3.1.3",
     "@edx/frontend-platform": "^8.0.0",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
Upgrade frontend-lib-learning-assistant to 2.19.1 to include audit trial optimizely experiment and bug fix for optimizely off/control variations.