### PR TITLE
fix: Update frontend-platform to version 8.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@edx/frontend-component-header": "^6.2.0",
         "@edx/frontend-lib-learning-assistant": "^2.20.0",
         "@edx/frontend-lib-special-exams": "^3.5.0",
-        "@edx/frontend-platform": "^8.3.1",
+        "@edx/frontend-platform": "^8.3.8",
         "@edx/openedx-atlas": "^0.6.0",
         "@edx/react-unit-test-utils": "^4.0.0",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -2538,16 +2538,16 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.3.4.tgz",
-      "integrity": "sha512-V3XtTo3KP8QSmId+Vvi4+qzpOVkxvTMNA6jH/i3Bfz+/jHjHBRnmp/Cc2pjTxiTgGNoKX4D1twiZkOBO+kWw1Q==",
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.3.8.tgz",
+      "integrity": "sha512-wr3HKzDcYGNuHcM7HuZ/mqBdqnY/A7eYa3JDVZEsceyjy0PJyVKHWFu3yneGpD1zufguQCvS0q53C8gJbVzIgw==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "1.8.4",
-        "axios-cache-interceptor": "1.6.2",
+        "axios": "1.9.0",
+        "axios-cache-interceptor": "1.8.0",
         "form-urlencoded": "4.1.4",
         "glob": "7.2.3",
         "history": "4.10.1",
@@ -7516,9 +7516,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -7527,9 +7527,9 @@
       }
     },
     "node_modules/axios-cache-interceptor": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.6.2.tgz",
-      "integrity": "sha512-YLbAODIHZZIcD4b3WYFVQOa5W2TY/WnJ6sBHqAg6Z+hx+RVj8/OcjQyRopO6awn7/kOkGL5X9TP16AucnlJ/lw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-1.8.0.tgz",
+      "integrity": "sha512-cTNnPGJyQkxnWp0EWvE3NRvgURU5cWw/Qx3dIhXyHSM4Ip0c7EEe0I3an0Jwa549m1CAOg57ibj27YRNLmQCcg==",
       "license": "MIT",
       "dependencies": {
         "cache-parser": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@edx/frontend-component-header": "^6.2.0",
     "@edx/frontend-lib-learning-assistant": "^2.20.0",
     "@edx/frontend-lib-special-exams": "^3.5.0",
-    "@edx/frontend-platform": "^8.3.1",
+    "@edx/frontend-platform": "^8.3.8",
     "@edx/openedx-atlas": "^0.6.0",
     "@edx/react-unit-test-utils": "^4.0.0",
     "@fortawesome/free-brands-svg-icons": "5.15.4",


### PR DESCRIPTION
Update frontend-platform to version 8.3.8 in the `teak-design-tokens` branch to incorporate the following two fixes that affect theming:

[8.3.7]: Simplify the logic for Paragon `fallbackThemeUrl` to always rely on `window.location?.origin`;
[8.3.8]: Allow the creation of URLs with only `brandOverride` definition.

[8.3.7]: https://github.com/openedx/frontend-platform/releases/tag/v8.3.7
[8.3.8]: https://github.com/openedx/frontend-platform/releases/tag/v8.3.8

**What changed?**

- `npm install @edx/frontend-platform@8.3.8`

**Developer Checklist**
- [X] Test suites passing

**Testing Instructions**

Theme the MFE with the following config:

```
MFE_CONFIG["PARAGON_THEME_URLS"] = {
    "core": {
        "urls": {
            "brandOverride": "http://local.edly.io:3000/core.min.css"
        },
    },
    "variants": {
        "light": {
            "urls": {
                "brandOverride": "http://local.edly.io:3000/light.min.css"
            },
        },
    },
}
```

Prior to the fix, it doesn’t load the CSS.

FYI: @brian-smith-tcril
