### PR TITLE
feat: add feature flag for chat v2 endpoint in LearnerAppConfig

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -196,6 +196,7 @@ initialize({
         PRIVACY_POLICY_URL: process.env.PRIVACY_POLICY_URL || null,
         SHOW_UNGRADED_ASSIGNMENT_PROGRESS: process.env.SHOW_UNGRADED_ASSIGNMENT_PROGRESS || false,
         ENABLE_XPERT_AUDIT: process.env.ENABLE_XPERT_AUDIT || false,
+        FEATURE_ENABLE_CHAT_V2_ENDPOINT: process.env.FEATURE_ENABLE_CHAT_V2_ENDPOINT || false,
       }, 'LearnerAppConfig');
     },
   },


### PR DESCRIPTION
This pull request introduces a small configuration change to the learner application. The main update is the addition of a new feature flag to control the use of a chat v2 endpoint.

* Added `FEATURE_ENABLE_CHAT_V2_ENDPOINT` to the app configuration, allowing the chat v2 endpoint feature to be toggled via environment variables.