### PR TITLE
feat: display the certificate available date if configured in progres tab

### DIFF
--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -187,7 +187,8 @@ const CertificateStatus = () => {
         // regardless of passing or nonpassing status
         if (!canViewCertificate) {
           certCase = 'notAvailable';
-          endDate = intl.formatDate(end, {
+          // use the certificate_available_date if it is available, otherwise use the end date of the course
+          endDate = intl.formatDate((certificateAvailableDate || end), {
             year: 'numeric',
             month: 'long',
             day: 'numeric',

--- a/src/courseware/course/course-exit/utils.js
+++ b/src/courseware/course/course-exit/utils.js
@@ -17,6 +17,7 @@ const CELEBRATION_STATUSES = [
   'audit_passing',
   'downloadable',
   'earned_but_not_available',
+  'not_earned_but_available_date',
   'honor_passing',
   'requesting',
   'unverified',


### PR DESCRIPTION
This Pull request aims to enhance the user experience by displaying the `certificate_available_date` in the progress tab > Certificate Status information if this has been configured and the course has not been complete yet. 

**Changes**
- Add the new certificate status in the `CELEBRATION_STATUSES` array.
- Update the default message validating the `certificate_available_date` and using it if it is set (otherwise use the end course date).


> [!IMPORTANT]
>This PR depends on https://github.com/openedx/edx-platform/pull/36790

## Testing instructions

- Enable the certificates.auto_certificate_generation waffle switch
- Create a  course with certificate mode (e.g. honor) 
- Configure a certificate available date in Studio entering in Course > Settings > Schedule & details
- Enroll a learner in the course
- Visit the progress tab and check the date in certificate status is the same as the one that you set (for this you will need the backend changes specified above)

**If certificate available date is set**
![image](https://github.com/user-attachments/assets/aa03dbf2-c4c5-4528-8c4a-8b9921b23f1a)

**If certificate available date is not set**
![image](https://github.com/user-attachments/assets/4ed4dc18-437d-4c36-b860-c2077f6a8c1b)




