### PR TITLE
Improve Accessibility for Expand/Collapse Functionality on Course Home Page

### DIFF
--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -156,7 +156,7 @@ const OutlineTab = () => {
             <>
               <div id="expand-button-row" className="row w-100 m-0 mb-3 justify-content-end">
                 <div className="col-12 col-md-auto p-0">
-                  <Button ref={expandButtonRef} variant="outline-primary" block onClick={() => { setExpandAll(!expandAll); }}>
+                  <Button ref={expandButtonRef} variant="outline-primary" block onClick={() => { setExpandAll(!expandAll); }} aria-label={`${expandAll ? intl.formatMessage(messages.collapseAll) : intl.formatMessage(messages.expandAll)} sections`}>
                     {expandAll ? intl.formatMessage(messages.collapseAll) : intl.formatMessage(messages.expandAll)}
                   </Button>
                 </div>

--- a/src/course-home/outline-tab/messages.ts
+++ b/src/course-home/outline-tab/messages.ts
@@ -106,8 +106,13 @@ const messages = defineMessages({
   },
   openSection: {
     id: 'learning.outline.altText.openSection',
-    defaultMessage: 'Open',
+    defaultMessage: 'Open Section',
     description: 'A button to open the given section of the course outline',
+  },
+  closeSection: {
+    id: 'learning.outline.altText.closeSection',
+    defaultMessage: 'Close Section',
+    description: 'A button to close the given section of the course outline',
   },
   proctoringInfoPanel: {
     id: 'learning.proctoringPanel.header',

--- a/src/course-home/outline-tab/section-outline/Section.tsx
+++ b/src/course-home/outline-tab/section-outline/Section.tsx
@@ -4,7 +4,6 @@ import { Collapsible, IconButton } from '@openedx/paragon';
 import { Minus, Plus } from '@openedx/paragon/icons';
 
 import { useModel } from '../../../generic/model-store';
-import genericMessages from '../../../generic/messages';
 import { useContextId } from '../../../data/hooks';
 import messages from '../messages';
 import SectionTitle from './SectionTitle';
@@ -61,7 +60,7 @@ const Section: React.FC<Props> = ({
         onToggle={() => { setOpen(!open); }}
         iconWhenClosed={(
           <IconButton
-            alt={intl.formatMessage(messages.openSection)}
+            alt={`${intl.formatMessage(messages.openSection)} ${title}`}
             iconAs={Plus}
             onClick={() => { setOpen(true); }}
             size="sm"
@@ -69,7 +68,7 @@ const Section: React.FC<Props> = ({
         )}
         iconWhenOpen={(
           <IconButton
-            alt={intl.formatMessage(genericMessages.close)}
+            alt={`${intl.formatMessage(messages.closeSection)} ${title}`}
             iconAs={Minus}
             onClick={() => { setOpen(false); }}
             size="sm"


### PR DESCRIPTION
### Description

This pull request resolves the button accessibility issue on the course outline page in the Tutor Indigo theme identified during a recent accessibility review. This update aims to improve usability for all users, especially those relying on assistive technologies. The changes also help ensure compliance with recognized accessibility standards, such as the Web Content Accessibility Guidelines (WCAG) 2.1.

For further details, please refer to the related issue: [overhangio/tutor-indigo#146](https://github.com/overhangio/tutor-indigo/issues/146).

---


#### Improve Accessibility for Expand/Collapse Functionality on Course Home Page

Accessibility enhancements were made to the expand/collapse functionality on the course home page to improve screen reader support:

- **ARIA labels** are added to the **"Expand All"** and **"Collapse All"** buttons, now reading `"Expand all sections"` and `"Collapse all sections"` respectively. This provides clear context to users of assistive technologies.
- For **individual section toggle buttons**, ARIA labels now follow the format:  
  **"Expand section [Title]"** or **"Collapse section [Title]"**, which clearly communicates the action and associated section to screen reader users.

These changes enhance usability and ensure better alignment with WCAG 2.1 accessibility guidelines.

- **Issue:** [Taiga - US/52](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/52)
- **Live Example:** [Course Outline Page](https://apps.sandbox.openedx.edly.io/learning/course/course-v1:OpenedX+DemoX+DemoCourse/home)

---

### Accessibility Audit Report

For the full audit and issue breakdown, please refer to the following report:  
[Accessibility Audit](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/epics)

