### PR TITLE
feat: accessibility HTML attributes for Course Navigation top bar

### DIFF
--- a/src/course-home/live-tab/LiveTab.jsx
+++ b/src/course-home/live-tab/LiveTab.jsx
@@ -13,6 +13,7 @@ const LiveTab = () => {
   return (
     <div
       id="live_tab"
+      role="region"
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: liveModel[courseId]?.iframe }}
     />

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -86,7 +86,6 @@ const SequenceNavigation = ({
       buttonText = intl.formatMessage(messages.nextButton);
     }
 
-    if (!buttonText) { return null; }
     return navigationDisabledNextSequence || (
       <NextUnitTopNavTriggerSlot
         {...{

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -85,6 +85,8 @@ const SequenceNavigation = ({
     } else if (!shouldDisplayNotificationTriggerInSequence) {
       buttonText = intl.formatMessage(messages.nextButton);
     }
+
+    if (!buttonText) { return null; }
     return navigationDisabledNextSequence || (
       <NextUnitTopNavTriggerSlot
         {...{
@@ -106,7 +108,7 @@ const SequenceNavigation = ({
       data-testid="courseware-sequence-navigation"
       className={classNames('sequence-navigation', className, { 'mr-2': shouldDisplayNotificationTriggerInSequence })}
       style={{ width: shouldDisplayNotificationTriggerInSequence ? '90%' : null }}
-      aria-label="course sequence tabs"
+      aria-label={intl.formatMessage(messages.sequenceNavLabel)}
     >
       {renderPreviousButton()}
       {renderUnitButtons()}

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.jsx
@@ -101,7 +101,13 @@ const SequenceNavigation = ({
   };
 
   return sequenceStatus === LOADED ? (
-    <nav id="courseware-sequence-navigation" data-testid="courseware-sequence-navigation" className={classNames('sequence-navigation', className, { 'mr-2': shouldDisplayNotificationTriggerInSequence })}>
+    <nav
+      id="courseware-sequence-navigation"
+      data-testid="courseware-sequence-navigation"
+      className={classNames('sequence-navigation', className, { 'mr-2': shouldDisplayNotificationTriggerInSequence })}
+      style={{ width: shouldDisplayNotificationTriggerInSequence ? '90%' : null }}
+      aria-label="course sequence tabs"
+    >
       {renderPreviousButton()}
       {renderUnitButtons()}
       {renderNextButton()}

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
@@ -50,7 +50,7 @@ describe('Sequence Navigation Dropdown', () => {
       });
       const dropdownMenu = container.querySelector('.dropdown-menu');
       // Only the current unit should be marked as active.
-      getAllByRole(dropdownMenu, 'link', { hidden: true }).forEach(button => {
+      getAllByRole(dropdownMenu, 'tab', { hidden: true }).forEach(button => {
         if (button.textContent === unit.display_name) {
           expect(button).toHaveClass('active');
         } else {
@@ -72,7 +72,7 @@ describe('Sequence Navigation Dropdown', () => {
       fireEvent.click(dropdownToggle);
     });
     const dropdownMenu = container.querySelector('.dropdown-menu');
-    getAllByRole(dropdownMenu, 'link', { hidden: true }).forEach(button => fireEvent.click(button));
+    getAllByRole(dropdownMenu, 'tab', { hidden: true }).forEach(button => fireEvent.click(button));
     expect(onNavigate).toHaveBeenCalledTimes(unitBlocks.length);
     unitBlocks.forEach((unit, index) => {
       expect(onNavigate).toHaveBeenNthCalledWith(index + 1, unit.id);

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Factory } from 'rosie';
 import { getAllByRole } from '@testing-library/dom';
 import { act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import SequenceNavigationDropdown from './SequenceNavigationDropdown';
 import {
   render, screen, fireEvent, initializeTestStore,
@@ -60,7 +62,7 @@ describe('Sequence Navigation Dropdown', () => {
     });
   });
 
-  it('handles the clicks', () => {
+  it('handles the clicks', async () => {
     const onNavigate = jest.fn();
     const { container } = render(
       <SequenceNavigationDropdown {...mockData} onNavigate={onNavigate} />,
@@ -72,7 +74,13 @@ describe('Sequence Navigation Dropdown', () => {
       fireEvent.click(dropdownToggle);
     });
     const dropdownMenu = container.querySelector('.dropdown-menu');
-    getAllByRole(dropdownMenu, 'tab', { hidden: true }).forEach(button => fireEvent.click(button));
+    const buttons = getAllByRole(dropdownMenu, 'tab', { hidden: true });
+
+    for (const button of buttons) {
+      // eslint-disable-next-line no-await-in-loop
+      await userEvent.click(button);
+    }
+
     expect(onNavigate).toHaveBeenCalledTimes(unitBlocks.length);
     unitBlocks.forEach((unit, index) => {
       expect(onNavigate).toHaveBeenNthCalledWith(index + 1, unit.id);

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.jsx
@@ -38,6 +38,7 @@ const SequenceNavigationTabs = ({
         <div
           className="sequence-navigation-tabs d-flex flex-grow-1"
           style={shouldDisplayDropdown ? invisibleStyle : null}
+          role="tablist"
           ref={containerRef}
         >
           {unitIds.map(buttonUnitId => (

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Factory } from 'rosie';
 import { getAllByRole } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -6,9 +5,22 @@ import userEvent from '@testing-library/user-event';
 import { initializeTestStore, render, screen } from '../../../../setupTest';
 import SequenceNavigationTabs from './SequenceNavigationTabs';
 import useIndexOfLastVisibleChild from '../../../../generic/tabs/useIndexOfLastVisibleChild';
+import {
+  useIsSidebarOpen,
+  useIsOnXLDesktop,
+  useIsOnLargeDesktop,
+  useIsOnMediumDesktop,
+} from './hooks';
 
 // Mock the hook to avoid relying on its implementation and mocking `getBoundingClientRect`.
 jest.mock('../../../../generic/tabs/useIndexOfLastVisibleChild');
+
+jest.mock('./hooks', () => ({
+  useIsSidebarOpen: jest.fn(),
+  useIsOnXLDesktop: jest.fn(),
+  useIsOnLargeDesktop: jest.fn(),
+  useIsOnMediumDesktop: jest.fn(),
+}));
 
 describe('Sequence Navigation Tabs', () => {
   let mockData;
@@ -44,7 +56,7 @@ describe('Sequence Navigation Tabs', () => {
     useIndexOfLastVisibleChild.mockReturnValue([0, null, null]);
     render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
 
-    expect(screen.getAllByRole('link')).toHaveLength(unitBlocks.length);
+    expect(screen.getAllByRole('tab')).toHaveLength(unitBlocks.length);
   });
 
   it('renders unit buttons and dropdown button', async () => {
@@ -54,7 +66,7 @@ describe('Sequence Navigation Tabs', () => {
     const booyah = render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
 
     // wait for links to appear so we aren't testing an empty div
-    await screen.findAllByRole('link');
+    await screen.findAllByRole('tab');
 
     container = booyah.container;
 
@@ -62,9 +74,77 @@ describe('Sequence Navigation Tabs', () => {
     await userEvent.click(dropdownToggle);
 
     const dropdownMenu = container.querySelector('.dropdown');
-    const dropdownButtons = getAllByRole(dropdownMenu, 'link');
+    const dropdownButtons = getAllByRole(dropdownMenu, 'tab');
     expect(dropdownButtons).toHaveLength(unitBlocks.length);
     expect(screen.getByRole('button', { name: `${activeBlockNumber} of ${unitBlocks.length}` }))
       .toHaveClass('dropdown-toggle');
+  });
+
+  it('adds class navigation-tab-width-xl when isOnXLDesktop and sidebar is open', () => {
+    useIsSidebarOpen.mockReturnValue(true);
+    useIsOnXLDesktop.mockReturnValue(true);
+    useIsOnLargeDesktop.mockReturnValue(false);
+    useIsOnMediumDesktop.mockReturnValue(false);
+    useIndexOfLastVisibleChild.mockReturnValue([0, null, null]);
+
+    const { container } = render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
+
+    const wrapperDiv = container.querySelector('.navigation-tab-width-xl');
+    expect(wrapperDiv).toBeInTheDocument();
+  });
+
+  it('adds class navigation-tab-width-large when isOnLargeDesktop and sidebar is open', () => {
+    useIsSidebarOpen.mockReturnValue(true);
+    useIsOnXLDesktop.mockReturnValue(false);
+    useIsOnLargeDesktop.mockReturnValue(true);
+    useIsOnMediumDesktop.mockReturnValue(false);
+    useIndexOfLastVisibleChild.mockReturnValue([0, null, null]);
+
+    const { container } = render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
+
+    const wrapperDiv = container.querySelector('.navigation-tab-width-large');
+    expect(wrapperDiv).toBeInTheDocument();
+  });
+
+  it('adds class navigation-tab-width-medium when isOnMediumDesktop and sidebar is open', () => {
+    useIsSidebarOpen.mockReturnValue(true);
+    useIsOnXLDesktop.mockReturnValue(false);
+    useIsOnLargeDesktop.mockReturnValue(false);
+    useIsOnMediumDesktop.mockReturnValue(true);
+    useIndexOfLastVisibleChild.mockReturnValue([0, null, null]);
+
+    const { container } = render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
+
+    const wrapperDiv = container.querySelector('.navigation-tab-width-medium');
+    expect(wrapperDiv).toBeInTheDocument();
+  });
+
+  it('applies invisibleStyle when shouldDisplayDropdown is true', () => {
+    useIsSidebarOpen.mockReturnValue(true);
+    useIsOnXLDesktop.mockReturnValue(false);
+    useIsOnLargeDesktop.mockReturnValue(false);
+    useIsOnMediumDesktop.mockReturnValue(false);
+
+    useIndexOfLastVisibleChild.mockReturnValue([
+      0,
+      null,
+      {
+        position: 'absolute',
+        left: '0px',
+        pointerEvents: 'none',
+        visibility: 'hidden',
+        maxWidth: '100%',
+      },
+    ]);
+
+    render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
+
+    const tabList = screen.getByRole('tablist');
+
+    expect(tabList.style.position).toBe('absolute');
+    expect(tabList.style.left).toBe('0px');
+    expect(tabList.style.pointerEvents).toBe('none');
+    expect(tabList.style.visibility).toBe('hidden');
+    expect(tabList.style.maxWidth).toBe('100%');
   });
 });

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
@@ -39,6 +39,9 @@ const UnitButton = ({
       variant="link"
       onClick={handleClick}
       title={title}
+      role="tab"
+      aria-selected={isActive}
+      aria-controls={title}
       as={Link}
       to={unitPath}
     >

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Factory } from 'rosie';
+import userEvent from '@testing-library/user-event';
+
 import {
-  fireEvent, initializeTestStore, render, screen,
-} from '../../../../setupTest';
+  initializeTestStore, render, screen,
+} from '@src/setupTest';
 import UnitButton from './UnitButton';
 
 jest.mock('react-router-dom', () => {
@@ -89,18 +91,18 @@ describe('Unit Button', () => {
     expect(bookmarkIcon.getAttribute('data-testid')).toBe('bookmark-icon');
   });
 
-  it('handles the click', () => {
+  it('handles the click', async () => {
     const onClick = jest.fn();
     render(<UnitButton {...mockData} onClick={onClick} />, { wrapWithRouter: true });
-    fireEvent.click(screen.getByRole('tab'));
+    await userEvent.click(screen.getByRole('tab'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onClick with correct unitId when clicked', () => {
+  it('calls onClick with correct unitId when clicked', async () => {
     const onClick = jest.fn();
     render(<UnitButton {...mockData} onClick={onClick} />, { wrapWithRouter: true });
 
-    fireEvent.click(screen.getByRole('tab'));
+    await userEvent.click(screen.getByRole('tab'));
 
     expect(onClick).toHaveBeenCalledWith(mockData.unitId);
   });

--- a/src/courseware/course/sequence/sequence-navigation/messages.ts
+++ b/src/courseware/course/sequence/sequence-navigation/messages.ts
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Previous',
     description: 'Button to return to the previous section',
   },
+  sequenceNavLabel: {
+    id: 'learn.sequence.navigation.aria.label',
+    defaultMessage: 'Course sequence tabs',
+    description: 'Accessibility label for the courseware sequence navigation bar',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
> [!NOTE]  
> This PR has been added to the product proposal to improve accessibility.
> [Product proposal ](https://github.com/openedx/platform-roadmap/issues/495)

## Issue
https://github.com/openedx/frontend-app-learning/issues/1881

## Description
This PR introduces accessibility (a11y) improvements to the **Course Top Navigation Bar** (Sequence Navigation).
This ensures the navigation is fully perceivable and operable for screen reader and keyboard-only users.

## Key Changes

- The container for the sequence navigation tabs now explicitly uses `role="tablist"`, creating a proper context for assistive technologies.
- A descriptive label (`aria-label="course sequence tabs"`) has been added to the main navigation element, allowing screen readers to identify this specific navigation region.

- **Tab Role:** Each button within the navigation bar now correctly uses `role="tab"`.
- **Selected State:** Implemented dynamic management of the `aria-selected` state. The active unit button is explicitly announced as `selected="true"`, while inactive buttons are `selected="false"`.
- **Relationship:** Added the `aria-controls` property to establish a programmatic link between the tab button and the content it controls.

## Steps to Test
*Note: These steps focus on verifying keyboard navigation behavior (Tab / Shift+Tab).*

1.  **Open Course:** Navigate to any course unit within the Learning MFE.
2.  **Navigate to Sequence Bar:** From the top of the page, press the Tab key repeatedly until the visual focus indicator lands on the Course Sequence Navigation
3.  **Forward Navigation:** Continue pressing `Tab`. Verify that focus moves logically from left to right, landing on each unit icon in the sequence.
4.  **Backward Navigation:** Press `Shift + Tab`. Verify that focus moves logically backwards (right to left) through the sequence without getting trapped or skipping elements.
5.  **Activation:** Navigate to an inactive unit using the keyboard and press `Enter`. Verify that the unit is selected and the content updates accordingly.

https://github.com/user-attachments/assets/ce7d4199-eeeb-4650-8b86-8296e6897ff0

