### PR TITLE
Deprecate react-unit-test-utils 2/2

### DIFF
--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
@@ -99,11 +99,13 @@ const setShowError = jest.fn();
 const setWindowTopOffset = jest.fn();
 
 const mockState = (state) => {
-  const { iframeHeight, hasLoaded, showError, windowTopOffset } = state;
-  if ('iframeHeight' in state) jest.spyOn(iframeBehaviorState, 'iframeHeight').mockImplementation(() => [iframeHeight, setIframeHeight]);
-  if ('hasLoaded' in state) jest.spyOn(iframeBehaviorState, 'hasLoaded').mockImplementation(() => [hasLoaded, setHasLoaded]);
-  if ('showError' in state) jest.spyOn(iframeBehaviorState, 'showError').mockImplementation(() => [showError, setShowError]);
-  if ('windowTopOffset' in state) jest.spyOn(iframeBehaviorState, 'windowTopOffset').mockImplementation(() => [windowTopOffset, setWindowTopOffset]);
+  const {
+    iframeHeight, hasLoaded, showError, windowTopOffset,
+  } = state;
+  if ('iframeHeight' in state) { jest.spyOn(iframeBehaviorState, 'iframeHeight').mockImplementation(() => [iframeHeight, setIframeHeight]); }
+  if ('hasLoaded' in state) { jest.spyOn(iframeBehaviorState, 'hasLoaded').mockImplementation(() => [hasLoaded, setHasLoaded]); }
+  if ('showError' in state) { jest.spyOn(iframeBehaviorState, 'showError').mockImplementation(() => [showError, setShowError]); }
+  if ('windowTopOffset' in state) { jest.spyOn(iframeBehaviorState, 'windowTopOffset').mockImplementation(() => [windowTopOffset, setWindowTopOffset]); }
 };
 
 describe('useIFrameBehavior hook', () => {
@@ -165,7 +167,7 @@ describe('useIFrameBehavior hook', () => {
         ]);
       });
       describe('resize message', () => {
-        const height = 23;
+        const customHeight = 23;
         const resizeMessage = (height = 23) => ({
           data: { type: messageTypes.resize, payload: { height } },
         });
@@ -182,9 +184,9 @@ describe('useIFrameBehavior hook', () => {
             mockState({ ...defaultStateVals, hasLoaded: true });
             renderHook(() => useIFrameBehavior(props));
             const { cb } = useEventListener.mock.calls[0][1];
-            cb(resizeMessage(height));
+            cb(resizeMessage(customHeight));
             expect(setIframeHeight).toHaveBeenCalledWith(0);
-            expect(setIframeHeight).toHaveBeenCalledWith(height);
+            expect(setIframeHeight).toHaveBeenCalledWith(customHeight);
           });
         });
         describe('payload height is 0', () => {
@@ -194,7 +196,7 @@ describe('useIFrameBehavior hook', () => {
             const { cb } = useEventListener.mock.calls[0][1];
             cb(resizeMessage(0));
             expect(setIframeHeight).toHaveBeenCalledWith(0);
-            expect(setIframeHeight).not.toHaveBeenCalledWith(height);
+            expect(setIframeHeight).not.toHaveBeenCalledWith(customHeight);
           });
         });
         describe('payload is present but uninitialized', () => {
@@ -277,7 +279,7 @@ describe('useIFrameBehavior hook', () => {
     describe('visibility tracking', () => {
       it('sets up visibility tracking after iframe has loaded', () => {
         mockState({ ...defaultStateVals, hasLoaded: true });
-        
+
         renderHook(() => useIFrameBehavior(props));
 
         expect(global.window.addEventListener).toHaveBeenCalledTimes(2);

--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
@@ -167,14 +167,15 @@ describe('useIFrameBehavior hook', () => {
         ]);
       });
       describe('resize message', () => {
-        const customHeight = 23;
-        const resizeMessage = (height = 23) => ({
+        const customHeight = 25;
+        const defaultHeight = 23;
+        const resizeMessage = (height = defaultHeight) => ({
           data: { type: messageTypes.resize, payload: { height } },
         });
         const videoFullScreenMessage = (open = false) => ({
           data: { type: messageTypes.videoFullScreen, payload: { open } },
         });
-        const testSetIFrameHeight = (height = 23) => {
+        const testSetIFrameHeight = (height = defaultHeight) => {
           const { cb } = useEventListener.mock.calls[0][1];
           cb(resizeMessage(height));
           expect(setIframeHeight).toHaveBeenCalledWith(height);
@@ -187,6 +188,7 @@ describe('useIFrameBehavior hook', () => {
             cb(resizeMessage(customHeight));
             expect(setIframeHeight).toHaveBeenCalledWith(0);
             expect(setIframeHeight).toHaveBeenCalledWith(customHeight);
+            expect(setIframeHeight).not.toHaveBeenCalledWith(defaultHeight);
           });
         });
         describe('payload height is 0', () => {
@@ -197,6 +199,7 @@ describe('useIFrameBehavior hook', () => {
             cb(resizeMessage(0));
             expect(setIframeHeight).toHaveBeenCalledWith(0);
             expect(setIframeHeight).not.toHaveBeenCalledWith(customHeight);
+            expect(setIframeHeight).not.toHaveBeenCalledWith(defaultHeight);
           });
         });
         describe('payload is present but uninitialized', () => {

--- a/src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
+++ b/src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
@@ -1,19 +1,11 @@
 import React from 'react';
-
-import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils/dist';
-
 import { useEventListener } from '@src/generic/hooks';
-
-export const stateKeys = StrictDict({
-  isOpen: 'isOpen',
-  options: 'options',
-});
 
 export const DEFAULT_HEIGHT = '100%';
 
 const useModalIFrameData = () => {
-  const [isOpen, setIsOpen] = useKeyedState(stateKeys.isOpen, false);
-  const [options, setOptions] = useKeyedState(stateKeys.options, { height: DEFAULT_HEIGHT });
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [options, setOptions] = React.useState({ height: DEFAULT_HEIGHT });
 
   const handleModalClose = () => {
     const rootFrame = document.querySelector('iframe');

--- a/src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.js
+++ b/src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.js
@@ -1,19 +1,13 @@
 import React from 'react';
-
-import { StrictDict, useKeyedState } from '@edx/react-unit-test-utils/dist';
 import { useModel } from '@src/generic/model-store';
 
 import { modelKeys } from '../constants';
-
-export const stateKeys = StrictDict({
-  shouldDisplay: 'shouldDisplay',
-});
 
 /**
  * @return {bool} should the honor code be displayed?
  */
 const useShouldDisplayHonorCode = ({ id, courseId }) => {
-  const [shouldDisplay, setShouldDisplay] = useKeyedState(stateKeys.shouldDisplay, false);
+  const [shouldDisplay, setShouldDisplay] = React.useState(false);
 
   const { graded } = useModel(modelKeys.units, id);
   const { userNeedsIntegritySignature } = useModel(modelKeys.coursewareMeta, courseId);

--- a/src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.test.js
@@ -1,21 +1,11 @@
-import React from 'react';
-
-import { getEffects, mockUseKeyedState } from '@edx/react-unit-test-utils';
+import { renderHook } from '@testing-library/react';
 import { useModel } from '@src/generic/model-store';
-
+import useShouldDisplayHonorCode from './useShouldDisplayHonorCode';
 import { modelKeys } from '../constants';
 
-import useShouldDisplayHonorCode, { stateKeys } from './useShouldDisplayHonorCode';
-
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useEffect: jest.fn(),
-}));
 jest.mock('@src/generic/model-store', () => ({
   useModel: jest.fn(),
 }));
-
-const state = mockUseKeyedState(stateKeys);
 
 const props = {
   id: 'test-id',
@@ -28,52 +18,29 @@ const mockModels = (graded, userNeedsIntegritySignature) => {
   ));
 };
 
-describe('useShouldDisplayHonorCode hook', () => {
+describe('useShouldDisplayHonorCode', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockModels(false, false);
-    state.mock();
   });
-  describe('behavior', () => {
-    it('initializes shouldDisplay to false', () => {
-      useShouldDisplayHonorCode(props);
-      state.expectInitializedWith(stateKeys.shouldDisplay, false);
-    });
-    describe('effect - on userNeedsIntegritySignature', () => {
-      describe('graded and needs integrity signature', () => {
-        it('sets shouldDisplay(true)', () => {
-          mockModels(true, true);
-          useShouldDisplayHonorCode(props);
-          const cb = getEffects([state.setState.shouldDisplay, true], React)[0];
-          cb();
-          expect(state.setState.shouldDisplay).toHaveBeenCalledWith(true);
-        });
-      });
-      describe('not graded', () => {
-        it('sets should not display', () => {
-          mockModels(true, false);
-          useShouldDisplayHonorCode(props);
-          const cb = getEffects([state.setState.shouldDisplay, false], React)[0];
-          cb();
-          expect(state.setState.shouldDisplay).toHaveBeenCalledWith(false);
-        });
-      });
-      describe('does not need integrity signature', () => {
-        it('sets should not display', () => {
-          mockModels(false, true);
-          useShouldDisplayHonorCode(props);
-          const cb = getEffects([state.setState.shouldDisplay, true], React)[0];
-          cb();
-          expect(state.setState.shouldDisplay).toHaveBeenCalledWith(false);
-        });
-      });
-    });
+
+  it('should return false when userNeedsIntegritySignature is false', () => {
+    mockModels(true, false);
+
+    const { result } = renderHook(() => useShouldDisplayHonorCode(props));
+    expect(result.current).toBe(false);
   });
-  describe('output', () => {
-    it('returns shouldDisplay value from state', () => {
-      const testValue = 'test-value';
-      state.mockVal(stateKeys.shouldDisplay, testValue);
-      expect(useShouldDisplayHonorCode(props)).toEqual(testValue);
-    });
+
+  it('should return false when graded is false', () => {
+    mockModels(false, true);
+
+    const { result } = renderHook(() => useShouldDisplayHonorCode(props));
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when both userNeedsIntegritySignature and graded are true', () => {
+    mockModels(true, true);
+
+    const { result } = renderHook(() => useShouldDisplayHonorCode(props));
+    expect(result.current).toBe(true);
   });
 });


### PR DESCRIPTION
### Description
Remove use of 'useKeyedState' (react-unit-test-utils) in following components/files:
- src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
- src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.js
- src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.js

Remove use of 'StrictDict' (react-unit-test-utils) in following components/files:
- src/courseware/course/sequence/Unit/hooks/useModalIFrameData.js
- src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.js
- src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.js

Remove use of 'mockUseKeyedState' (react-unit-test-utils) in following components/files:
- src/courseware/course/sequence/Unit/hooks/useModalIFrameData.test.js
- src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.test.js
- src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js

Remove use of 'getEffects' (react-unit-test-utils) in following components/files:
- src/courseware/course/sequence/Unit/hooks/useShouldDisplayHonorCode.test.js
- src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js

#### Support Information
Closes #1749 