### PR TITLE
fix: right sidebar icon behavior

### DIFF
--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsTrigger.tsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsTrigger.tsx
@@ -27,6 +27,9 @@ const DiscussionsNotificationsTrigger = ({ onClick }) => {
     isDiscussionbarAvailable,
   } = useContext(SidebarContext);
 
+  console.log(currentSidebar);
+  
+
   const dispatch = useDispatch();
   const intl = useIntl();
   const { tabs } = useModel('courseHomeMeta', courseId);
@@ -35,6 +38,8 @@ const DiscussionsNotificationsTrigger = ({ onClick }) => {
     () => tabs?.find(tab => tab.slug === 'discussion'),
     [tabs],
   );
+
+  const sidebarIcon = currentSidebar === ID ? RightSidebarFilled : RightSidebarOutlined;
 
   useEffect(() => {
     if (baseUrl && edxProvider) {
@@ -81,7 +86,7 @@ const DiscussionsNotificationsTrigger = ({ onClick }) => {
 
   return (
     <IconButton
-      src={currentSidebar ? RightSidebarFilled : RightSidebarOutlined}
+      src={sidebarIcon}
       iconAs={Icon}
       onClick={handleClick}
       alt={intl.formatMessage(messages.openSidebarTrigger)}

--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsTrigger.tsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsTrigger.tsx
@@ -27,9 +27,6 @@ const DiscussionsNotificationsTrigger = ({ onClick }) => {
     isDiscussionbarAvailable,
   } = useContext(SidebarContext);
 
-  console.log(currentSidebar);
-  
-
   const dispatch = useDispatch();
   const intl = useIntl();
   const { tabs } = useModel('courseHomeMeta', courseId);


### PR DESCRIPTION
## Description

When using the right `new-sidebar` with the left sidebar navigation, the icon for the right sidebar changes whenever the left sidebar is open. The icon change is supposed to indicate to users that the right sidebar is open. It is confusing to users  when the left sidebar navigation is open and the right sidebar icon is filled instead of outlined.

### Before
<img width="1422" alt="Screenshot 2025-03-12 at 4 18 16 PM" src="https://github.com/user-attachments/assets/1d505f6a-747d-4d12-815a-3f0c78cd3b18" />
<img width="1422" alt="Screenshot 2025-03-12 at 4 22 44 PM" src="https://github.com/user-attachments/assets/bf840c6c-0034-46be-9519-1d50f72b65f2" />

### After
<img width="1422" alt="Screenshot 2025-03-12 at 4 18 16 PM" src="https://github.com/user-attachments/assets/1d505f6a-747d-4d12-815a-3f0c78cd3b18" />
<img width="1422" alt="Screenshot 2025-03-12 at 4 18 27 PM" src="https://github.com/user-attachments/assets/ebb1ea13-4ef2-4974-a849-bdd427a5fae8" />

## Supporting Information

JIRA Ticket: [AU-2447 🔒](https://2u-internal.atlassian.net/browse/AU-2447)
> When the left sidebar icon is clicked, the right sidebar icon switches to "open" state