### PR TITLE
fix(deps): update frontend-lib-learning-assistant to v2.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/browserslist-config": "1.5.0",
         "@edx/frontend-component-footer": "^14.6.0",
         "@edx/frontend-component-header": "^6.2.0",
-        "@edx/frontend-lib-learning-assistant": "^2.20.0",
+        "@edx/frontend-lib-learning-assistant": "^2.21.1",
         "@edx/frontend-lib-special-exams": "^4.0.0",
         "@edx/frontend-platform": "^8.3.1",
         "@edx/openedx-atlas": "^0.7.0",
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/@edx/frontend-lib-learning-assistant": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.21.0.tgz",
-      "integrity": "sha512-CUzPCQaBgXi6E1kvY0nyBSVFu8RUGpwKH4V0p8ZuysyHyRHpA+339b+gEi9FvVBMP/X4IxZHsZhi7nphlr43Iw==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-lib-learning-assistant/-/frontend-lib-learning-assistant-2.21.1.tgz",
+      "integrity": "sha512-CHWvQVEtb7iTMl13VNwhZwW2spEq85PyX0y+sqPYWsQ7phKQOpyMdRb5FauIkiu2OzMGF+KeIiyXk+scCJa/4A==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/browserslist-config": "1.5.0",
     "@edx/frontend-component-footer": "^14.6.0",
     "@edx/frontend-component-header": "^6.2.0",
-    "@edx/frontend-lib-learning-assistant": "^2.20.0",
+    "@edx/frontend-lib-learning-assistant": "^2.21.1",
     "@edx/frontend-lib-special-exams": "^4.0.0",
     "@edx/frontend-platform": "^8.3.1",
     "@edx/openedx-atlas": "^0.7.0",


### PR DESCRIPTION
**Description:**
This pull request updates the version of `@edx/frontend-lib-learning-assistant` in the `package.json` file from `^2.20.0` to `^2.21.1`. This release has an updated Chat API V2. The usage of the V2 api can be enabled through a feature flag.

**JIRA:** [COSMO-700](https://2u-internal.atlassian.net/browse/COSMO-700) (private)
