### PR TITLE
fix: space gap between modals buttons in the discussions-sidebar-frame

### DIFF
--- a/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
+++ b/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
@@ -6,4 +6,19 @@
     .pgn__modal-footer .pgn__action-row {
         gap: 8px;
     }
+
+    #post,
+    #reply,
+    #comment.text-primary-500 {
+        color: var(--pgn-color-body-base) !important;
+    }
+
+    button[aria-label="Endorse"].text-dark-500,
+    button[aria-label="Endorse"].text-success-500 {
+        color: var(--pgn-color-primary-base) !important;
+    }
+
+    .alert-content.bg-success-500 .author-name {
+        color: var(--pgn-color-white) !important;
+    }
 }

--- a/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
+++ b/src/courseware/course/sidebar/sidebars/discussions/Discussions.scss
@@ -2,4 +2,8 @@
     @media (--pgn-size-breakpoint-max-width-xl) {
         max-height: calc(100vh - 65px);
     }
+
+    .pgn__modal-footer .pgn__action-row {
+        gap: 8px;
+    }
 }


### PR DESCRIPTION
There is an issue, if open discussions in the sidebar when in course. And then choose dropdown with the actions, then report or delete, in the appeared modal focus on buttons will be overlaped on each other:

<img width="1725" height="907" alt="Screenshot 2025-07-28 at 12 03 48" src="https://github.com/user-attachments/assets/24440ea0-ed6f-4518-a861-6a3877619fe6" />

This fix add some gap, to prevent this style issue:
<img width="1728" height="907" alt="Screenshot 2025-07-28 at 12 08 05" src="https://github.com/user-attachments/assets/ff20a4b5-b4ec-441d-a005-40c6e3ddf7cb" />

Additionally fixed styles for the reply/post sections, for now it has style issues when opened in the sidebar:
<img width="403" height="272" alt="Screenshot 2025-08-04 at 11 34 26" src="https://github.com/user-attachments/assets/721d1bcc-477a-469e-b7e5-8fd4bcb230ff" />

After fix:
<img width="378" height="262" alt="Screenshot 2025-08-04 at 11 43 08" src="https://github.com/user-attachments/assets/0067b7be-4304-40d8-92f9-d4b62813b67a" />

