### PR TITLE
fix: ensure iframe visibility tracking is triggered on load

### DIFF
--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
@@ -280,7 +280,7 @@ describe('useIFrameBehavior hook', () => {
       });
     });
     describe('visibility tracking', () => {
-      it('sets up visibility tracking after iframe has loaded', () => {
+      it('sets up visibility tracking after iframe loads', () => {
         mockState({ ...defaultStateVals, hasLoaded: true });
 
         renderHook(() => useIFrameBehavior(props));
@@ -288,15 +288,9 @@ describe('useIFrameBehavior hook', () => {
         expect(global.window.addEventListener).toHaveBeenCalledTimes(2);
         expect(global.window.addEventListener).toHaveBeenCalledWith('scroll', expect.any(Function));
         expect(global.window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
-        // Initial visibility update.
-        expect(postMessage).toHaveBeenCalledWith(
-          {
-            type: 'unit.visibilityStatus',
-            data: {
-              topPosition: 100,
-              viewportHeight: 800,
-            },
-          },
+        // Initial visibility update is handled by the `handleIFrameLoad` method.
+        expect(postMessage).not.toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'unit.visibilityStatus' }),
           config.LMS_BASE_URL,
         );
       });
@@ -361,6 +355,20 @@ describe('useIFrameBehavior hook', () => {
         const event = { data: { event_name: eventName } };
         window.onmessage(event);
         expect(dispatch).toHaveBeenCalledWith(processEvent(event.data, fetchCourse));
+      });
+      it('updates initial iframe visibility on load', () => {
+        const { result } = renderHook(() => useIFrameBehavior(props));
+        result.current.handleIFrameLoad();
+        expect(postMessage).toHaveBeenCalledWith(
+          {
+            type: 'unit.visibilityStatus',
+            data: {
+              topPosition: 100,
+              viewportHeight: 800,
+            },
+          },
+          config.LMS_BASE_URL,
+        );
       });
     });
     it('forwards handleIframeLoad, showError, and hasLoaded from state fields', () => {

--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts
@@ -102,6 +102,23 @@ const useIFrameBehavior = ({
   useEventListener('message', receiveMessage);
 
   // Send visibility status to the iframe. It's used to mark XBlocks as viewed.
+  const updateIframeVisibility = () => {
+    const iframeElement = document.getElementById(elementId) as HTMLIFrameElement | null;
+    const rect = iframeElement?.getBoundingClientRect();
+    const visibleInfo = {
+      type: 'unit.visibilityStatus',
+      data: {
+        topPosition: rect?.top,
+        viewportHeight: window.innerHeight,
+      },
+    };
+    iframeElement?.contentWindow?.postMessage(
+      visibleInfo,
+      `${getConfig().LMS_BASE_URL}`,
+    );
+  };
+
+  // Set up visibility tracking event listeners.
   React.useEffect(() => {
     if (!hasLoaded) {
       return undefined;
@@ -112,26 +129,8 @@ const useIFrameBehavior = ({
       return undefined;
     }
 
-    const updateIframeVisibility = () => {
-      const rect = iframeElement.getBoundingClientRect();
-      const visibleInfo = {
-        type: 'unit.visibilityStatus',
-        data: {
-          topPosition: rect.top,
-          viewportHeight: window.innerHeight,
-        },
-      };
-      iframeElement?.contentWindow?.postMessage(
-        visibleInfo,
-        `${getConfig().LMS_BASE_URL}`,
-      );
-    };
-
     // Throttle the update function to prevent it from sending too many messages to the iframe.
     const throttledUpdateVisibility = throttle(updateIframeVisibility, 100);
-
-    // Update the visibility of the iframe in case the element is already visible.
-    updateIframeVisibility();
 
     // Add event listeners to update the visibility of the iframe when the window is scrolled or resized.
     window.addEventListener('scroll', throttledUpdateVisibility);
@@ -167,6 +166,9 @@ const useIFrameBehavior = ({
         dispatch(processEvent(e.data, fetchCourse));
       }
     };
+
+    // Update the visibility of the iframe in case the element is already visible.
+    updateIframeVisibility();
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
The previous implementation (https://github.com/openedx/frontend-app-learning/pull/1491) had a race condition that sometimes prevented XBlocks from being marked as viewed. Users had to scroll or resize the window to trigger visibility tracking instead of having it happen once the content loads.

## Description

## Testing instructions:
1. (Optional) Set `COMPLETION_BY_VIEWING_DELAY_MS = 1000` in `lms/envs/private.py` for easier testing. The default value is `5000`.
2. (Optional) Change `publish_completion` to `publish_completions` in `lms/static/completion/js/CompletionOnViewService.js` for easier testing. Otherwise, you will need to create a new XBlock for the next check or manually remove the `BlockCompletion` object from the DB to get the API call re-triggered the next time you view it.
3. Use Chrome for the next steps (do not check out this branch yet).
4. Create an HTML block with a single line. Check that the `publish_completion` request is not called in the Learning MFE.
5. Check out this branch and repeat the previous step. Ensure that the request has been published.

## Deadline

"None"

## Other information

_Private-ref: [BB-9602](https://tasks.opencraft.com/browse/BB-9602)_