### PR TITLE
feat: Update previous and next unit navigation buttons design

### DIFF
--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -196,7 +196,6 @@ const Sequence = ({
           )}
 
           <div className="unit-container flex-grow-1 pt-4">
-            {isEnabledOutlineSidebar && renderUnitNavigation(true)}
             <SequenceContent
               courseId={courseId}
               gated={gated}
@@ -204,6 +203,8 @@ const Sequence = ({
               unitId={unitId}
               unitLoadedHandler={handleUnitLoaded}
               isOriginalUserStaff={originalUserIsStaff}
+              isEnabledOutlineSidebar={isEnabledOutlineSidebar}
+              renderUnitNavigation={renderUnitNavigation}
             />
             {unitHasLoaded && renderUnitNavigation(false)}
           </div>

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -196,6 +196,7 @@ const Sequence = ({
           )}
 
           <div className="unit-container flex-grow-1 pt-4">
+            {isEnabledOutlineSidebar && renderUnitNavigation(true)}
             <SequenceContent
               courseId={courseId}
               gated={gated}
@@ -223,7 +224,6 @@ const Sequence = ({
           originalUserIsStaff={originalUserIsStaff}
           canAccessProctoredExams={canAccessProctoredExams}
         >
-          {isEnabledOutlineSidebar && renderUnitNavigation(true)}
           {defaultContent}
         </SequenceExamWrapper>
         <CourseLicense license={license || undefined} />

--- a/src/courseware/course/sequence/SequenceContent.jsx
+++ b/src/courseware/course/sequence/SequenceContent.jsx
@@ -16,6 +16,8 @@ const SequenceContent = ({
   unitId,
   unitLoadedHandler,
   isOriginalUserStaff,
+  isEnabledOutlineSidebar,
+  renderUnitNavigation,
 }) => {
   const intl = useIntl();
   const sequence = useModel('sequences', sequenceId);
@@ -61,6 +63,8 @@ const SequenceContent = ({
       id={unitId}
       onLoaded={unitLoadedHandler}
       isOriginalUserStaff={isOriginalUserStaff}
+      isEnabledOutlineSidebar={isEnabledOutlineSidebar}
+      renderUnitNavigation={renderUnitNavigation}
     />
   );
 };
@@ -72,6 +76,8 @@ SequenceContent.propTypes = {
   unitId: PropTypes.string,
   unitLoadedHandler: PropTypes.func.isRequired,
   isOriginalUserStaff: PropTypes.bool.isRequired,
+  isEnabledOutlineSidebar: PropTypes.bool.isRequired,
+  renderUnitNavigation: PropTypes.func.isRequired,
 };
 
 SequenceContent.defaultProps = {

--- a/src/courseware/course/sequence/Unit/__snapshots__/index.test.jsx.snap
+++ b/src/courseware/course/sequence/Unit/__snapshots__/index.test.jsx.snap
@@ -21,18 +21,22 @@ exports[`Unit component output snapshot: not bookmarked, do not show content 1`]
   className="unit"
 >
   <div
-    className="mb-0"
+    className="d-flex justify-content-between align-items-center"
   >
-    <h3
-      className="h3"
+    <div
+      className="mb-0"
     >
-      unit-title
-    </h3>
-    <UnitTitleSlot
-      courseId="test-course-id"
-      unitId="test-props-id"
-      unitTitle="unit-title"
-    />
+      <h3
+        className="h3"
+      >
+        unit-title
+      </h3>
+      <UnitTitleSlot
+        courseId="test-course-id"
+        unitId="test-props-id"
+        unitTitle="unit-title"
+      />
+    </div>
   </div>
   <p
     className="sr-only"

--- a/src/courseware/course/sequence/Unit/index.jsx
+++ b/src/courseware/course/sequence/Unit/index.jsx
@@ -23,6 +23,8 @@ const Unit = ({
   onLoaded,
   id,
   isOriginalUserStaff,
+  isEnabledOutlineSidebar,
+  renderUnitNavigation,
 }) => {
   const { formatMessage } = useIntl();
   const [searchParams] = useSearchParams();
@@ -48,9 +50,12 @@ const Unit = ({
 
   return (
     <div className="unit">
-      <div className="mb-0">
-        <h3 className="h3">{unit.title}</h3>
-        <UnitTitleSlot courseId={courseId} unitId={id} unitTitle={unit.title} />
+      <div className="d-flex justify-content-between align-items-center">
+        <div className="mb-0">
+          <h3 className="h3">{unit.title}</h3>
+          <UnitTitleSlot courseId={courseId} unitId={id} unitTitle={unit.title} />
+        </div>
+        {isEnabledOutlineSidebar && renderUnitNavigation(true)}
       </div>
       <p className="sr-only">{formatMessage(messages.headerPlaceholder)}</p>
       <BookmarkButton
@@ -79,6 +84,8 @@ Unit.propTypes = {
   id: PropTypes.string.isRequired,
   onLoaded: PropTypes.func,
   isOriginalUserStaff: PropTypes.bool.isRequired,
+  isEnabledOutlineSidebar: PropTypes.bool.isRequired,
+  renderUnitNavigation: PropTypes.func.isRequired,
 };
 
 Unit.defaultProps = {

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -88,7 +88,6 @@ const SequenceNavigation = ({
     return navigationDisabledNextSequence || (
       <NextUnitTopNavTriggerSlot
         {...{
-          courseId,
           disabled,
           buttonText,
           nextLink,

--- a/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
@@ -23,23 +23,31 @@ const UnitNavigation = ({
     isFirstUnit, isLastUnit, nextLink, previousLink,
   } = useSequenceNavigationMetadata(sequenceId, unitId);
 
-  const renderPreviousButton = () => (
-    <PreviousButton
-      isFirstUnit={isFirstUnit}
-      variant="outline-secondary"
-      buttonLabel={intl.formatMessage(messages.previousButton)}
-      buttonStyle="previous-button justify-content-center"
-      onClick={onClickPrevious}
-      previousLink={previousLink}
-    />
-  );
+  const renderPreviousButton = () => {
+    const buttonStyle = isAtTop
+      ? 'previous-icon-button text-dark mr-4'
+      : 'previous-button justify-content-center';
+    return (
+      <PreviousButton
+        isFirstUnit={isFirstUnit}
+        variant="outline-secondary"
+        buttonLabel={intl.formatMessage(messages.previousButton)}
+        buttonStyle={buttonStyle}
+        onClick={onClickPrevious}
+        previousLink={previousLink}
+        isAtTop={isAtTop}
+      />
+    );
+  };
 
   const renderNextButton = () => {
     const { exitActive, exitText } = GetCourseExitNavigation(courseId, intl);
     const buttonText = (isLastUnit && exitText) ? exitText : intl.formatMessage(messages.nextButton);
     const disabled = isLastUnit && !exitActive;
     const variant = 'outline-primary';
-    const buttonStyle = 'next-button justify-content-center';
+    const buttonStyle = isAtTop
+      ? 'next-icon-button text-dark'
+      : 'next-button justify-content-center';
 
     if (isAtTop) {
       return (
@@ -53,6 +61,7 @@ const UnitNavigation = ({
             sequenceId,
             nextLink,
             onClickHandler: onClickNext,
+            isAtTop,
           }}
         />
       );

--- a/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitNavigation.jsx
@@ -24,9 +24,7 @@ const UnitNavigation = ({
   } = useSequenceNavigationMetadata(sequenceId, unitId);
 
   const renderPreviousButton = () => {
-    const buttonStyle = isAtTop
-      ? 'previous-icon-button text-dark mr-4'
-      : 'previous-button justify-content-center';
+    const buttonStyle = `previous-button ${isAtTop ? 'text-dark mr-3' : 'justify-content-center'}`;
     return (
       <PreviousButton
         isFirstUnit={isFirstUnit}
@@ -45,15 +43,12 @@ const UnitNavigation = ({
     const buttonText = (isLastUnit && exitText) ? exitText : intl.formatMessage(messages.nextButton);
     const disabled = isLastUnit && !exitActive;
     const variant = 'outline-primary';
-    const buttonStyle = isAtTop
-      ? 'next-icon-button text-dark'
-      : 'next-button justify-content-center';
+    const buttonStyle = `next-button ${isAtTop ? 'text-dark' : 'justify-content-center'}`;
 
     if (isAtTop) {
       return (
         <NextUnitTopNavTriggerSlot
           {...{
-            courseId,
             variant,
             buttonStyle,
             buttonText,
@@ -81,7 +76,11 @@ const UnitNavigation = ({
   };
 
   return (
-    <div className={classNames('unit-navigation d-flex', { 'top-unit-navigation mb-3 w-100': isAtTop })}>
+    <div className={classNames('d-flex', {
+      'unit-navigation': !isAtTop,
+      'top-unit-navigation': isAtTop,
+    })}
+    >
       {renderPreviousButton()}
       {renderNextButton()}
     </div>

--- a/src/courseware/course/sequence/sequence-navigation/UnitNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitNavigation.test.jsx
@@ -5,6 +5,13 @@ import {
 } from '../../../../setupTest';
 import UnitNavigation from './UnitNavigation';
 
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
 describe('Unit Navigation', () => {
   let mockData;
   const courseMetadata = Factory.build('courseMetadata');
@@ -54,6 +61,26 @@ describe('Unit Navigation', () => {
 
     fireEvent.click(screen.getByRole('link', { name: /next/i }));
     expect(onClickNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('when clicked it calls navigate when is at the top', () => {
+    const onClickPrevious = jest.fn();
+    const onClickNext = jest.fn();
+
+    render(<UnitNavigation
+      {...mockData}
+      onClickPrevious={onClickPrevious}
+      onClickNext={onClickNext}
+      isAtTop
+    />, { wrapWithRouter: true });
+
+    fireEvent.click(screen.getByRole('button', { name: /previous/i }));
+    expect(onClickPrevious).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(onClickNext).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledTimes(2);
   });
 
   it('has the navigation buttons enabled for the non-corner unit in the sequence', () => {

--- a/src/courseware/course/sequence/sequence-navigation/generic/NextButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/generic/NextButton.jsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
-import { Link, useLocation } from 'react-router-dom';
-import { Button } from '@openedx/paragon';
-import { ChevronLeft, ChevronRight } from '@openedx/paragon/icons';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Button, IconButton, Icon } from '@openedx/paragon';
+import {
+  ArrowBack,
+  ArrowForward,
+  ChevronLeft,
+  ChevronRight,
+} from '@openedx/paragon/icons';
 import { isRtl, getLocale } from '@edx/frontend-platform/i18n';
 
 import UnitNavigationEffortEstimate from '../UnitNavigationEffortEstimate';
@@ -14,8 +19,9 @@ const NextButton = ({
   buttonStyle,
   disabled,
   hasEffortEstimate,
+  isAtTop,
 }) => {
-  const nextArrow = isRtl(getLocale()) ? ChevronLeft : ChevronRight;
+  const navigate = useNavigate();
   const { pathname } = useLocation();
   const navLink = pathname.startsWith('/preview') ? `/preview${nextLink}` : nextLink;
   const buttonContent = hasEffortEstimate ? (
@@ -23,6 +29,33 @@ const NextButton = ({
       {buttonText}
     </UnitNavigationEffortEstimate>
   ) : buttonText;
+
+  const getNextArrow = () => {
+    if (isAtTop) {
+      return isRtl(getLocale()) ? ArrowBack : ArrowForward;
+    }
+    return isRtl(getLocale()) ? ChevronLeft : ChevronRight;
+  };
+
+  const nextArrow = getNextArrow();
+
+  const onClick = () => {
+    navigate(navLink);
+    onClickHandler();
+  };
+
+  if (isAtTop) {
+    return (
+      <IconButton
+        variant="light"
+        className={buttonStyle}
+        onClick={onClick}
+        src={nextArrow}
+        disabled={disabled}
+        iconAs={Icon}
+      />
+    );
+  }
 
   return (
     <Button
@@ -51,6 +84,7 @@ NextButton.propTypes = {
   buttonStyle: PropTypes.string.isRequired,
   disabled: PropTypes.bool.isRequired,
   hasEffortEstimate: PropTypes.bool,
+  isAtTop: PropTypes.bool.isRequired,
 };
 
 export default NextButton;

--- a/src/courseware/course/sequence/sequence-navigation/generic/NextButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/generic/NextButton.jsx
@@ -53,6 +53,7 @@ const NextButton = ({
         src={nextArrow}
         disabled={disabled}
         iconAs={Icon}
+        alt={buttonText}
       />
     );
   }

--- a/src/courseware/course/sequence/sequence-navigation/generic/PreviousButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/generic/PreviousButton.jsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types';
-import { Link, useLocation } from 'react-router-dom';
-import { Button } from '@openedx/paragon';
-import { ChevronLeft, ChevronRight } from '@openedx/paragon/icons';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Button, IconButton, Icon } from '@openedx/paragon';
+import {
+  ArrowBack,
+  ArrowForward,
+  ChevronLeft,
+  ChevronRight,
+} from '@openedx/paragon/icons';
 import { isRtl, getLocale } from '@edx/frontend-platform/i18n';
 
 const PreviousButton = ({
@@ -11,11 +16,39 @@ const PreviousButton = ({
   variant,
   buttonStyle,
   isFirstUnit,
+  isAtTop,
 }) => {
+  const navigate = useNavigate();
   const disabled = isFirstUnit;
-  const prevArrow = isRtl(getLocale()) ? ChevronRight : ChevronLeft;
   const { pathname } = useLocation();
   const navLink = pathname.startsWith('/preview') ? `/preview${previousLink}` : previousLink;
+
+  const getPrevArrow = () => {
+    if (isAtTop) {
+      return isRtl(getLocale()) ? ArrowForward : ArrowBack;
+    }
+    return isRtl(getLocale()) ? ChevronRight : ChevronLeft;
+  };
+
+  const prevArrow = getPrevArrow();
+
+  const onClickHandler = () => {
+    navigate(navLink);
+    onClick();
+  };
+
+  if (isAtTop) {
+    return (
+      <IconButton
+        variant="light"
+        className={buttonStyle}
+        onClick={onClickHandler}
+        src={prevArrow}
+        disabled={disabled}
+        iconAs={Icon}
+      />
+    );
+  }
 
   return (
     <Button
@@ -39,6 +72,7 @@ PreviousButton.propTypes = {
   variant: PropTypes.string.isRequired,
   buttonStyle: PropTypes.string.isRequired,
   isFirstUnit: PropTypes.bool.isRequired,
+  isAtTop: PropTypes.bool.isRequired,
 };
 
 export default PreviousButton;

--- a/src/courseware/course/sequence/sequence-navigation/generic/PreviousButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/generic/PreviousButton.jsx
@@ -46,6 +46,7 @@ const PreviousButton = ({
         src={prevArrow}
         disabled={disabled}
         iconAs={Icon}
+        alt={buttonLabel}
       />
     );
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -336,6 +336,11 @@
     gap: $spacer;
   }
 
+  .previous-icon-button,
+  .next-icon-button {
+    font-size: 1.5rem;
+  }
+
   .previous-button,
   .next-button {
     border-radius: 4px;

--- a/src/index.scss
+++ b/src/index.scss
@@ -336,11 +336,6 @@
     gap: $spacer;
   }
 
-  .previous-icon-button,
-  .next-icon-button {
-    font-size: 1.5rem;
-  }
-
   .previous-button,
   .next-button {
     border-radius: 4px;
@@ -368,15 +363,13 @@
 }
 
 .top-unit-navigation {
+  display: flex;
   max-width: 100%;
   justify-content: flex-end;
 
   .next-button,
   .previous-button {
-    @media (min-width: map-get($grid-breakpoints, "md")) {
-      flex-basis: auto;
-      min-width: 8rem;
-    }
+    font-size: 1.5rem;
   }
 }
 

--- a/src/plugin-slots/NextUnitTopNavTriggerSlot/index.tsx
+++ b/src/plugin-slots/NextUnitTopNavTriggerSlot/index.tsx
@@ -14,6 +14,7 @@ interface Props {
   onClickHandler: () => void;
   variant: string;
   buttonStyle: string;
+  isAtTop: boolean;
 }
 
 export const NextUnitTopNavTriggerSlot : React.FC<Props> = ({
@@ -25,6 +26,7 @@ export const NextUnitTopNavTriggerSlot : React.FC<Props> = ({
   onClickHandler,
   variant,
   buttonStyle,
+  isAtTop,
 }) => (
   <PluginSlot
     id="next_unit_top_nav_trigger_slot"
@@ -47,6 +49,7 @@ export const NextUnitTopNavTriggerSlot : React.FC<Props> = ({
         nextLink,
         disabled,
         buttonText,
+        isAtTop,
       }}
     />
   </PluginSlot>

--- a/src/plugin-slots/NextUnitTopNavTriggerSlot/index.tsx
+++ b/src/plugin-slots/NextUnitTopNavTriggerSlot/index.tsx
@@ -5,7 +5,6 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import NextButton from '../../courseware/course/sequence/sequence-navigation/generic/NextButton';
 
 interface Props {
-  courseId: string | '';
   disabled: boolean;
   buttonText: string | '';
   nextLink: string;
@@ -18,7 +17,6 @@ interface Props {
 }
 
 export const NextUnitTopNavTriggerSlot : React.FC<Props> = ({
-  courseId,
   disabled,
   buttonText,
   nextLink,
@@ -31,7 +29,6 @@ export const NextUnitTopNavTriggerSlot : React.FC<Props> = ({
   <PluginSlot
     id="next_unit_top_nav_trigger_slot"
     pluginProps={{
-      courseId,
       disabled,
       buttonText,
       nextLink,
@@ -39,6 +36,7 @@ export const NextUnitTopNavTriggerSlot : React.FC<Props> = ({
       onClickHandler,
       variant,
       buttonStyle,
+      isAtTop,
     }}
   >
     <NextButton


### PR DESCRIPTION
### Axim Team:

We've received feedback about the placement of these buttons, and we'd like to make the following change on the open edx platform as well: Move the previous and next buttons at the top of the page down (in line with the content header). For this reason, I think it should be OK to make this change within the MFE itself.

### Description

The top previous and next buttons should be moved to match the design pictured below and attached.

<img width="838" alt="Screenshot 2025-02-28 at 4 43 03 PM" src="https://github.com/user-attachments/assets/838a184e-2287-492c-86f6-508905fd9b27" />
<img width="907" alt="Screenshot 2025-02-28 at 4 23 21 PM" src="https://github.com/user-attachments/assets/95d45c1c-d7df-4079-946f-00c527970e80" />
<img width="908" alt="Screenshot 2025-02-28 at 4 23 30 PM" src="https://github.com/user-attachments/assets/45072437-ea7a-4b2f-b7d2-942d3f7400b7" />
<img width="425" alt="Screenshot 2025-02-28 at 4 24 06 PM" src="https://github.com/user-attachments/assets/23461033-26b7-4928-82fa-274e2912131e" />

There is a requirement from support to make sure the bottom of the page previous and next buttons remain

### After
<img width="1792" alt="Screenshot 2025-03-03 at 3 04 46 PM" src="https://github.com/user-attachments/assets/d2990272-929e-4dba-80b7-b51fc7830841" />
<img width="1791" alt="Screenshot 2025-03-03 at 3 04 55 PM" src="https://github.com/user-attachments/assets/a20f920c-9e5c-400c-b484-2f7543bb6f6f" />


### Caveat

Since there's an already margin and padding for the unit content the arrow buttons were added within the inside content without affecting that design. The wanted changes locate the buttons as if there was no margin but we are not skipping this default configuration unless is requested.

<img width="1792" alt="Screenshot 2025-03-03 at 3 06 57 PM" src="https://github.com/user-attachments/assets/26bfb08d-0d8c-4441-b681-3ba4a37e7c07" />

