### PR TITLE
feat: Search a11y updated behavior.

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,31 +1,9 @@
-#!/bin/sh
-if [ -z "$husky_skip_init" ]; then
-  debug () {
-    if [ "$HUSKY_DEBUG" = "1" ]; then
-      echo "husky (debug) - $1"
-    fi
-  }
+echo "husky - DEPRECATED
 
-  readonly hook_name="$(basename "$0")"
-  debug "starting $hook_name..."
+Please remove the following two lines from $0:
 
-  if [ "$HUSKY" = "0" ]; then
-    debug "HUSKY env variable is set to 0, skipping hook"
-    exit 0
-  fi
+#!/usr/bin/env sh
+. \"\$(dirname -- \"\$0\")/_/husky.sh\"
 
-  if [ -f ~/.huskyrc ]; then
-    debug "sourcing ~/.huskyrc"
-    . ~/.huskyrc
-  fi
-
-  export readonly husky_skip_init=1
-  sh -e "$0" "$@"
-  exitCode="$?"
-
-  if [ $exitCode != 0 ]; then
-    echo "husky - $hook_name hook exited with code $exitCode (error)"
-  fi
-
-  exit $exitCode
-fi
+They WILL FAIL in v10.0.0
+"

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,9 +1,31 @@
-echo "husky - DEPRECATED
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
+  }
 
-Please remove the following two lines from $0:
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
 
-#!/usr/bin/env sh
-. \"\$(dirname -- \"\$0\")/_/husky.sh\"
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
 
-They WILL FAIL in v10.0.0
-"
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+  fi
+
+  exit $exitCode
+fi

--- a/src/course-home/courseware-search/CoursewareSearch.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.jsx
@@ -119,7 +119,7 @@ const CoursewareSearch = ({ ...sectionProps }) => {
   }
 
   return (
-    <dialog ref={dialogRef} className="courseware-search" style={{ '--modal-top-position': top }} data-testid="courseware-search-section" onClose={handleSearchClose} {...sectionProps}>
+    <dialog ref={dialogRef} className="courseware-search" style={{ '--modal-top-position': top }} data-testid="courseware-search-dialog" onClose={handleSearchClose} {...sectionProps}>
       <div className="courseware-search__outer-content">
         <div className="courseware-search__content" data-testid="courseware-search-content">
           <div className="courseware-search__form">

--- a/src/course-home/courseware-search/CoursewareSearch.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.jsx
@@ -98,13 +98,13 @@ const CoursewareSearch = ({ ...sectionProps }) => {
       handleSubmit(searchKeyword); // In case it's opened with a search link, we run the search.
     }
 
-    window.addEventListener('popstate', handlePopState);
-    dialog.addEventListener('click', handleBackdropClick);
+    const controller = new AbortController();
+    const { signal } = controller;
 
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-      dialog.removeEventListener('click', handleBackdropClick);
-    };
+    window.addEventListener('popstate', handlePopState, { signal });
+    dialog.addEventListener('click', handleBackdropClick, { signal });
+
+    return () => controller.abort(); // Removes event listeners.
   }, []);
 
   const handleSearchClose = () => close();

