### PR TITLE
feat: Drop canShowUpgradeSock course data.

### DIFF
--- a/src/course-home/data/__factories__/outlineTabData.factory.js
+++ b/src/course-home/data/__factories__/outlineTabData.factory.js
@@ -31,7 +31,6 @@ Factory.define('outlineTabData')
     course_access_redirect: false,
     has_scheduled_content: null,
     access_expiration: null,
-    can_show_upgrade_sock: false,
     cert_data: {
       cert_status: null,
       cert_web_view_url: null,

--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -489,7 +489,6 @@ exports[`Data layer integration tests Test fetchOutlineTab Should fetch, normali
     "outline": {
       "course-v1:edX+DemoX+Demo_Course": {
         "accessExpiration": null,
-        "canShowUpgradeSock": false,
         "certData": {
           "certStatus": null,
           "certWebViewUrl": null,

--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -367,7 +367,6 @@ export async function getOutlineTabData(courseId) {
   } = tabData;
 
   const accessExpiration = camelCaseObject(data.access_expiration);
-  const canShowUpgradeSock = data.can_show_upgrade_sock;
   const certData = camelCaseObject(data.cert_data);
   const courseBlocks = data.course_blocks ? normalizeOutlineBlocks(courseId, data.course_blocks.blocks) : {};
   const courseGoals = camelCaseObject(data.course_goals);
@@ -389,7 +388,6 @@ export async function getOutlineTabData(courseId) {
 
   return {
     accessExpiration,
-    canShowUpgradeSock,
     certData,
     courseBlocks,
     courseGoals,

--- a/src/course-home/data/pact-tests/lmsPact.test.jsx
+++ b/src/course-home/data/pact-tests/lmsPact.test.jsx
@@ -46,7 +46,6 @@ describe('Course Home Service', () => {
           willRespondWith: {
             status: 200,
             body: {
-              can_show_upgrade_sock: boolean(false),
               verified_mode: like({
                 access_expiration_date: null,
                 currency: 'USD',
@@ -94,7 +93,6 @@ describe('Course Home Service', () => {
           },
         });
         const normalizedTabData = {
-          canShowUpgradeSock: false,
           verifiedMode: {
             accessExpirationDate: null,
             currency: 'USD',

--- a/src/courseware/data/pact-tests/lmsPact.test.jsx
+++ b/src/courseware/data/pact-tests/lmsPact.test.jsx
@@ -192,7 +192,6 @@ describe('Courseware Service', () => {
           upgradeDeadline: '2013-02-05T05:00:00Z',
           upgradeUrl: 'link',
         },
-        canShowUpgradeSock: false,
         contentTypeGatingEnabled: false,
         id: 'course-v1:edX+DemoX+Demo_Course',
         title: 'Demonstration Course',
@@ -256,7 +255,6 @@ describe('Courseware Service', () => {
                 }),
                 upgrade_url: string('link'),
               },
-              can_show_upgrade_sock: boolean(false),
               content_type_gating_enabled: boolean(false),
               end: term({
                 generate: '2013-02-05T05:00:00Z',

--- a/src/courseware/data/utils.js
+++ b/src/courseware/data/utils.js
@@ -73,7 +73,6 @@ export function normalizeMetadata(metadata) {
   const { data, headers } = metadata;
   return {
     accessExpiration: camelCaseObject(data.access_expiration),
-    canShowUpgradeSock: data.can_show_upgrade_sock,
     contentTypeGatingEnabled: data.content_type_gating_enabled,
     courseGoals: camelCaseObject(data.course_goals),
     id: data.id,


### PR DESCRIPTION
DEPR: https://github.com/openedx/edx-platform/issues/36429

This piece of data is not being used anywhere but was still being
consumed so just drop the data so that the backend can be updated to no
longer provide the data.

The backend API is being updated in https://github.com/openedx/edx-platform/pull/36436
