### PR TITLE
feat: remove align-items-center from unit title main header

### DIFF
--- a/src/courseware/course/sequence/Unit/__snapshots__/index.test.jsx.snap
+++ b/src/courseware/course/sequence/Unit/__snapshots__/index.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`Unit component output snapshot: not bookmarked, do not show content 1`]
   className="unit"
 >
   <div
-    className="d-flex justify-content-between align-items-center"
+    className="d-flex justify-content-between"
   >
     <div
       className="mb-0"

--- a/src/courseware/course/sequence/Unit/index.jsx
+++ b/src/courseware/course/sequence/Unit/index.jsx
@@ -50,7 +50,7 @@ const Unit = ({
 
   return (
     <div className="unit">
-      <div className="d-flex justify-content-between align-items-center">
+      <div className="d-flex justify-content-between">
         <div className="mb-0">
           <h3 className="h3">{unit.title}</h3>
           <UnitTitleSlot courseId={courseId} unitId={id} unitTitle={unit.title} />


### PR DESCRIPTION
TLDR: Remove `align-items-center` from header so that navigation buttons stay aligned with the unit title.

### Before
<img width="1792" alt="Screenshot 2025-03-06 at 12 23 54 PM" src="https://github.com/user-attachments/assets/ff4e4e9e-41f3-470c-a1e5-5c09ada7be7f" />


### After
<img width="1792" alt="Screenshot 2025-03-06 at 12 23 26 PM" src="https://github.com/user-attachments/assets/7d20e726-e6c9-4f4e-a815-180c7df1be14" />
