### PR TITLE
fix: use sentence casing

### DIFF
--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -111,7 +111,7 @@ describe('Progress Tab', () => {
       await fetchAndRender();
       sendTrackEvent.mockClear();
 
-      const outlineTabLink = screen.getAllByRole('link', { name: 'Course Outline' });
+      const outlineTabLink = screen.getAllByRole('link', { name: 'Course outline' });
       fireEvent.click(outlineTabLink[1]); // outlineTabLink[0] corresponds to the link in the DetailedGrades component
 
       expect(sendTrackEvent).toHaveBeenCalledTimes(1);
@@ -896,7 +896,7 @@ describe('Progress Tab', () => {
       sendTrackEvent.mockClear();
       expect(screen.getByText('Detailed grades')).toBeInTheDocument();
 
-      const outlineLink = screen.getAllByRole('link', { name: 'Course Outline' })[0];
+      const outlineLink = screen.getAllByRole('link', { name: 'Course outline' })[0];
       fireEvent.click(outlineLink);
 
       expect(sendTrackEvent).toHaveBeenCalledTimes(1);

--- a/src/course-home/progress-tab/grades/messages.ts
+++ b/src/course-home/progress-tab/grades/messages.ts
@@ -78,7 +78,7 @@ const messages = defineMessages({
   },
   courseOutline: {
     id: 'progress.courseOutline',
-    defaultMessage: 'Course Outline',
+    defaultMessage: 'Course outline',
     description: 'Anchor text for link that redirects to (course outline) tab',
   },
   currentGradeLabel: {

--- a/src/course-home/progress-tab/related-links/messages.ts
+++ b/src/course-home/progress-tab/related-links/messages.ts
@@ -18,7 +18,7 @@ const messages = defineMessages({
   },
   outlineCardLink: {
     id: 'progress.relatedLinks.outlineCard.link',
-    defaultMessage: 'Course Outline',
+    defaultMessage: 'Course outline',
     description: 'Anchor text for link that redirects to course outline tab',
   },
   relatedLinks: {

--- a/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.test.jsx
+++ b/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.test.jsx
@@ -64,7 +64,7 @@ describe('<CourseOutlineTray />', () => {
 
     expect(screen.getByText(messages.loading.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(messages.courseOutlineTitle.defaultMessage)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Course Outline' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Course outline' })).not.toBeInTheDocument();
   });
 
   it('doesn\'t render when outline sidebar is disabled', async () => {

--- a/src/courseware/course/sidebar/sidebars/course-outline/messages.ts
+++ b/src/courseware/course/sidebar/sidebars/course-outline/messages.ts
@@ -13,7 +13,7 @@ const messages = defineMessages({
   },
   courseOutlineTitle: {
     id: 'courseOutline.tray.title',
-    defaultMessage: 'Course Outline',
+    defaultMessage: 'Course outline',
     description: 'Title text displayed for the course outline tray',
   },
   completedUnit: {


### PR DESCRIPTION
## Description
This PR updates messages that use "Course Outline" instead of "Course outline". The current casing does not follow the general guidelines outlined in the [Microcopy writing guidelines](https://openedx.atlassian.net/wiki/spaces/BPL/pages/1966375321/Microcopy+writing+guidelines). See fourth (4) bullet under "General guidelines"

### Before
<img width="523" alt="Screenshot 2025-03-17 at 4 05 59 PM" src="https://github.com/user-attachments/assets/9347c2f1-2220-42ce-9e2e-c19b8c979f58" />

### After
<img width="523" alt="Screenshot 2025-03-17 at 4 05 31 PM" src="https://github.com/user-attachments/assets/ae2c0de7-6e25-48f5-8581-fcb3792441ce" />

## Supporting Information
JIRA Ticket: [AU-2437 🔒](https://2u-internal.atlassian.net/browse/AU-2437)
> We try to use sentence case whenever possible with Paragon. Change “Course Outline” to “Course outline” (use lowercase “o”).