### PR TITLE
fix: fixed right panel closing issue

### DIFF
--- a/src/courseware/course/new-sidebar/SidebarContextProvider.tsx
+++ b/src/courseware/course/new-sidebar/SidebarContextProvider.tsx
@@ -54,6 +54,7 @@ const SidebarProvider: React.FC<Props> = ({
   }, [courseId]);
 
   useEffect(() => {
+    window.sessionStorage.setItem('hideCourseOutlineSidebar', 'true');
     setHideDiscussionbar(!isDiscussionbarAvailable);
     setHideNotificationbar(!isNotificationbarAvailable);
     if (initialSidebar && currentSidebar !== initialSidebar) {

--- a/src/courseware/course/new-sidebar/SidebarContextProvider.tsx
+++ b/src/courseware/course/new-sidebar/SidebarContextProvider.tsx
@@ -55,6 +55,7 @@ const SidebarProvider: React.FC<Props> = ({
 
   useEffect(() => {
     window.sessionStorage.setItem('hideCourseOutlineSidebar', 'true');
+    window.sessionStorage.setItem(`notificationTrayStatus.${courseId}`, 'open');
     setHideDiscussionbar(!isDiscussionbarAvailable);
     setHideNotificationbar(!isNotificationbarAvailable);
     if (initialSidebar && currentSidebar !== initialSidebar) {

--- a/src/courseware/course/sidebar/sidebars/course-outline/hooks.js
+++ b/src/courseware/course/sidebar/sidebars/course-outline/hooks.js
@@ -68,6 +68,7 @@ export const useCourseOutlineSidebar = () => {
     } else {
       toggleSidebar(ID);
       window.sessionStorage.removeItem('hideCourseOutlineSidebar');
+      window.sessionStorage.setItem(`notificationTrayStatus.${courseId}`, 'closed');
     }
   };
 


### PR DESCRIPTION
[INF-1926](https://2u-internal.atlassian.net/browse/INF-1926)

**Description**
Stacked right sidebar not working correctly with left nav sidebar

**Solution**
The issue has been resolved by closing the left panel when the unit changes.

The change is related to hiding the course outline sidebar whenever the unit or topic changes. As a result, when navigating to a new unit or topic, the course outline sidebar will automatically close, and only the right panel will remain visible.








