### PR TITLE
fix: sidebar unitid undefined

### DIFF
--- a/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarUnit.test.jsx
+++ b/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarUnit.test.jsx
@@ -102,11 +102,11 @@ describe('<SidebarUnit />', () => {
     it('should handle click when activeUnitId is null/undefined (covers findSequenceByUnitId return null)', async () => {
       const user = userEvent.setup();
       await initTestStore();
-      
+
       // Render with activeUnitId as null to trigger the findSequenceByUnitId return null
-      renderWithProvider({ 
+      renderWithProvider({
         activeUnitId: null,
-        unit: { ...unit } 
+        unit: { ...unit },
       });
 
       // Click should not cause errors and should not send tracking events
@@ -120,11 +120,11 @@ describe('<SidebarUnit />', () => {
     it('should handle click when activeUnitId is undefined (covers findSequenceByUnitId return null)', async () => {
       const user = userEvent.setup();
       await initTestStore();
-      
+
       // Render with activeUnitId as undefined to trigger the findSequenceByUnitId return null
-      renderWithProvider({ 
+      renderWithProvider({
         activeUnitId: undefined,
-        unit: { ...unit } 
+        unit: { ...unit },
       });
 
       await user.click(screen.getByText(unit.title));
@@ -137,14 +137,14 @@ describe('<SidebarUnit />', () => {
     it('should handle click when unit id is not found in any sequence (covers early return)', async () => {
       const user = userEvent.setup();
       await initTestStore();
-      
+
       // Use a unit ID that doesn't exist in any sequence
       const nonExistentUnitId = 'non-existent-unit-id';
-      
-      renderWithProvider({ 
+
+      renderWithProvider({
         unit: { ...unit, id: nonExistentUnitId },
         id: nonExistentUnitId,
-        activeUnitId: unit.id // valid activeUnitId but invalid target unit
+        activeUnitId: unit.id, // valid activeUnitId but invalid target unit
       });
 
       await user.click(screen.getByText(unit.title));
@@ -157,14 +157,14 @@ describe('<SidebarUnit />', () => {
     it('should handle click when both activeUnitId and target unit id are invalid', async () => {
       const user = userEvent.setup();
       await initTestStore();
-      
+
       const nonExistentUnitId = 'non-existent-unit-id';
       const anotherNonExistentUnitId = 'another-non-existent-unit-id';
-      
-      renderWithProvider({ 
+
+      renderWithProvider({
         unit: { ...unit, id: nonExistentUnitId },
         id: nonExistentUnitId,
-        activeUnitId: anotherNonExistentUnitId
+        activeUnitId: anotherNonExistentUnitId,
       });
 
       await user.click(screen.getByText(unit.title));

--- a/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarUnit.test.jsx
+++ b/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarUnit.test.jsx
@@ -98,6 +98,83 @@ describe('<SidebarUnit />', () => {
     expect(screen.getByText(unit.title)).toBeInTheDocument();
   });
 
+  describe('handleUnitClick coverage tests', () => {
+    it('should handle click when activeUnitId is null/undefined (covers findSequenceByUnitId return null)', async () => {
+      const user = userEvent.setup();
+      await initTestStore();
+      
+      // Render with activeUnitId as null to trigger the findSequenceByUnitId return null
+      renderWithProvider({ 
+        activeUnitId: null,
+        unit: { ...unit } 
+      });
+
+      // Click should not cause errors and should not send tracking events
+      await user.click(screen.getByText(unit.title));
+
+      // Since activeSequence will be null, tracking events should not be sent
+      expect(sendTrackEvent).not.toHaveBeenCalled();
+      expect(sendTrackingLogEvent).not.toHaveBeenCalled();
+    });
+
+    it('should handle click when activeUnitId is undefined (covers findSequenceByUnitId return null)', async () => {
+      const user = userEvent.setup();
+      await initTestStore();
+      
+      // Render with activeUnitId as undefined to trigger the findSequenceByUnitId return null
+      renderWithProvider({ 
+        activeUnitId: undefined,
+        unit: { ...unit } 
+      });
+
+      await user.click(screen.getByText(unit.title));
+
+      // Since activeSequence will be null, tracking events should not be sent
+      expect(sendTrackEvent).not.toHaveBeenCalled();
+      expect(sendTrackingLogEvent).not.toHaveBeenCalled();
+    });
+
+    it('should handle click when unit id is not found in any sequence (covers early return)', async () => {
+      const user = userEvent.setup();
+      await initTestStore();
+      
+      // Use a unit ID that doesn't exist in any sequence
+      const nonExistentUnitId = 'non-existent-unit-id';
+      
+      renderWithProvider({ 
+        unit: { ...unit, id: nonExistentUnitId },
+        id: nonExistentUnitId,
+        activeUnitId: unit.id // valid activeUnitId but invalid target unit
+      });
+
+      await user.click(screen.getByText(unit.title));
+
+      // Since targetSequence will be null, tracking events should not be sent
+      expect(sendTrackEvent).not.toHaveBeenCalled();
+      expect(sendTrackingLogEvent).not.toHaveBeenCalled();
+    });
+
+    it('should handle click when both activeUnitId and target unit id are invalid', async () => {
+      const user = userEvent.setup();
+      await initTestStore();
+      
+      const nonExistentUnitId = 'non-existent-unit-id';
+      const anotherNonExistentUnitId = 'another-non-existent-unit-id';
+      
+      renderWithProvider({ 
+        unit: { ...unit, id: nonExistentUnitId },
+        id: nonExistentUnitId,
+        activeUnitId: anotherNonExistentUnitId
+      });
+
+      await user.click(screen.getByText(unit.title));
+
+      // Both sequences will be null, so tracking events should not be sent
+      expect(sendTrackEvent).not.toHaveBeenCalled();
+      expect(sendTrackingLogEvent).not.toHaveBeenCalled();
+    });
+  });
+
   describe('When a unit is clicked', () => {
     it('sends log event correctly', async () => {
       const user = userEvent.setup();

--- a/src/courseware/course/sidebar/sidebars/course-outline/hooks.js
+++ b/src/courseware/course/sidebar/sidebars/course-outline/hooks.js
@@ -74,9 +74,17 @@ export const useCourseOutlineSidebar = () => {
 
   const handleUnitClick = ({ sequenceId, activeUnitId, id }) => {
     const logEvent = (eventName, widgetPlacement) => {
-      const findSequenceByUnitId = () => Object.values(sequences).find(seq => seq.unitIds.includes(activeUnitId));
+      const findSequenceByUnitId = (searchUnitId) => {
+        if (!searchUnitId) {
+          return null;
+        }
+        return Object.values(sequences).find(seq => seq.unitIds.includes(searchUnitId));
+      };
       const activeSequence = findSequenceByUnitId(activeUnitId);
       const targetSequence = findSequenceByUnitId(id);
+      if (!activeSequence || !targetSequence) {
+        return;
+      }
       const payload = {
         id: activeUnitId,
         current_tab: activeSequence.unitIds.indexOf(activeUnitId) + 1,
@@ -95,7 +103,9 @@ export const useCourseOutlineSidebar = () => {
     };
 
     logEvent('edx.ui.lms.sequence.tab_selected', 'left');
-    dispatch(checkBlockCompletion(courseId, sequenceId, activeUnitId));
+    if (activeUnitId) {
+      dispatch(checkBlockCompletion(courseId, sequenceId, activeUnitId));
+    }
 
     // Hide the sidebar after selecting a unit on a mobile device.
     if (shouldDisplayFullScreen) {

--- a/src/courseware/data/redux.test.js
+++ b/src/courseware/data/redux.test.js
@@ -357,15 +357,15 @@ describe('Data layer integration tests', () => {
         // Test the first return {} - when unitId is falsy
         const thunk = thunks.checkBlockCompletion(courseId, sequenceId, null);
         const result = await thunk(store.dispatch, store.getState);
-        
+
         expect(result).toEqual({});
       });
 
       it('Should return empty object when unitId is undefined', async () => {
-        // Test the first return {} - when unitId is undefined  
+        // Test the first return {} - when unitId is undefined
         const thunk = thunks.checkBlockCompletion(courseId, sequenceId, undefined);
         const result = await thunk(store.dispatch, store.getState);
-        
+
         expect(result).toEqual({});
       });
 
@@ -373,14 +373,14 @@ describe('Data layer integration tests', () => {
         // Test the first return {} - when unitId is empty string
         const thunk = thunks.checkBlockCompletion(courseId, sequenceId, '');
         const result = await thunk(store.dispatch, store.getState);
-        
+
         expect(result).toEqual({});
       });
 
       it('Should return empty object when unit is already complete', async () => {
         // First, set up the state so that the unit is already marked as complete
         const testUnitId = 'test-unit-id';
-        
+
         // Dispatch an action to mark the unit as complete in the store
         store.dispatch(updateModel({
           modelType: 'units',
@@ -389,16 +389,16 @@ describe('Data layer integration tests', () => {
             complete: true,
           },
         }));
-        
+
         // Record the current number of API calls before our test
         const initialRequestCount = axiosMock.history.post.length;
-        
+
         // Now call checkBlockCompletion - it should return {} without making API calls
         const thunk = thunks.checkBlockCompletion(courseId, sequenceId, testUnitId);
         const result = await thunk(store.dispatch, store.getState);
-        
+
         expect(result).toEqual({});
-        
+
         // Verify that no new API calls were made (since it should return early)
         expect(axiosMock.history.post.length).toBe(initialRequestCount);
       });

--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -179,6 +179,7 @@ export function checkBlockCompletion(courseId, sequenceId, unitId) {
     if (!unitId) {
       return {};
     }
+
     const { models } = getState();
     if (models.units[unitId]?.complete) {
       return {}; // do nothing. Things don't get uncompleted after they are completed.

--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -179,7 +179,6 @@ export function checkBlockCompletion(courseId, sequenceId, unitId) {
     if (!unitId) {
       return {};
     }
-    
     const { models } = getState();
     if (models.units[unitId]?.complete) {
       return {}; // do nothing. Things don't get uncompleted after they are completed.

--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -176,6 +176,10 @@ export function fetchSequence(sequenceId, isPreview) {
 
 export function checkBlockCompletion(courseId, sequenceId, unitId) {
   return async (dispatch, getState) => {
+    if (!unitId) {
+      return {};
+    }
+    
     const { models } = getState();
     if (models.units[unitId]?.complete) {
       return {}; // do nothing. Things don't get uncompleted after they are completed.


### PR DESCRIPTION
Fixes https://github.com/openedx/frontend-app-learning/issues/1747

This bug is due to activeUnitId being null when viewing a locked unit. The fix was to add some defensiveness to the handleUnitClick and checkBlockCompletion functions.

This prevents sendTrackEvent, sendTrackingLogEvent, checkBlockCompletion from running when navigating from a locked unit. If those methods need to run, even when the unit is locked, then we need to add some more logic to handle that state without throwing a null pointer error.

https://github.com/user-attachments/assets/b21a7232-b9b0-498d-b411-710908a2f809

