### PR TITLE
fix: ensure full-height layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.2.0",
         "@edx/frontend-lib-learning-assistant": "^2.20.0",
-        "@edx/frontend-lib-special-exams": "^3.5.0",
+        "@edx/frontend-lib-special-exams": "^4.0.0",
         "@edx/frontend-platform": "^8.3.1",
         "@edx/openedx-atlas": "^0.7.0",
         "@edx/react-unit-test-utils": "^4.0.0",
@@ -2287,9 +2287,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-special-exams": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-3.5.0.tgz",
-      "integrity": "sha512-lRKD3K+XAuoKAaxbZxb7QLTWkSlV9yIy08XflYoHh/weClesVTETU3+NtJ5YRsC/kYHZrzSYIpMZnBnkKTGTww==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-special-exams/-/frontend-lib-special-exams-4.0.0.tgz",
+      "integrity": "sha512-mJdrxebdKO9NxDFkQZ1vyWVUvWCk393pIVHJyz9vH42Kvn08LC5db8/gYk37srCfsA4Dl78pMLa408CoT14JMA==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "1.2.34",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-component-header": "^6.2.0",
     "@edx/frontend-lib-learning-assistant": "^2.20.0",
-    "@edx/frontend-lib-special-exams": "^3.5.0",
+    "@edx/frontend-lib-special-exams": "^4.0.0",
     "@edx/frontend-platform": "^8.3.1",
     "@edx/openedx-atlas": "^0.7.0",
     "@edx/react-unit-test-utils": "^4.0.0",

