### PR TITLE
chore(deps): update dependency @openedx/frontend-build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3698,9 +3698,9 @@
       }
     },
     "node_modules/@openedx/frontend-build": {
-      "version": "14.4.2",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.4.2.tgz",
-      "integrity": "sha512-RWAsaYq88cGlqO4eDDo/ylY6dJsbeBsI+4LxmKPrW4MPh0rIFZILvH+X3z/t9SVTlGTx4UkUQV9LXPGLKdcA1g==",
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.5.0.tgz",
+      "integrity": "sha512-HY0PdXvXBxrvJHj8HsRA+VNCHDePENFhqOIvbSz9Ke7HDwHpfDjg2CeKk41aU/8iTyj3eESfPwKQr5fTE0A3Ww==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/cli": "7.24.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "@openedx/frontend-build": "^14.3.3",
+    "@openedx/frontend-build": "^14.5.0",
     "@openedx/frontend-plugin-framework": "^1.6.0",
     "@openedx/frontend-slot-footer": "^1.0.2",
     "@openedx/paragon": "^22.16.0",


### PR DESCRIPTION
The upgrade of the package `@openedx/frontend-build` to `v.14.5.0` will extract more messages to be translated, improving localization when they are translated on transifex.
This upgrade will extract messages from `messages.ts` files.

Count how many strings extracted to be translated.

Before
```bash
$ npm run i18n_extract && grep '"id"' temp/babel-plugin-formatjs/Default.messages.json | wc -l
....
126
```

After:
```bash
$ npm run i18n_extract && grep '"id"' temp/babel-plugin-formatjs/Default.messages.json | wc -l
....
499
```