### PR TITLE
build: remove unused @edx/reactifex package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "truncate-html": "1.0.4"
       },
       "devDependencies": {
-        "@edx/reactifex": "2.2.0",
         "@pact-foundation/pact": "^13.0.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -2599,30 +2598,6 @@
       "license": "AGPL-3.0",
       "bin": {
         "atlas": "atlas"
-      }
-    },
-    "node_modules/@edx/reactifex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.2.0.tgz",
-      "integrity": "sha512-vyGDtx3BwCr6Gjbm4y6gJ8Bzc2TOSNBlBa2hMerz59HoXaot14MihxxiDU+JDNybGLLcKDBiK511bOi/77i1lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "edx_reactifex": "main.js"
-      }
-    },
-    "node_modules/@edx/reactifex/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@edx/typescript-config": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "truncate-html": "1.0.4"
   },
   "devDependencies": {
-    "@edx/reactifex": "2.2.0",
     "@pact-foundation/pact": "^13.0.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",


### PR DESCRIPTION
Remove @edx/reactifex package from devDependencies as it is no longer
needed. Translation extraction functionality has been verified to work
correctly without this dependency.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
