### PR TITLE
Centering and aligning previous and next buttons

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -345,22 +345,6 @@
       border-radius: 6px;
     }
   }
-
-  .next-button {
-    flex-basis: 25%;
-
-     @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
-       flex-basis: 100%;
-     }
-  }
-
-  .previous-button {
-    flex-basis: 25%;
-
-     @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
-       flex-basis: 100%;
-     }
-  }
 }
 
 .top-unit-navigation {

--- a/src/index.scss
+++ b/src/index.scss
@@ -328,6 +328,7 @@
 .unit-navigation {
   display: flex;
   justify-content: center;
+  gap: 5px;
   max-width: 640px;
   margin: 0 auto;
 
@@ -346,7 +347,7 @@
   }
 
   .next-button {
-    flex-basis: 75%;
+    flex-basis: 25%;
 
      @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
        flex-basis: 100%;
@@ -365,6 +366,7 @@
 .top-unit-navigation {
   display: flex;
   max-width: 100%;
+  gap: 5px;
   justify-content: flex-end;
 
   .next-button,


### PR DESCRIPTION
## Description
The buttons for previous and next on course content navigation were not aligned correctly.
#1706

## Steps to reproduce
1. Log in to the platform.
2. Open any course (e.g., Demo course).
3. Scroll to the bottom of a lesson or content page.
4. Observe the positioning of the "Next" and "Previous" buttons.


### Before
#### Mobile screen
<img width="380" alt="Captura de pantalla 2025-06-02 a la(s) 9 54 49 a m" src="https://github.com/user-attachments/assets/2bd1330f-5871-4be4-aca5-f6b7cd157726" />

#### Desktop screen
<img width="1889" alt="Captura de pantalla 2025-06-02 a la(s) 9 54 23 a m" src="https://github.com/user-attachments/assets/65f7ac7c-eaf0-4f95-8f31-5433203f7c6d" />

### After
#### Mobile screen
<img width="381" alt="Captura de pantalla 2025-05-29 a la(s) 9 39 37 a m" src="https://github.com/user-attachments/assets/a1bf9a0a-4a8b-4b77-b58b-03e3171cc361" />

#### Desktop screen
<img width="1593" alt="Captura de pantalla 2025-05-29 a la(s) 9 39 09 a m" src="https://github.com/user-attachments/assets/b2773ef1-3135-4797-b7dc-5592fe6dd95c" />


