### PR TITLE
temp: reverse stack order of discussions and upsell in sidebar

### DIFF
--- a/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsSidebar.tsx
+++ b/src/courseware/course/new-sidebar/sidebars/discussions-notifications/DiscussionsNotificationsSidebar.tsx
@@ -21,9 +21,9 @@ const DiscussionsNotificationsSidebar = () => {
       showTitleBar={false}
       showBorder={false}
     >
-      <NotificationTray />
-      {!hideNotificationbar && <div className="my-1.5" />}
       <DiscussionsSidebar />
+      {!hideNotificationbar && <div className="my-1.5" />}
+      <NotificationTray />
     </SidebarBase>
   );
 };


### PR DESCRIPTION
[INF-1893](https://2u-internal.atlassian.net/browse/INF-1893)
**Description**

Discussions activity shows a significant decline this year (1st screenshot). Part of the reason could be decline in daily active users which is why i plotted % of DAUs who interact with discussions (2nd screenshot). But that also gone down since 2023 even though we now have tray and email notifications.

I suspect that certificate preview in sidebar has contributed in this decline. The preview pushes discussions below the scroll line (3rd and 4th screenshots). 

But this is just a hypothesis! I want to test this hypothesis but reversing the order of the CTA and discussions (discussions on top) for a few days. This means that users will see discussions on top ONLY on units where discussions is enabled. I want to see the impact on discussions activity and purchase.

Deploy changes on Monday and revert on the following Monday. That should give us 7 days of test data. 