### PR TITLE
Removing '-1 +' from media queries

### DIFF
--- a/src/courseware/course/sidebar/common/SidebarBase.scss
+++ b/src/courseware/course/sidebar/common/SidebarBase.scss
@@ -1,5 +1,5 @@
 #course-sidebar {
-    @media (max-width: -1 + map-get($grid-breakpoints, "lg")) {
+    @media (max-width: map-get($grid-breakpoints, "lg")) {
         overflow-y: scroll;
         padding: 0 .625rem !important;
     }

--- a/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss
+++ b/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss
@@ -66,7 +66,7 @@
             border-radius: 0;
             padding: map-get($spacers, 3\.5) map-get($spacers, 4) map-get($spacers, 3\.5) map-get($spacers, 5);
 
-            @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+            @media (max-width: map-get($grid-breakpoints, "sm")) {
                 padding-left: map-get($spacers, 4);
             }
 
@@ -90,7 +90,7 @@
         ol li > a {
             padding: map-get($spacers, 3\.5) map-get($spacers, 4) map-get($spacers, 3\.5) map-get($spacers, 5\.5);
 
-            @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+            @media (max-width: map-get($grid-breakpoints, "sm")) {
                 padding-left: map-get($spacers, 4\.5);
             }
 

--- a/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
+++ b/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
@@ -1,5 +1,5 @@
 .discussions-sidebar-frame {
-    @media (max-width: -1 + map-get($grid-breakpoints, "xl")) {
+    @media (max-width: map-get($grid-breakpoints, "xl")) {
         max-height: calc(100vh - 65px);
     }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -87,7 +87,7 @@
 }
 
 .notification-btn {
-  @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+  @media (max-width: map-get($grid-breakpoints, "sm")) {
     height: 3rem;
   }
 }
@@ -96,7 +96,7 @@
   display: flex;
   flex-grow: 1;
 
-  @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+  @media (max-width: map-get($grid-breakpoints, "sm")) {
     max-width: 100%;
   }
 
@@ -104,7 +104,7 @@
     margin: -1px -1px 0;
   }
 
-  @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+  @media (max-width: map-get($grid-breakpoints, "sm")) {
     width: 100% !important;
   }
 
@@ -249,7 +249,7 @@
     justify-content: center;
     align-items: center;
 
-    @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+    @media (max-width: map-get($grid-breakpoints, "sm")) {
       padding-top: 1rem;
       padding-bottom: 1rem;
     }
@@ -331,7 +331,7 @@
   max-width: 640px;
   margin: 0 auto;
 
-  @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+  @media (max-width: map-get($grid-breakpoints, "sm")) {
     flex-direction: column;
     gap: $spacer;
   }
@@ -348,7 +348,7 @@
   .next-button {
     flex-basis: 75%;
 
-     @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+     @media (max-width: map-get($grid-breakpoints, "sm")) {
        flex-basis: 100%;
      }
   }
@@ -356,7 +356,7 @@
   .previous-button {
     flex-basis: 25%;
 
-     @media (max-width: -1 + map-get($grid-breakpoints, "sm")) {
+     @media (max-width: map-get($grid-breakpoints, "sm")) {
        flex-basis: 100%;
      }
   }


### PR DESCRIPTION
## Description
Removing `-1 +` from media queries on css files since it does not affect the display. 
All removals were verified and they do not represent any visual difference on the rendered screen.
Issue: https://github.com/openedx/frontend-app-learning/issues/1701

## Screenshots for before and after


<img width="380" alt="Captura de pantalla 2025-06-04 a la(s) 1 25 45 p m" src="https://github.com/user-attachments/assets/9b76451d-700a-435e-84a6-7518f26a0749" />

<img width="383" alt="Captura de pantalla 2025-06-04 a la(s) 1 26 18 p m" src="https://github.com/user-attachments/assets/6e2022be-8126-4dfd-b9f1-80531e773b96" />

---

<img width="379" alt="Captura de pantalla 2025-06-04 a la(s) 12 20 17 p m" src="https://github.com/user-attachments/assets/a0525473-c1ef-4de3-b596-6a14570f019f" />

<img width="380" alt="Captura de pantalla 2025-06-04 a la(s) 12 22 34 p m" src="https://github.com/user-attachments/assets/44ccfa1c-b3dc-4d4c-afbe-f4b3069bf96b" />

---

<img width="381" alt="Captura de pantalla 2025-06-04 a la(s) 12 32 54 p m" src="https://github.com/user-attachments/assets/9013d76d-2c7d-46f2-aabd-f50a364ad150" />
<img width="380" alt="Captura de pantalla 2025-06-04 a la(s) 12 34 26 p m" src="https://github.com/user-attachments/assets/aa438dfe-0f37-4452-a819-5f8939c16aec" />

---
<img width="1476" alt="Captura de pantalla 2025-06-04 a la(s) 12 42 38 p m" src="https://github.com/user-attachments/assets/9835835a-9976-4fa0-9822-4eac057416b0" />
<img width="1478" alt="Captura de pantalla 2025-06-04 a la(s) 12 43 41 p m" src="https://github.com/user-attachments/assets/f57e3206-f270-4475-b9ea-90c597f706a8" />

---

<img width="322" alt="Captura de pantalla 2025-06-04 a la(s) 1 12 14 p m" src="https://github.com/user-attachments/assets/fcfc6166-1a0c-43db-b494-f3e9f0489936" />
<img width="324" alt="Captura de pantalla 2025-06-04 a la(s) 1 13 12 p m" src="https://github.com/user-attachments/assets/505a4bd3-873c-4f56-bc56-b3a0c63f1526" />

---

<img width="321" alt="Captura de pantalla 2025-06-04 a la(s) 1 14 41 p m" src="https://github.com/user-attachments/assets/a88a1d6a-7fdf-4bbe-a2fc-8549173a7c08" />

<img width="319" alt="Captura de pantalla 2025-06-04 a la(s) 1 16 12 p m" src="https://github.com/user-attachments/assets/205de5b2-5faf-4551-9091-49bafc02a4f7" />