--- a/src/course-home/courseware-search/CoursewareSearch.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.jsx
@@ -81,18 +81,29 @@ const CoursewareSearch = ({ ...sectionProps }) => {
 
   const handlePopState = () => close();
 
+  const handleBackdropClick = function (event) {
+    if (event.target === dialogRef.current) {
+      dialogRef.current.close();
+    }
+  };
+
   useEffect(() => {
+    // We need this to keep the dialog reference when unmounting.
+    const dialog = dialogRef.current;
+
     // Open the dialog as a modal on render to confine focus within it.
     dialogRef.current.showModal();
 
     if (searchKeyword) {
-      handleSubmit(searchKeyword); // In case it's opened with a search link.
+      handleSubmit(searchKeyword); // In case it's opened with a search link, we run the search.
     }
 
     window.addEventListener('popstate', handlePopState);
+    dialog.addEventListener('click', handleBackdropClick);
 
     return () => {
       window.removeEventListener('popstate', handlePopState);
+      dialog.removeEventListener('click', handleBackdropClick);
     };
   }, []);
 

--- a/src/course-home/courseware-search/CoursewareSearch.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.test.jsx
@@ -103,20 +103,7 @@ const mockSearchParams = ((params) => {
 });
 
 describe('CoursewareSearch', () => {
-  beforeAll(() => {
-    // jsdom does not support HTML Dialogs yet: https://github.com/jsdom/jsdom/issues/3294
-    HTMLDialogElement.prototype.show = jest.fn();
-    HTMLDialogElement.prototype.showModal = jest.fn(function mock() {
-      const onShowModal = new CustomEvent('show_modal');
-      this.dispatchEvent(onShowModal);
-    });
-    HTMLDialogElement.prototype.close = jest.fn(function mock() {
-      const onClose = new CustomEvent('close');
-      this.dispatchEvent(onClose);
-    });
-
-    initializeMockApp();
-  });
+  beforeAll(() => initializeMockApp());
 
   beforeEach(() => {
     mockModels();
@@ -142,7 +129,7 @@ describe('CoursewareSearch', () => {
     it('should have a "--modal-top-position" CSS variable matching the CourseTabsNavigation top position', () => {
       renderComponent();
 
-      const section = screen.getByTestId('courseware-search-section');
+      const section = screen.getByTestId('courseware-search-dialog');
       expect(section.style.getPropertyValue('--modal-top-position')).toBe(`${tabsTopPosition}px`);
     });
   });
@@ -167,7 +154,7 @@ describe('CoursewareSearch', () => {
 
       renderComponent();
 
-      const section = screen.getByTestId('courseware-search-section');
+      const section = screen.getByTestId('courseware-search-dialog');
       expect(section.style.getPropertyValue('--modal-top-position')).toBe('0');
     });
   });
@@ -176,7 +163,7 @@ describe('CoursewareSearch', () => {
     it('should pass on extra props to section element', () => {
       renderComponent({ foo: 'bar' });
 
-      const section = screen.getByTestId('courseware-search-section');
+      const section = screen.getByTestId('courseware-search-dialog');
       expect(section).toHaveAttribute('foo', 'bar');
     });
   });

--- a/src/course-home/courseware-search/CoursewareSearch.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.test.jsx
@@ -19,6 +19,7 @@ import { updateModel, useModel } from '../../generic/model-store';
 
 jest.mock('./hooks');
 jest.mock('../../generic/model-store', () => ({
+  ...jest.requireActual('../../generic/model-store'),
   updateModel: jest.fn(),
   useModel: jest.fn(),
 }));
@@ -56,7 +57,7 @@ const defaultProps = {
   total: 0,
 };
 
-const coursewareSearch = {
+const defaultSearchParams = {
   query: '',
   filter: '',
   setQuery: jest.fn(),
@@ -96,14 +97,33 @@ const mockModels = ((props = defaultProps) => {
   });
 });
 
-const mockSearchParams = ((props = coursewareSearch) => {
+const mockSearchParams = ((params) => {
+  const props = { ...defaultSearchParams, ...params };
   useCoursewareSearchParams.mockReturnValue(props);
 });
 
 describe('CoursewareSearch', () => {
-  beforeAll(initializeMockApp);
+  beforeAll(() => {
+    // jsdom does not support HTML Dialogs yet: https://github.com/jsdom/jsdom/issues/3294
+    HTMLDialogElement.prototype.show = jest.fn();
+    HTMLDialogElement.prototype.showModal = jest.fn(function mock() {
+      const onShowModal = new CustomEvent('show_modal');
+      this.dispatchEvent(onShowModal);
+    });
+    HTMLDialogElement.prototype.close = jest.fn(function mock() {
+      const onClose = new CustomEvent('close');
+      this.dispatchEvent(onClose);
+    });
+
+    initializeMockApp();
+  });
 
   beforeEach(() => {
+    mockModels();
+    mockSearchParams();
+  });
+
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
@@ -113,17 +133,13 @@ describe('CoursewareSearch', () => {
     });
 
     it('should use useElementBoundingBox() and useLockScroll() hooks', () => {
-      mockModels();
-      mockSearchParams();
       renderComponent();
 
-      expect(useElementBoundingBox).toBeCalledTimes(1);
-      expect(useLockScroll).toBeCalledTimes(1);
+      expect(useElementBoundingBox).toHaveBeenCalledTimes(1);
+      expect(useLockScroll).toHaveBeenCalledTimes(1);
     });
 
     it('should have a "--modal-top-position" CSS variable matching the CourseTabsNavigation top position', () => {
-      mockModels();
-      mockSearchParams();
       renderComponent();
 
       const section = screen.getByTestId('courseware-search-section');
@@ -132,8 +148,7 @@ describe('CoursewareSearch', () => {
   });
 
   describe('when clicking on the "Close" button', () => {
-    it('should dispatch setShowSearch(false)', async () => {
-      mockModels();
+    it('should close the dialog', async () => {
       renderComponent();
 
       await waitFor(() => {
@@ -141,7 +156,8 @@ describe('CoursewareSearch', () => {
         fireEvent.click(close);
       });
 
-      expect(setShowSearch).toBeCalledWith(false);
+      expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+      expect(setShowSearch).toHaveBeenCalledWith(false);
     });
   });
 
@@ -149,8 +165,6 @@ describe('CoursewareSearch', () => {
     it('should use "--modal-top-position: 0" if  nce element is not present', () => {
       useElementBoundingBox.mockImplementation(() => undefined);
 
-      mockModels();
-      mockSearchParams();
       renderComponent();
 
       const section = screen.getByTestId('courseware-search-section');
@@ -160,8 +174,6 @@ describe('CoursewareSearch', () => {
 
   describe('when passing extra props', () => {
     it('should pass on extra props to section element', () => {
-      mockModels();
-      mockSearchParams();
       renderComponent({ foo: 'bar' });
 
       const section = screen.getByTestId('courseware-search-section');
@@ -171,7 +183,6 @@ describe('CoursewareSearch', () => {
 
   describe('when submitting an empty search', () => {
     it('should clear the search by dispatch updateModel', async () => {
-      mockModels();
       renderComponent();
 
       await waitFor(() => {
@@ -203,7 +214,6 @@ describe('CoursewareSearch', () => {
     });
 
     it('should call searchCourseContent', async () => {
-      mockModels();
       renderComponent();
 
       const searchKeyword = 'course';
@@ -259,6 +269,7 @@ describe('CoursewareSearch', () => {
 
   describe('when clearing the search input', () => {
     it('should clear the search by dispatch updateModel', async () => {
+      mockSearchParams({ query: 'fubar' });
       mockModels({
         searchKeyword: 'fubar',
         total: 2,

--- a/src/course-home/courseware-search/CoursewareSearchForm.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchForm.jsx
@@ -1,43 +1,44 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { SearchField } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
 const CoursewareSearchForm = ({
-  intl,
   searchTerm,
   onSubmit,
   onChange,
   placeholder,
-}) => (
-  <SearchField.Advanced
-    value={searchTerm}
-    onSubmit={onSubmit}
-    onChange={onChange}
-    submitButtonLocation="external"
-    className="courseware-search-form"
-    screenReaderText={{
-      label: intl.formatMessage(messages.searchSubmitLabel),
-      clearButton: intl.formatMessage(messages.searchClearAction),
-      submitButton: null, // Remove the sr-only label in the button.
-    }}
-  >
-    <div className="pgn__searchfield_wrapper" data-testid="courseware-search-form">
-      <SearchField.Label />
-      <SearchField.Input placeholder={placeholder} autoFocus />
-      <SearchField.ClearButton />
-    </div>
-    <SearchField.SubmitButton
-      buttonText={intl.formatMessage(messages.searchSubmitLabel)}
+}) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <SearchField.Advanced
+      value={searchTerm}
+      onSubmit={onSubmit}
+      onChange={onChange}
       submitButtonLocation="external"
-      data-testid="courseware-search-form-submit"
-    />
-  </SearchField.Advanced>
-);
+      className="courseware-search-form"
+      screenReaderText={{
+        label: formatMessage(messages.searchSubmitLabel),
+        clearButton: formatMessage(messages.searchClearAction),
+        submitButton: null, // Remove the sr-only label in the button.
+      }}
+    >
+      <div className="pgn__searchfield_wrapper" data-testid="courseware-search-form">
+        <SearchField.Label />
+        <SearchField.Input placeholder={placeholder} autoFocus />
+        <SearchField.ClearButton />
+      </div>
+      <SearchField.SubmitButton
+        buttonText={formatMessage(messages.searchSubmitLabel)}
+        submitButtonLocation="external"
+        data-testid="courseware-search-form-submit"
+      />
+    </SearchField.Advanced>
+  );
+};
 
 CoursewareSearchForm.propTypes = {
-  intl: intlShape.isRequired,
   searchTerm: PropTypes.string,
   onSubmit: PropTypes.func,
   onChange: PropTypes.func,
@@ -51,4 +52,4 @@ CoursewareSearchForm.defaultProps = {
   placeholder: undefined,
 };
 
-export default injectIntl(CoursewareSearchForm);
+export default CoursewareSearchForm;

--- a/src/course-home/courseware-search/courseware-search.scss
+++ b/src/course-home/courseware-search/courseware-search.scss
@@ -5,13 +5,25 @@
   left: 0;
   right: 0;
   bottom: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  margin: 0;
   border-top: 1px solid $light-300;
   z-index: $zindex-modal; // Bootstrap's z-index layer for Modals.
 
+  &__form {
+    position: relative;
+
+    .h2 {
+      margin-right: 2.5rem;
+    }
+  }
+
   &__close {
     position: absolute !important; // For some reason it gets overridden
-    top: 0.5rem;
-    right: 1rem;
+    top: 0;
+    right: 0;
     font-size: 1.5rem;
     line-height: 1;
   }
@@ -152,9 +164,16 @@
 }
 
 @media (min-width: map-get($grid-breakpoints, 'md')) {
-  .courseware-search__content {
-    padding-top: 8rem;
+  .courseware-search {
+    &__close {
+      right: -2.5rem;
+    }
+
+    &__content {
+      padding-top: 8rem;
+    }
   }
+
 }
 
 body._search-no-scroll {

--- a/src/course-tabs/CourseTabsNavigation.test.jsx
+++ b/src/course-tabs/CourseTabsNavigation.test.jsx
@@ -73,13 +73,13 @@ describe('Course Tabs Navigation', () => {
   it('should NOT render CoursewareSearch if the flag is off', () => {
     renderComponent();
 
-    expect(screen.queryByTestId('courseware-search-section')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('courseware-search-dialog')).not.toBeInTheDocument();
   });
 
   it('should render CoursewareSearch if the flag is on', () => {
     useCoursewareSearchState.mockImplementation(() => ({ show: true }));
     renderComponent();
 
-    expect(screen.queryByTestId('courseware-search-section')).toBeInTheDocument();
+    expect(screen.queryByTestId('courseware-search-dialog')).toBeInTheDocument();
   });
 });

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -61,6 +61,18 @@ const supressWarningBlock = (callback) => {
 };
 /* eslint-enable no-console */
 
+// Mocks for HTML Dialogs behavior. */
+// jsdom does not support HTML Dialogs yet: https://github.com/jsdom/jsdom/issues/3294
+HTMLDialogElement.prototype.show = jest.fn();
+HTMLDialogElement.prototype.showModal = jest.fn(function mock() {
+  const onShowModal = new CustomEvent('show_modal');
+  this.dispatchEvent(onShowModal);
+});
+HTMLDialogElement.prototype.close = jest.fn(function mock() {
+  const onClose = new CustomEvent('close');
+  this.dispatchEvent(onClose);
+});
+
 // Mock Intersection Observer which is unavailable in the context of a test.
 global.IntersectionObserver = jest.fn(function mockIntersectionObserver() {
   this.observe = jest.fn();


### PR DESCRIPTION
## Description

These changes fix several accessibility issues with the Courseware Search panel.

These changes include:
- Moving the close panel button closer to the search button, so it doesn't get lost on large viewports.
- Moved the close button tab order to the third place. When opening the search panel, the search input is auto focused, then the focus moves to the search button and after that the close button takes focus.
- Updated browser's back navigation behavior while the search dialog is open. If the search panel is open when going back it closes the dialog instead.
- Reworked the component to use the Dialog HTML element with the modal functionality. This adds more quality of life features like closing the panel when hitting escape or clicking on the backdrop and restricts the element focus to cycle through the panel controls only (before these changes, the user was able to get focus into elements behind the search panel).

## Screenshots

![Screenshot 2025-02-28 at 09 38 59](https://github.com/user-attachments/assets/7eb95c65-de4c-4434-9c5f-3a76dd40f8a8)



