### PR TITLE
feat: update version of frontend-lib-learning-assistant to 2.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "1.5.0",
         "@edx/frontend-component-header": "^5.8.0",
-        "@edx/frontend-lib-learning-assistant": "^2.19.1",
+        "@edx/frontend-lib-learning-assistant": "^2.19.2",
         "@edx/frontend-lib-special-exams": "^3.1.3",
         "@edx/frontend-platform": "^8.0.0",
         "@edx/openedx-atlas": "^0.6.0",
@@ -2292,9 +2292,10 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.19.1.tgz",
-      "integrity": "sha512-QJvTorP+38gUnP2e7FtIORsPlsrIaMHt6skgHG1MDzsU/Y1JtBxkN2UtAD9banWynPiqXbG/a/E1iEGauKjGfg==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.19.2.tgz",
+      "integrity": "sha512-EF2JPEe0llJfw8GwDgFsBr+5VKuqwVGqCBAP0jhWuWnLnJ2KUJJ+oxm8t0Dlni8M59LiO8QlO52OilJ6+/5IJw==",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@optimizely/react-sdk": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "1.5.0",
     "@edx/frontend-component-header": "^5.8.0",
-    "@edx/frontend-lib-learning-assistant": "^2.19.1",
+    "@edx/frontend-lib-learning-assistant": "^2.19.2",
     "@edx/frontend-lib-special-exams": "^3.1.3",
     "@edx/frontend-platform": "^8.0.0",
     "@edx/openedx-atlas": "^0.6.0",


### PR DESCRIPTION
### Description

This commit installs version 2.19.2 of @edx/frontend-lib-learning-assistant.

This release commit fixes a bug where the days remaining banner appears after an audit trial learner sends their first message. In this case, the days remaining is not displayed until the call to the chat summary endpoint completes. This commit adds a loading spinner to the banner that appears while that call is in progress.

See https://github.com/edx/frontend-lib-learning-assistant/releases/tag/v2.19.2.

**Jira**: [COSMO-678](https://2u-internal.atlassian.net/browse/COSMO-678) (private)