--- a/src/__snapshots__/index.test.jsx.snap
+++ b/src/__snapshots__/index.test.jsx.snap
@@ -34,188 +34,192 @@ exports[`app registry subscribe: APP_READY.  links App to root element 1`] = `
     <PathFixesProvider>
       <NoticesProvider>
         <UserMessagesProvider>
-          <Routes>
-            <Route
-              element={
-                <PageWrap>
-                  <Page Not Found />
-                </PageWrap>
-              }
-              path="*"
-            />
-            <Route
-              element={
-                <PageWrap>
-                  <Goal Unsubscribe />
-                </PageWrap>
-              }
-              path="/goal-unsubscribe/:token"
-            />
-            <Route
-              element={
-                <PageWrap>
-                  <Courseware Redirect Landing Page />
-                </PageWrap>
-              }
-              path="/redirect/*"
-            />
-            <Route
-              element={
-                <PageWrap>
-                  <Preferences Unsubscribe />
-                </PageWrap>
-              }
-              path="/preferences-unsubscribe/:userToken/:updatePatch"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Course Access Error Page />
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/access-denied"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Tab Container
-                    fetch={[Function]}
-                    slice="courseHome"
-                    tab="outline"
-                  >
-                    <Outline Tab />
-                  </Tab Container>
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/home"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Tab Container
-                    fetch={[Function]}
-                    slice="courseHome"
-                    tab="lti_live"
-                  >
-                    <Live Tab />
-                  </Tab Container>
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/live"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Tab Container
-                    fetch={[Function]}
-                    slice="courseHome"
-                    tab="dates"
-                  >
-                    <Dates Tab />
-                  </Tab Container>
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/dates"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Tab Container
-                    fetch={[Function]}
-                    slice="courseHome"
-                    tab="discussion"
-                  >
-                    <Discussion Tab />
-                  </Tab Container>
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/discussion/:path/*"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Tab Container
-                    fetch={[Function]}
-                    isProgressTab={true}
-                    slice="courseHome"
-                    tab="progress"
-                  >
-                    <Progress Tab />
-                  </Tab Container>
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/progress/:targetUserId/"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Tab Container
-                    fetch={[Function]}
-                    isProgressTab={true}
-                    slice="courseHome"
-                    tab="progress"
-                  >
-                    <Progress Tab />
-                  </Tab Container>
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/progress"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Tab Container
-                    fetch={[Function]}
-                    slice="courseware"
-                    tab="courseware"
-                  >
-                    <Course Exit />
-                  </Tab Container>
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/course-end"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Courseware Container />
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/:sequenceId/:unitId"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Courseware Container />
-                </DecodePageRoute>
-              }
-              path="/course/:courseId/:sequenceId"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Courseware Container />
-                </DecodePageRoute>
-              }
-              path="/course/:courseId"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Courseware Container />
-                </DecodePageRoute>
-              }
-              path="/preview/course/:courseId/:sequenceId/:unitId"
-            />
-            <Route
-              element={
-                <DecodePageRoute>
-                  <Courseware Container />
-                </DecodePageRoute>
-              }
-              path="/preview/course/:courseId/:sequenceId"
-            />
-          </Routes>
+          <div
+            className="app-container"
+          >
+            <Routes>
+              <Route
+                element={
+                  <PageWrap>
+                    <Page Not Found />
+                  </PageWrap>
+                }
+                path="*"
+              />
+              <Route
+                element={
+                  <PageWrap>
+                    <Goal Unsubscribe />
+                  </PageWrap>
+                }
+                path="/goal-unsubscribe/:token"
+              />
+              <Route
+                element={
+                  <PageWrap>
+                    <Courseware Redirect Landing Page />
+                  </PageWrap>
+                }
+                path="/redirect/*"
+              />
+              <Route
+                element={
+                  <PageWrap>
+                    <Preferences Unsubscribe />
+                  </PageWrap>
+                }
+                path="/preferences-unsubscribe/:userToken/:updatePatch"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Course Access Error Page />
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/access-denied"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Tab Container
+                      fetch={[Function]}
+                      slice="courseHome"
+                      tab="outline"
+                    >
+                      <Outline Tab />
+                    </Tab Container>
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/home"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Tab Container
+                      fetch={[Function]}
+                      slice="courseHome"
+                      tab="lti_live"
+                    >
+                      <Live Tab />
+                    </Tab Container>
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/live"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Tab Container
+                      fetch={[Function]}
+                      slice="courseHome"
+                      tab="dates"
+                    >
+                      <Dates Tab />
+                    </Tab Container>
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/dates"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Tab Container
+                      fetch={[Function]}
+                      slice="courseHome"
+                      tab="discussion"
+                    >
+                      <Discussion Tab />
+                    </Tab Container>
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/discussion/:path/*"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Tab Container
+                      fetch={[Function]}
+                      isProgressTab={true}
+                      slice="courseHome"
+                      tab="progress"
+                    >
+                      <Progress Tab />
+                    </Tab Container>
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/progress/:targetUserId/"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Tab Container
+                      fetch={[Function]}
+                      isProgressTab={true}
+                      slice="courseHome"
+                      tab="progress"
+                    >
+                      <Progress Tab />
+                    </Tab Container>
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/progress"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Tab Container
+                      fetch={[Function]}
+                      slice="courseware"
+                      tab="courseware"
+                    >
+                      <Course Exit />
+                    </Tab Container>
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/course-end"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Courseware Container />
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/:sequenceId/:unitId"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Courseware Container />
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId/:sequenceId"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Courseware Container />
+                  </DecodePageRoute>
+                }
+                path="/course/:courseId"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Courseware Container />
+                  </DecodePageRoute>
+                }
+                path="/preview/course/:courseId/:sequenceId/:unitId"
+              />
+              <Route
+                element={
+                  <DecodePageRoute>
+                    <Courseware Container />
+                  </DecodePageRoute>
+                }
+                path="/preview/course/:courseId/:sequenceId"
+              />
+            </Routes>
+          </div>
         </UserMessagesProvider>
       </NoticesProvider>
     </PathFixesProvider>

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -219,15 +219,17 @@ const Sequence = ({
   if (sequenceStatus === 'loaded') {
     return (
       <>
-        <SequenceExamWrapper
-          sequence={sequence}
-          courseId={courseId}
-          isStaff={isStaff}
-          originalUserIsStaff={originalUserIsStaff}
-          canAccessProctoredExams={canAccessProctoredExams}
-        >
-          {defaultContent}
-        </SequenceExamWrapper>
+        <div className="d-flex flex-column flex-grow-1 justify-content-center">
+          <SequenceExamWrapper
+            sequence={sequence}
+            courseId={courseId}
+            isStaff={isStaff}
+            originalUserIsStaff={originalUserIsStaff}
+            canAccessProctoredExams={canAccessProctoredExams}
+          >
+            {defaultContent}
+          </SequenceExamWrapper>
+        </div>
         <CourseLicense license={license || undefined} />
       </>
     );

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -218,7 +218,7 @@ const Sequence = ({
 
   if (sequenceStatus === 'loaded') {
     return (
-      <div>
+      <>
         <SequenceExamWrapper
           sequence={sequence}
           courseId={courseId}
@@ -229,7 +229,7 @@ const Sequence = ({
           {defaultContent}
         </SequenceExamWrapper>
         <CourseLicense license={license || undefined} />
-      </div>
+      </>
     );
   }
 

--- a/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss
+++ b/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss
@@ -1,14 +1,12 @@
 .outline-sidebar-wrapper {
     width: 32.125rem;
     max-width: 100%;
-    overflow: auto;
     position: relative;
     flex-shrink: 0;
 }
 
 .outline-sidebar {
     @media (min-width: map-get($grid-breakpoints, "xl")) {
-        position: absolute;
         left: 0;
         top: 0;
     }

--- a/src/generic/notices/NoticesProvider.jsx
+++ b/src/generic/notices/NoticesProvider.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
 import { getNotices } from './api';
@@ -25,11 +25,7 @@ const NoticesProvider = ({ children }) => {
     getData();
   }, []);
 
-  return (
-    <div>
-      {isRedirected === true ? null : children}
-    </div>
-  );
+  return isRedirected === true ? null : children;
 };
 
 NoticesProvider.propTypes = {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,109 +43,111 @@ subscribe(APP_READY, () => {
   root.render(
     <StrictMode>
       <AppProvider store={store}>
-        <Helmet>
-          <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
-        </Helmet>
-        <PathFixesProvider>
-          <NoticesProvider>
-            <UserMessagesProvider>
-              <Routes>
-                <Route path="*" element={<PageWrap><PageNotFound /></PageWrap>} />
-                <Route path={ROUTES.UNSUBSCRIBE} element={<PageWrap><GoalUnsubscribe /></PageWrap>} />
-                <Route path={ROUTES.REDIRECT} element={<PageWrap><CoursewareRedirectLandingPage /></PageWrap>} />
-                <Route
-                  path={ROUTES.PREFERENCES_UNSUBSCRIBE}
-                  element={
-                    <PageWrap><PreferencesUnsubscribe /></PageWrap>
-                }
-                />
-                <Route
-                  path={DECODE_ROUTES.ACCESS_DENIED}
-                  element={<DecodePageRoute><CourseAccessErrorPage /></DecodePageRoute>}
-                />
-                <Route
-                  path={DECODE_ROUTES.HOME}
-                  element={(
-                    <DecodePageRoute>
-                      <TabContainer tab="outline" fetch={fetchOutlineTab} slice="courseHome">
-                        <OutlineTab />
-                      </TabContainer>
-                    </DecodePageRoute>
-              )}
-                />
-                <Route
-                  path={DECODE_ROUTES.LIVE}
-                  element={(
-                    <DecodePageRoute>
-                      <TabContainer tab="lti_live" fetch={fetchLiveTab} slice="courseHome">
-                        <LiveTab />
-                      </TabContainer>
-                    </DecodePageRoute>
-                )}
-                />
-                <Route
-                  path={DECODE_ROUTES.DATES}
-                  element={(
-                    <DecodePageRoute>
-                      <TabContainer tab="dates" fetch={fetchDatesTab} slice="courseHome">
-                        <DatesTab />
-                      </TabContainer>
-                    </DecodePageRoute>
-                )}
-                />
-                <Route
-                  path={DECODE_ROUTES.DISCUSSION}
-                  element={(
-                    <DecodePageRoute>
-                      <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
-                        <DiscussionTab />
-                      </TabContainer>
-                    </DecodePageRoute>
-                )}
-                />
-                {DECODE_ROUTES.PROGRESS.map((route) => (
+        <div className="app-container">
+          <Helmet>
+            <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
+          </Helmet>
+          <PathFixesProvider>
+            <NoticesProvider>
+              <UserMessagesProvider>
+                <Routes>
+                  <Route path="*" element={<PageWrap><PageNotFound /></PageWrap>} />
+                  <Route path={ROUTES.UNSUBSCRIBE} element={<PageWrap><GoalUnsubscribe /></PageWrap>} />
+                  <Route path={ROUTES.REDIRECT} element={<PageWrap><CoursewareRedirectLandingPage /></PageWrap>} />
                   <Route
-                    key={route}
-                    path={route}
+                    path={ROUTES.PREFERENCES_UNSUBSCRIBE}
+                    element={
+                      <PageWrap><PreferencesUnsubscribe /></PageWrap>
+                    }
+                  />
+                  <Route
+                    path={DECODE_ROUTES.ACCESS_DENIED}
+                    element={<DecodePageRoute><CourseAccessErrorPage /></DecodePageRoute>}
+                  />
+                  <Route
+                    path={DECODE_ROUTES.HOME}
                     element={(
                       <DecodePageRoute>
-                        <TabContainer
-                          tab="progress"
-                          fetch={fetchProgressTab}
-                          slice="courseHome"
-                          isProgressTab
-                        >
-                          <ProgressTab />
+                        <TabContainer tab="outline" fetch={fetchOutlineTab} slice="courseHome">
+                          <OutlineTab />
                         </TabContainer>
                       </DecodePageRoute>
-                  )}
+                    )}
                   />
-                ))}
-                <Route
-                  path={DECODE_ROUTES.COURSE_END}
-                  element={(
-                    <DecodePageRoute>
-                      <TabContainer tab="courseware" fetch={fetchCourse} slice="courseware">
-                        <CourseExit />
-                      </TabContainer>
-                    </DecodePageRoute>
-                )}
-                />
-                {DECODE_ROUTES.COURSEWARE.map((route) => (
                   <Route
-                    key={route}
-                    path={route}
+                    path={DECODE_ROUTES.LIVE}
                     element={(
                       <DecodePageRoute>
-                        <CoursewareContainer />
+                        <TabContainer tab="lti_live" fetch={fetchLiveTab} slice="courseHome">
+                          <LiveTab />
+                        </TabContainer>
                       </DecodePageRoute>
-                  )}
+                    )}
                   />
-                ))}
-              </Routes>
-            </UserMessagesProvider>
-          </NoticesProvider>
-        </PathFixesProvider>
+                  <Route
+                    path={DECODE_ROUTES.DATES}
+                    element={(
+                      <DecodePageRoute>
+                        <TabContainer tab="dates" fetch={fetchDatesTab} slice="courseHome">
+                          <DatesTab />
+                        </TabContainer>
+                      </DecodePageRoute>
+                    )}
+                  />
+                  <Route
+                    path={DECODE_ROUTES.DISCUSSION}
+                    element={(
+                      <DecodePageRoute>
+                        <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
+                          <DiscussionTab />
+                        </TabContainer>
+                      </DecodePageRoute>
+                    )}
+                  />
+                  {DECODE_ROUTES.PROGRESS.map((route) => (
+                    <Route
+                      key={route}
+                      path={route}
+                      element={(
+                        <DecodePageRoute>
+                          <TabContainer
+                            tab="progress"
+                            fetch={fetchProgressTab}
+                            slice="courseHome"
+                            isProgressTab
+                          >
+                            <ProgressTab />
+                          </TabContainer>
+                        </DecodePageRoute>
+                      )}
+                    />
+                  ))}
+                  <Route
+                    path={DECODE_ROUTES.COURSE_END}
+                    element={(
+                      <DecodePageRoute>
+                        <TabContainer tab="courseware" fetch={fetchCourse} slice="courseware">
+                          <CourseExit />
+                        </TabContainer>
+                      </DecodePageRoute>
+                    )}
+                  />
+                  {DECODE_ROUTES.COURSEWARE.map((route) => (
+                    <Route
+                      key={route}
+                      path={route}
+                      element={(
+                        <DecodePageRoute>
+                          <CoursewareContainer />
+                        </DecodePageRoute>
+                      )}
+                    />
+                  ))}
+                </Routes>
+              </UserMessagesProvider>
+            </NoticesProvider>
+          </PathFixesProvider>
+        </div>
       </AppProvider>
     </StrictMode>,
   );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,13 +43,13 @@ subscribe(APP_READY, () => {
   root.render(
     <StrictMode>
       <AppProvider store={store}>
-        <div className="app-container">
-          <Helmet>
-            <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
-          </Helmet>
-          <PathFixesProvider>
-            <NoticesProvider>
-              <UserMessagesProvider>
+        <Helmet>
+          <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
+        </Helmet>
+        <PathFixesProvider>
+          <NoticesProvider>
+            <UserMessagesProvider>
+              <div className="app-container">
                 <Routes>
                   <Route path="*" element={<PageWrap><PageNotFound /></PageWrap>} />
                   <Route path={ROUTES.UNSUBSCRIBE} element={<PageWrap><GoalUnsubscribe /></PageWrap>} />
@@ -144,10 +144,10 @@ subscribe(APP_READY, () => {
                     />
                   ))}
                 </Routes>
-              </UserMessagesProvider>
-            </NoticesProvider>
-          </PathFixesProvider>
-        </div>
+              </div>
+            </UserMessagesProvider>
+          </NoticesProvider>
+        </PathFixesProvider>
       </AppProvider>
     </StrictMode>,
   );

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,7 +8,7 @@
 
 
 #root {
-  .browser-router {
+  .app-container {
     display: flex;
     flex-direction: column;
     min-height: 100svh;

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,12 +8,19 @@
 
 
 #root {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-
+  [data-testid="browser-router"] {
+    display: flex;
+    flex-direction: column;
+    min-height: 100svh;
+  }
+  
   main {
     flex-grow: 1;
+  }
+  #main-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
   }
 
   header {

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,7 +8,7 @@
 
 
 #root {
-  [data-testid="browser-router"] {
+  .browser-router {
     display: flex;
     flex-direction: column;
     min-height: 100svh;


### PR DESCRIPTION
Fixes #1695
Related PR: https://github.com/openedx/frontend-lib-special-exams/pull/164
Summary:
When content within a sequence is shorter than the height of the browser viewport, the .sequence-container > .outline-sidebar-wrapper element does not expand appropriately. This causes the course outline sidebar to be partially or completely hidden from view.

Steps to Reproduce:

Open a course sequence that contains very little content (e.g., a short paragraph or notice).

View the course in a tall browser window.

Observe that the sidebar navigation is cut off or hidden.

Expected Behavior:

The sidebar should remain fully visible and accessible, regardless of the amount of content in the main pane.

Actual Behavior:
When the content is short, the parent container height collapses to fit that content, which in turn restricts the sidebar’s height, hiding part of the navigation.

Screenshots:
![image](https://github.com/user-attachments/assets/751d9f7e-ce8a-4e07-91b7-a34a65cb6b1c)
![image](https://github.com/user-attachments/assets/ac6762f5-38b3-4267-9354-bb5c9bfb6947)


Removing unnecessary wrapper divs and adding some very specific CSS to target the layout parent.

Demo of fix:
https://github.com/user-attachments/assets/627061e0-bb17-459e-af57-fb9a5c1175a9