### PR TITLE
build: add start:with-theme command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postinstall": "patch-package",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
+    "start:with-theme": "paragon install-theme && npm start && npm install",
     "dev": "PUBLIC_PATH=/learning/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "fedx-scripts jest --coverage --passWithNoTests",
     "test:watch": "fedx-scripts jest --watch --passWithNoTests",


### PR DESCRIPTION
### Description

This changes fixes the ability to change the css theme when running the code locally.  Previously the theme could be overridden via `module.config.js`, but at some point this option stopped working. Without running `npm run start:with-theme` there is no way to change the theme from the default openedX theme.