### PR TITLE
chore: re-add query-string dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "lodash.camelcase": "4.3.0",
         "postcss-loader": "^8.1.1",
         "prop-types": "15.8.1",
+        "query-string": "^7.1.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet": "6.1.0",
@@ -18315,6 +18316,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/querystringify": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lodash.camelcase": "4.3.0",
     "postcss-loader": "^8.1.1",
     "prop-types": "15.8.1",
+    "query-string": "^7.1.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet": "6.1.0",


### PR DESCRIPTION
#1676  removed the `query-string` package. Several of our plugins still rely on this, though it should still be removed.