### PR TITLE
fix: modal size for lti content

### DIFF
--- a/src/courseware/course/sequence/Unit/ContentIFrame.jsx
+++ b/src/courseware/course/sequence/Unit/ContentIFrame.jsx
@@ -76,7 +76,7 @@ const ContentIFrame = ({
       {modalOptions.isOpen
           && (
           <ModalDialog
-            dialogClassName="modal-lti"
+            className="modal-lti"
             onClose={handleModalClose}
             size={modalOptions.isFullscreen ? 'fullscreen' : 'md'}
             isOpen

--- a/src/index.scss
+++ b/src/index.scss
@@ -367,20 +367,20 @@
 // window (retaining padding around the edge).  Bootstrap modals don't have a full-screen
 // size like this.  Because of the hack below around react-focus-on's div, it would be better long-term to pull this into Paragon and perhaps call it "modal-full" or something like that.
 .modal-lti {
-  height: 100%;
+  height: 80vh;
   max-width: 100% !important;
 
   // I don't like this.  We need to set a height of 100% on a div created by react-focus-on, a
   // package we use in our Modal.  That div has no class name or ID, so instead we're uniquely
   // identifying it by based on a unique attribute it has which its siblings don't share.
   > div[data-focus-lock-disabled="false"] {
-    height: 100%;
+    height: 80vh;
   }
 
   // Along with setting the height of modal-content's parent div from react-focus-on, we need to
   // set modal-content's height as well to get the modal to expand to full-screen height.
   .modal-content {
-    height: 100%;
+    height: 80vh;
   }
 }
 


### PR DESCRIPTION
Ticket: [COSMO2-716](https://2u-internal.atlassian.net/browse/COSMO2-716)
- dialogClassName was working with Modal from paragon, but after paragon v23 upgrade. We replaced Modal with ModalDialog with which dialogClassName doesn't work.
  - So, replace dialogClassName with simple className to apply same styles to get the past behavior for the modal.
  
Please review 
paragon [v22](https://paragon-openedx-v22.netlify.app/components/modal/#props-api) Modal Props VS paragon ModalDialog Props API which used className instead of dialogClassName.