### PR TITLE
feat: add plugin slot for content iframe error component

### DIFF
--- a/src/courseware/course/sequence/Unit/ContentIFrame.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 
-import { ErrorPage } from '@edx/frontend-platform/react';
 import { ModalDialog } from '@openedx/paragon';
 import { ContentIFrameLoaderSlot } from '../../../../plugin-slots/ContentIFrameLoaderSlot';
+import { ContentIFrameErrorSlot } from '../../../../plugin-slots/ContentIFrameErrorSlot';
 
 import * as hooks from './hooks';
 
@@ -66,7 +66,11 @@ const ContentIFrame = ({
   return (
     <>
       {(shouldShowContent && !hasLoaded) && (
-        showError ? <ErrorPage /> : <ContentIFrameLoaderSlot courseId={courseId} loadingMessage={loadingMessage} />
+        showError ? (
+          <ContentIFrameErrorSlot courseId={courseId} />
+         ) : (
+          <ContentIFrameLoaderSlot courseId={courseId} loadingMessage={loadingMessage} />
+        )
       )}
       {shouldShowContent && (
         <div className="unit-iframe-wrapper">

--- a/src/courseware/course/sequence/Unit/ContentIFrame.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.jsx
@@ -68,7 +68,7 @@ const ContentIFrame = ({
       {(shouldShowContent && !hasLoaded) && (
         showError ? (
           <ContentIFrameErrorSlot courseId={courseId} />
-         ) : (
+        ) : (
           <ContentIFrameLoaderSlot courseId={courseId} loadingMessage={loadingMessage} />
         )
       )}

--- a/src/plugin-slots/ContentIFrameErrorSlot/README.md
+++ b/src/plugin-slots/ContentIFrameErrorSlot/README.md
@@ -1,4 +1,4 @@
-# Content iframe Loader Slot
+# Content iFrame Error Slot
 
 ### Slot ID: `org.openedx.frontend.learning.content_iframe_error.v1`
 
@@ -25,7 +25,7 @@ const config = {
           widget: {
             id: 'custom_error_page',
             type: DIRECT_PLUGIN,
-            RenderWidget: (courseId) => (
+            RenderWidget: ({courseId}) => (
               <h1>🚨🤖💥</h1>
             ),
           },

--- a/src/plugin-slots/ContentIFrameErrorSlot/README.md
+++ b/src/plugin-slots/ContentIFrameErrorSlot/README.md
@@ -1,0 +1,39 @@
+# Content iframe Loader Slot
+
+### Slot ID: `org.openedx.frontend.learning.content_iframe_error.v1`
+
+### Parameters: `courseId`
+
+## Description
+
+This slot is used to replace/modify the content iframe error page.
+
+## Example
+
+The following `env.config.jsx` will replace the error page with emojis.
+
+```js
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const config = {
+  pluginSlots: {
+    'org.openedx.frontend.learning.content_iframe_error.v1': {
+      keepDefault: false,
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_error_page',
+            type: DIRECT_PLUGIN,
+            RenderWidget: (courseId) => (
+              <h1>🚨🤖💥</h1>
+            ),
+          },
+        },
+      ]
+    }
+  },
+}
+
+export default config;
+```

--- a/src/plugin-slots/ContentIFrameErrorSlot/index.tsx
+++ b/src/plugin-slots/ContentIFrameErrorSlot/index.tsx
@@ -1,0 +1,15 @@
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
+import { ErrorPage } from '@edx/frontend-platform/react';
+
+export const ContentIFrameErrorSlot : React.FC<Props> = ({courseId}) => (
+  <PluginSlot 
+    id="org.openedx.frontend.learning.content_iframe_error.v1"
+    pluginProps={{courseId}}
+  >
+    <ErrorPage />
+  </PluginSlot>
+);
+
+interface Props {
+    courseId: string;
+}

--- a/src/plugin-slots/ContentIFrameErrorSlot/index.tsx
+++ b/src/plugin-slots/ContentIFrameErrorSlot/index.tsx
@@ -1,6 +1,10 @@
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { ErrorPage } from '@edx/frontend-platform/react';
 
+interface Props {
+  courseId: string;
+}
+
 export const ContentIFrameErrorSlot : React.FC<Props> = ({ courseId }: Props) => (
   <PluginSlot
     id="org.openedx.frontend.learning.content_iframe_error.v1"
@@ -9,7 +13,3 @@ export const ContentIFrameErrorSlot : React.FC<Props> = ({ courseId }: Props) =>
     <ErrorPage />
   </PluginSlot>
 );
-
-interface Props {
-  courseId: string;
-}

--- a/src/plugin-slots/ContentIFrameErrorSlot/index.tsx
+++ b/src/plugin-slots/ContentIFrameErrorSlot/index.tsx
@@ -1,15 +1,15 @@
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { ErrorPage } from '@edx/frontend-platform/react';
 
-export const ContentIFrameErrorSlot : React.FC<Props> = ({courseId}) => (
-  <PluginSlot 
+export const ContentIFrameErrorSlot : React.FC<Props> = ({ courseId }: Props) => (
+  <PluginSlot
     id="org.openedx.frontend.learning.content_iframe_error.v1"
-    pluginProps={{courseId}}
+    pluginProps={{ courseId }}
   >
     <ErrorPage />
   </PluginSlot>
 );
 
 interface Props {
-    courseId: string;
+  courseId: string;
 }


### PR DESCRIPTION
Adds a plugin slot, `org.openedx.frontend.learning.content_iframe_error.v1` to enable customization via plugins of the error page shown when the unit iframe fails to load. 