### PR TITLE
feat: customize proctoring review requirements link using externalLinkUrlOverrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@edx/frontend-component-header": "^6.2.0",
         "@edx/frontend-lib-learning-assistant": "^2.22.0",
         "@edx/frontend-lib-special-exams": "^4.0.0",
-        "@edx/frontend-platform": "^8.3.1",
+        "@edx/frontend-platform": "^8.4.0",
         "@edx/openedx-atlas": "^0.7.0",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
         "@fortawesome/free-regular-svg-icons": "5.15.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@edx/frontend-component-header": "^6.2.0",
     "@edx/frontend-lib-learning-assistant": "^2.22.0",
     "@edx/frontend-lib-special-exams": "^4.0.0",
-    "@edx/frontend-platform": "^8.3.1",
+    "@edx/frontend-platform": "^8.4.0",
     "@edx/openedx-atlas": "^0.7.0",
     "@fortawesome/free-brands-svg-icons": "5.15.4",
     "@fortawesome/free-regular-svg-icons": "5.15.4",

--- a/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
+++ b/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import camelCase from 'lodash.camelcase';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
+import { getExternalLinkUrl } from '@edx/frontend-platform';
 import { Button } from '@openedx/paragon';
 
 import messages from '../messages';
@@ -207,7 +208,7 @@ const ProctoringInfoPanel = () => {
             {isSubmissionRequired(readableStatus) && (
               onboardingExamButton
             )}
-            <Button variant="outline-primary" block href="https://support.edx.org/hc/en-us/sections/115004169247-Taking-Timed-and-Proctored-Exams">
+            <Button variant="outline-primary" block href={getExternalLinkUrl('https://support.edx.org/hc/en-us/sections/115004169247-Taking-Timed-and-Proctored-Exams')}>
               {intl.formatMessage(messages.proctoringReviewRequirementsButton)}
             </Button>
           </div>


### PR DESCRIPTION
## Description

This PR applies the [`externalLinkUrlOverrides`](https://github.com/openedx/frontend-platform/tree/master?tab=readme-ov-file#overriding-default-external-links) feature to customize the `Review instructions and system requirements` link in the Proctoring Panel. It also pins the `frontend-platform` dependency to `^8.4.0`, the version where this feature was originally introduced.

## Testing instructions

- Paste the following config in the `env.config.jsx` file
```JS
const config = {
  externalLinkUrlOverrides : {
    "https://support.edx.org/hc/en-us/sections/115004169247-Taking-Timed-and-Proctored-Exams": "https://www.custom-link.com",
  },
}

export default config;
```
- Verify that the `Review instructions and system requirements` link is pointing to the custom link: `"https://www.custom-link.com"`