### PR TITLE
Fixed tab navigation to non-interactive elements

### DIFF
--- a/src/course-home/outline-tab/LmsHtmlFragment.jsx
+++ b/src/course-home/outline-tab/LmsHtmlFragment.jsx
@@ -53,6 +53,7 @@ const LmsHtmlFragment = ({
       scrolling="no"
       srcDoc={wholePage}
       title={title}
+      tabIndex={-1}
       {...rest}
     />
   );


### PR DESCRIPTION
### Description:
When navigating the page using a keyboard, the focus moves to two iframes (Welcome Message and Course Handouts) containing non-interactive elements. This disrupts the navigation flow and confuses keyboard users. The focus should move to interactive elements.

**Steps to Reproduce:**
1. Go to https://apps.sandbox.openedx.edly.io/learning/course/course-v1:OpenedX+DemoX+DemoCourse/home
2. Sign in as an Admin/Learner.
3. Navigate the page through the Keyboard Tab.
4. Observe that the keyboard focus moves to the Welcome Message and Course Handouts iframes.

[Taiga Ticket (If someone have access)](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/51)

Related to https://github.com/overhangio/tutor-indigo/issues/146