### PR TITLE
chore: add workflow to pull release testing issues into the BTR board

### DIFF
--- a/.github/add-issue-to-btr-project.yml
+++ b/.github/add-issue-to-btr-project.yml
@@ -1,0 +1,18 @@
+# Run the workflow that adds new tickets that are labelled "release testing"
+# to the org-wide BTR project board
+
+name: Add release testing issues to the BTR project board
+
+on:
+  issues:
+    types: [labeled]
+    # This workflow is triggered when an issue is labeled with 'release testing'.
+    # It adds the issue to the BTR project and applies the 'needs triage' label
+    # if it doesn't already have it.
+
+jobs:
+  handle-release-testing:
+    uses: openedx/.github/.github/workflows/add-issue-to-btr-project.yml@master
+    secrets:
+      GITHUB_APP_ID: ${{ secrets.GRAPHQL_AUTH_APP_ID }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.GRAPHQL_AUTH_APP_PEM }}


### PR DESCRIPTION
## Description

Add GH workflow that includes issues into the BTR board after the issue is labeled with `release testing`.  Also add label needs triage for bug triaging issues.

## Supporting information

For more details about this automation, please read this thread: https://openedx.slack.com/archives/C049JQZFR5E/p1747865383089089