### PR TITLE
feat: updated notification preferences unsubscribe flow

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@ export const DECODE_ROUTES = {
 
 export const ROUTES = {
   UNSUBSCRIBE: '/goal-unsubscribe/:token',
-  PREFERENCES_UNSUBSCRIBE: '/preferences-unsubscribe/:userToken/:updatePatch',
+  PREFERENCES_UNSUBSCRIBE: '/preferences-unsubscribe/:userToken/:updatePatch?',
   REDIRECT: '/redirect/*',
   DASHBOARD: 'dashboard',
   ENTERPRISE_LEARNER_DASHBOARD: 'enterprise-learner-dashboard',

--- a/src/preferences-unsubscribe/data/api.js
+++ b/src/preferences-unsubscribe/data/api.js
@@ -1,11 +1,11 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
-export const getUnsubscribeUrl = (userToken, updatePatch) => (
-  `${getConfig().LMS_BASE_URL}/api/notifications/preferences/update/${userToken}/${updatePatch}/`
+export const getUnsubscribeUrl = (userToken) => (
+  `${getConfig().LMS_BASE_URL}/api/notifications/preferences/update/${userToken}/`
 );
 
-export async function unsubscribeNotificationPreferences(userToken, updatePatch) {
-  const url = getUnsubscribeUrl(userToken, updatePatch);
+export async function unsubscribeNotificationPreferences(userToken) {
+  const url = getUnsubscribeUrl(userToken);
   return getAuthenticatedHttpClient().get(url);
 }

--- a/src/preferences-unsubscribe/index.jsx
+++ b/src/preferences-unsubscribe/index.jsx
@@ -17,18 +17,18 @@ import messages from './messages';
 
 const PreferencesUnsubscribe = () => {
   const intl = useIntl();
-  const { userToken, updatePatch } = useParams();
+  const { userToken } = useParams();
   const [status, setStatus] = useState(LOADING);
 
   useEffect(() => {
-    unsubscribeNotificationPreferences(userToken, updatePatch).then(
+    unsubscribeNotificationPreferences(userToken).then(
       () => setStatus(LOADED),
       (error) => {
         setStatus(FAILED);
         logError(error);
       },
     );
-    sendTrackEvent('edx.ui.lms.notifications.preferences.unsubscribe', { userToken, updatePatch });
+    sendTrackEvent('edx.ui.lms.notifications.preferences.unsubscribe', { userToken });
   }, []);
 
   const pageContent = {

--- a/src/preferences-unsubscribe/index.test.jsx
+++ b/src/preferences-unsubscribe/index.test.jsx
@@ -24,8 +24,7 @@ describe('Notification Preferences One Click Unsubscribe', () => {
   let component;
   let store;
   const userToken = '1234';
-  const updatePatch = 'abc123';
-  const url = getUnsubscribeUrl(userToken, updatePatch);
+  const url = getUnsubscribeUrl(userToken);
 
   beforeAll(async () => {
     await initializeTestStore();
@@ -39,7 +38,7 @@ describe('Notification Preferences One Click Unsubscribe', () => {
     component = (
       <AppProvider store={store} wrapWithRouter={false}>
         <UserMessagesProvider>
-          <MemoryRouter initialEntries={[`${`/preferences-unsubscribe/${userToken}/${updatePatch}/`}`]}>
+          <MemoryRouter initialEntries={[`${`/preferences-unsubscribe/${userToken}/`}`]}>
             <Routes>
               <Route path={ROUTES.PREFERENCES_UNSUBSCRIBE} element={<PreferencesUnsubscribe />} />
             </Routes>
@@ -69,7 +68,6 @@ describe('Notification Preferences One Click Unsubscribe', () => {
     expect(screen.getByTestId('heading-text')).toHaveTextContent('Error unsubscribing from preference');
     expect(sendTrackEvent).toHaveBeenCalledWith('edx.ui.lms.notifications.preferences.unsubscribe', {
       userToken,
-      updatePatch,
     });
   });
 });


### PR DESCRIPTION
Updated notification unsubscribe flow url
- patch is not required... removed hashed patch from url
- To make it backwards compatible, hashed patch can still be used but will not be sent to backend