### PR TITLE
feat: improved accessibility skipping to main content

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,3 +72,5 @@ export const LOADED = 'loaded';
 export const FAILED = 'failed';
 export const DENIED = 'denied';
 export type StatusValue = typeof LOADING | typeof LOADED | typeof FAILED | typeof DENIED;
+
+export const MAIN_CONTENT_ID = 'main-content-heading';

--- a/src/course-home/dates-tab/DatesTab.jsx
+++ b/src/course-home/dates-tab/DatesTab.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
+import { MAIN_CONTENT_ID } from '@src/constants';
 import messages from './messages';
 import Timeline from './timeline/Timeline';
 
@@ -13,12 +14,15 @@ import SuggestedScheduleHeader from '../suggested-schedule-messaging/SuggestedSc
 import ShiftDatesAlert from '../suggested-schedule-messaging/ShiftDatesAlert';
 import UpgradeToCompleteAlert from '../suggested-schedule-messaging/UpgradeToCompleteAlert';
 import UpgradeToShiftDatesAlert from '../suggested-schedule-messaging/UpgradeToShiftDatesAlert';
+import { useScrollToContent } from '../../generic/hooks';
 
 const DatesTab = () => {
   const intl = useIntl();
   const {
     courseId,
   } = useSelector(state => state.courseHome);
+
+  useScrollToContent(MAIN_CONTENT_ID);
 
   const {
     isSelfPaced,
@@ -44,7 +48,13 @@ const DatesTab = () => {
 
   return (
     <>
-      <div role="heading" aria-level="1" className="h2 my-3">
+      <div
+        id={MAIN_CONTENT_ID}
+        tabIndex="-1"
+        role="heading"
+        aria-level="1"
+        className="h2 my-3"
+      >
         {intl.formatMessage(messages.title)}
       </div>
       {isSelfPaced && hasDeadlines && (

--- a/src/course-home/dates-tab/DatesTab.jsx
+++ b/src/course-home/dates-tab/DatesTab.jsx
@@ -4,6 +4,7 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { MAIN_CONTENT_ID } from '@src/constants';
+import { useScrollToContent } from '@src/generic/hooks';
 import messages from './messages';
 import Timeline from './timeline/Timeline';
 
@@ -14,7 +15,6 @@ import SuggestedScheduleHeader from '../suggested-schedule-messaging/SuggestedSc
 import ShiftDatesAlert from '../suggested-schedule-messaging/ShiftDatesAlert';
 import UpgradeToCompleteAlert from '../suggested-schedule-messaging/UpgradeToCompleteAlert';
 import UpgradeToShiftDatesAlert from '../suggested-schedule-messaging/UpgradeToShiftDatesAlert';
-import { useScrollToContent } from '../../generic/hooks';
 
 const DatesTab = () => {
   const intl = useIntl();

--- a/src/course-home/progress-tab/ProgressHeader.jsx
+++ b/src/course-home/progress-tab/ProgressHeader.jsx
@@ -3,6 +3,8 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 import { useSelector } from 'react-redux';
 
+import { useScrollToContent } from '@src/generic/hooks';
+import { MAIN_CONTENT_ID } from '@src/constants';
 import { useModel } from '../../generic/model-store';
 
 import messages from './messages';
@@ -18,6 +20,8 @@ const ProgressHeader = () => {
 
   const { studioUrl, username } = useModel('progress', courseId);
 
+  useScrollToContent(MAIN_CONTENT_ID);
+
   const viewingOtherStudentsProgressPage = (targetUserId && targetUserId !== userId);
 
   const pageTitle = viewingOtherStudentsProgressPage
@@ -26,7 +30,7 @@ const ProgressHeader = () => {
 
   return (
     <div className="row w-100 m-0 mt-3 mb-4 justify-content-between">
-      <h1>{pageTitle}</h1>
+      <h1 id={MAIN_CONTENT_ID} tabIndex="-1">{pageTitle}</h1>
       {administrator && studioUrl && (
       <Button variant="outline-primary" size="sm" className="align-self-center" href={studioUrl}>
         {intl.formatMessage(messages.studioLink)}

--- a/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
+++ b/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
@@ -1,6 +1,8 @@
 import { Icon } from '@openedx/paragon';
 import { Bookmark } from '@openedx/paragon/icons';
 
-const BookmarkFilledIcon = (props) => <Icon src={Bookmark} screenReaderText="Bookmark" {...props} />;
+import messages from "../sequence/sequence-navigation/messages";
+
+const BookmarkFilledIcon = (props) => <Icon src={Bookmark} screenReaderText={messages.bookmark.defaultMessage} {...props} />;
 
 export default BookmarkFilledIcon;

--- a/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
+++ b/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
@@ -1,8 +1,14 @@
 import { Icon } from '@openedx/paragon';
 import { Bookmark } from '@openedx/paragon/icons';
 
-import messages from "../sequence/sequence-navigation/messages";
+import messages from '../sequence/sequence-navigation/messages';
 
-const BookmarkFilledIcon = (props) => <Icon src={Bookmark} screenReaderText={messages.bookmark.defaultMessage} {...props} />;
+const BookmarkFilledIcon = (props) => (
+  <Icon
+    src={Bookmark}
+    screenReaderText={messages.bookmark.defaultMessage}
+    {...props}
+  />
+);
 
 export default BookmarkFilledIcon;

--- a/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
+++ b/src/courseware/course/bookmark/BookmarkFilledIcon.jsx
@@ -1,0 +1,6 @@
+import { Icon } from '@openedx/paragon';
+import { Bookmark } from '@openedx/paragon/icons';
+
+const BookmarkFilledIcon = (props) => <Icon src={Bookmark} screenReaderText="Bookmark" {...props} />;
+
+export default BookmarkFilledIcon;

--- a/src/courseware/course/bookmark/index.js
+++ b/src/courseware/course/bookmark/index.js
@@ -1,1 +1,2 @@
 export { default as BookmarkButton } from './BookmarkButton';
+export { default as BookmarkFilledIcon } from './BookmarkFilledIcon';

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigation.test.jsx
@@ -76,7 +76,7 @@ describe('Sequence Navigation', () => {
     const onNavigate = jest.fn();
     render(<SequenceNavigation {...mockData} {...{ onNavigate }} />, { wrapWithRouter: true });
 
-    const unitButtons = screen.getAllByRole('link', { name: /\d+/ });
+    const unitButtons = screen.getAllByRole('tabpanel', { name: /\d+/ });
     expect(unitButtons).toHaveLength(unitButtons.length);
     unitButtons.forEach(button => fireEvent.click(button));
     expect(onNavigate).toHaveBeenCalledTimes(unitButtons.length);

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationDropdown.test.jsx
@@ -50,7 +50,7 @@ describe('Sequence Navigation Dropdown', () => {
       });
       const dropdownMenu = container.querySelector('.dropdown-menu');
       // Only the current unit should be marked as active.
-      getAllByRole(dropdownMenu, 'link', { hidden: true }).forEach(button => {
+      getAllByRole(dropdownMenu, 'tabpanel', { hidden: true }).forEach(button => {
         if (button.textContent === unit.display_name) {
           expect(button).toHaveClass('active');
         } else {
@@ -72,7 +72,7 @@ describe('Sequence Navigation Dropdown', () => {
       fireEvent.click(dropdownToggle);
     });
     const dropdownMenu = container.querySelector('.dropdown-menu');
-    getAllByRole(dropdownMenu, 'link', { hidden: true }).forEach(button => fireEvent.click(button));
+    getAllByRole(dropdownMenu, 'tabpanel', { hidden: true }).forEach(button => fireEvent.click(button));
     expect(onNavigate).toHaveBeenCalledTimes(unitBlocks.length);
     unitBlocks.forEach((unit, index) => {
       expect(onNavigate).toHaveBeenNthCalledWith(index + 1, unit.id);

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.jsx
@@ -40,13 +40,14 @@ const SequenceNavigationTabs = ({
           style={shouldDisplayDropdown ? invisibleStyle : null}
           ref={containerRef}
         >
-          {unitIds.map(buttonUnitId => (
+          {unitIds.map((buttonUnitId, idx) => (
             <UnitButton
               key={buttonUnitId}
               unitId={buttonUnitId}
               isActive={unitId === buttonUnitId}
               showCompletion={showCompletion}
               onClick={onNavigate}
+              unitIdx={idx}
             />
           ))}
         </div>

--- a/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/SequenceNavigationTabs.test.jsx
@@ -44,7 +44,7 @@ describe('Sequence Navigation Tabs', () => {
     useIndexOfLastVisibleChild.mockReturnValue([0, null, null]);
     render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
 
-    expect(screen.getAllByRole('link')).toHaveLength(unitBlocks.length);
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(unitBlocks.length);
   });
 
   it('renders unit buttons and dropdown button', async () => {
@@ -54,7 +54,7 @@ describe('Sequence Navigation Tabs', () => {
     const booyah = render(<SequenceNavigationTabs {...mockData} />, { wrapWithRouter: true });
 
     // wait for links to appear so we aren't testing an empty div
-    await screen.findAllByRole('link');
+    await screen.findAllByRole('tabpanel');
 
     container = booyah.container;
 
@@ -62,7 +62,7 @@ describe('Sequence Navigation Tabs', () => {
     await userEvent.click(dropdownToggle);
 
     const dropdownMenu = container.querySelector('.dropdown');
-    const dropdownButtons = getAllByRole(dropdownMenu, 'link');
+    const dropdownButtons = getAllByRole(dropdownMenu, 'tabpanel');
     expect(dropdownButtons).toHaveLength(unitBlocks.length);
     expect(screen.getByRole('button', { name: `${activeBlockNumber} of ${unitBlocks.length}` }))
       .toHaveClass('dropdown-toggle');

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.jsx
@@ -3,9 +3,10 @@ import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 import classNames from 'classnames';
-import { Button, Icon } from '@openedx/paragon';
-import { Bookmark } from '@openedx/paragon/icons';
+import { Button } from '@openedx/paragon';
 
+import { BookmarkFilledIcon } from '@src/courseware/course/bookmark';
+import { useScrollToContent } from '@src/generic/hooks';
 import UnitIcon from './UnitIcon';
 import CompleteIcon from './CompleteIcon';
 
@@ -20,15 +21,35 @@ const UnitButton = ({
   unitId,
   className,
   showTitle,
+  unitIdx,
 }) => {
   const { courseId, sequenceId } = useSelector(state => state.courseware);
   const { pathname } = useLocation();
   const basePath = `/course/${courseId}/${sequenceId}/${unitId}`;
   const unitPath = pathname.startsWith('/preview') ? `/preview${basePath}` : basePath;
 
+  useScrollToContent(isActive ? `${title}-${unitIdx}` : null);
+
   const handleClick = useCallback(() => {
     onClick(unitId);
   }, [onClick, unitId]);
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      onClick(unitId);
+
+      const performFocus = () => {
+        const targetElement = document.getElementById('bookmark-button');
+        if (targetElement) {
+          targetElement.focus();
+        }
+      };
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(performFocus);
+      });
+    }
+  };
 
   return (
     <Button
@@ -41,16 +62,20 @@ const UnitButton = ({
       title={title}
       as={Link}
       to={unitPath}
+      role="tabpanel"
+      tabIndex={isActive ? 0 : -1}
+      aria-controls={title}
+      id={`${title}-${unitIdx}`}
+      aria-labelledby={title}
+      onKeyDown={handleKeyDown}
     >
       <UnitIcon type={contentType} />
       {showTitle && <span className="unit-title">{title}</span>}
       {showCompletion && complete ? <CompleteIcon size="sm" className="text-success ml-2" /> : null}
       {bookmarked ? (
-        <Icon
+        <BookmarkFilledIcon
+          className="unit-filled-bookmark text-primary small position-absolute"
           data-testid="bookmark-icon"
-          src={Bookmark}
-          className="text-primary small position-absolute"
-          style={{ top: '-3px', right: '5px' }}
         />
       ) : null}
     </Button>
@@ -68,6 +93,7 @@ UnitButton.propTypes = {
   showTitle: PropTypes.bool,
   title: PropTypes.string.isRequired,
   unitId: PropTypes.string.isRequired,
+  unitIdx: PropTypes.number.isRequired,
 };
 
 UnitButton.defaultProps = {

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.scss
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.scss
@@ -1,0 +1,6 @@
+.unit-filled-bookmark {
+  top: -3px;
+  right: 2px;
+  height: 20px;
+  width: 20px;
+}

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Factory } from 'rosie';
 import {
-  fireEvent, initializeTestStore, render, screen,
+  act,
+  fireEvent,
+  initializeTestStore,
+  render,
+  screen,
+  waitFor,
 } from '../../../../setupTest';
 import UnitButton from './UnitButton';
 
@@ -28,17 +33,35 @@ describe('Unit Button', () => {
     mockData = {
       unitId: unit.id,
       onClick: () => {},
+      unitIdx: 0,
     };
+
+    global.requestAnimationFrame = jest.fn((cb) => {
+      setImmediate(cb);
+    });
   });
 
   it('hides title by default', () => {
     render(<UnitButton {...mockData} />, { wrapWithRouter: true });
-    expect(screen.getByRole('link')).not.toHaveTextContent(unit.display_name);
+    expect(screen.getByRole('tabpanel')).not.toHaveTextContent(unit.display_name);
   });
 
   it('shows title', () => {
     render(<UnitButton {...mockData} showTitle />, { wrapWithRouter: true });
-    expect(screen.getByRole('link')).toHaveTextContent(unit.display_name);
+    expect(screen.getByRole('tabpanel')).toHaveTextContent(unit.display_name);
+  });
+
+  it('check button attributes', () => {
+    render(<UnitButton {...mockData} showTitle />, { wrapWithRouter: true });
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', `${unit.display_name}-0`);
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-controls', unit.display_name);
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', unit.display_name);
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('button with isActive prop has tabindex 0', () => {
+    render(<UnitButton {...mockData} isActive />, { wrapWithRouter: true });
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('tabindex', '0');
   });
 
   it('does not show completion for non-completed unit', () => {
@@ -79,7 +102,65 @@ describe('Unit Button', () => {
   it('handles the click', () => {
     const onClick = jest.fn();
     render(<UnitButton {...mockData} onClick={onClick} />, { wrapWithRouter: true });
-    fireEvent.click(screen.getByRole('link'));
+    fireEvent.click(screen.getByRole('tabpanel'));
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses the bookmark button after key press', async () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <>
+        <UnitButton {...mockData} />
+        <button id="bookmark-button" type="button">Bookmark</button>
+      </>,
+      { wrapWithRouter: true },
+    );
+    const unitButton = container.querySelector('[role="tabpanel"]');
+
+    fireEvent.keyDown(unitButton, { key: 'Enter' });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(document.getElementById('bookmark-button'));
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('calls onClick and focuses bookmark button on Enter or Space key press', async () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <>
+        <UnitButton {...mockData} onClick={onClick} />
+        <button id="bookmark-button" type="button">Bookmark</button>
+      </>,
+      { wrapWithRouter: true },
+    );
+
+    const unitButton = container.querySelector('[role="tabpanel"]');
+
+    await act(async () => {
+      fireEvent.keyDown(unitButton, { key: 'Enter' });
+    });
+
+    await waitFor(() => {
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(2);
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(document.getElementById('bookmark-button'));
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(unitButton, { key: ' ' });
+    });
+
+    await waitFor(() => {
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(4);
+      expect(onClick).toHaveBeenCalledTimes(2);
+      expect(document.activeElement).toBe(document.getElementById('bookmark-button'));
+    });
   });
 });

--- a/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
+++ b/src/courseware/course/sequence/sequence-navigation/UnitButton.test.jsx
@@ -9,6 +9,7 @@ import {
   waitFor,
 } from '../../../../setupTest';
 import UnitButton from './UnitButton';
+import messages from './messages';
 
 describe('Unit Button', () => {
   let mockData;
@@ -112,7 +113,7 @@ describe('Unit Button', () => {
     const { container } = render(
       <>
         <UnitButton {...mockData} />
-        <button id="bookmark-button" type="button">Bookmark</button>
+        <button id="bookmark-button" type="button">{messages.bookmark.defaultMessage}</button>
       </>,
       { wrapWithRouter: true },
     );
@@ -136,7 +137,7 @@ describe('Unit Button', () => {
     const { container } = render(
       <>
         <UnitButton {...mockData} onClick={onClick} />
-        <button id="bookmark-button" type="button">Bookmark</button>
+        <button id="bookmark-button" type="button">{messages.bookmark.defaultMessage}</button>
       </>,
       { wrapWithRouter: true },
     );

--- a/src/courseware/course/sequence/sequence-navigation/messages.ts
+++ b/src/courseware/course/sequence/sequence-navigation/messages.ts
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Previous',
     description: 'Button to return to the previous section',
   },
+  bookmark: {
+    id: 'learning.generic.bookmark',
+    defaultMessage: 'Bookmark',
+    description: 'Button text for bookmarking',
+  },
 });
 
 export default messages;

--- a/src/generic/hooks.test.jsx
+++ b/src/generic/hooks.test.jsx
@@ -63,7 +63,7 @@ describe('Hooks', () => {
     test('should scroll to target element and focus', async () => {
       render(<TestComponent />);
 
-      const skipLink = screen.getByRole('link', { name: /skip to content/i });
+      const skipLink = screen.getByRole('link', { name: new RegExp(messages.skipToContent.defaultMessage, 'i') });
       const targetContent = screen.getByTestId('target-content');
 
       targetContent.focus = jest.fn();
@@ -114,7 +114,7 @@ describe('Hooks', () => {
 
       render(<ComponentWithoutTarget />);
 
-      const skipLink = screen.getByRole('link', { name: /skip to content/i });
+      const skipLink = screen.getByRole('link', { name: new RegExp(messages.skipToContent.defaultMessage, 'i') });
 
       await userEvent.click(skipLink);
 

--- a/src/generic/hooks.test.jsx
+++ b/src/generic/hooks.test.jsx
@@ -1,5 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { useEventListener, useIFrameHeight } from './hooks';
+import userEvent from '@testing-library/user-event';
+
+import { useEventListener, useIFrameHeight, useScrollToContent } from './hooks';
+import messages from './messages';
+
+global.scrollTo = jest.fn();
+global.console.warn = jest.fn();
 
 describe('Hooks', () => {
   test('useEventListener', async () => {
@@ -41,5 +47,81 @@ describe('Hooks', () => {
     await waitFor(() => expect(onLoaded).toHaveBeenCalled());
     await waitFor(() => expect(screen.getByTestId('loaded')).toHaveTextContent('true'));
     expect(screen.getByTestId('height')).toHaveTextContent('1234');
+  });
+
+  describe('useScrollToContent', () => {
+    const TestComponent = () => {
+      useScrollToContent();
+      return (
+        <>
+          <a href="#main-content" data-testid="skip-link">{messages.skipToContent.defaultMessage}</a>
+          <div id="main-content" tabIndex={-1} data-testid="target-content">{messages.mainContent.defaultMessage}</div>
+        </>
+      );
+    };
+
+    test('should scroll to target element and focus', async () => {
+      render(<TestComponent />);
+
+      const skipLink = screen.getByRole('link', { name: /skip to content/i });
+      const targetContent = screen.getByTestId('target-content');
+
+      targetContent.focus = jest.fn();
+
+      userEvent.click(skipLink);
+
+      await waitFor(() => {
+        expect(global.scrollTo).toHaveBeenCalledWith({
+          top: expect.any(Number), behavior: 'smooth',
+        });
+      });
+      expect(targetContent.focus).toHaveBeenCalled();
+    });
+
+    test('should warn if element is not focusable', async () => {
+      render(<TestComponent />);
+
+      const skipLink = screen.getByTestId('skip-link');
+      const targetContent = screen.getByTestId('target-content');
+
+      Object.defineProperty(targetContent, 'focus', {
+        value: undefined,
+        configurable: true,
+      });
+
+      await userEvent.click(skipLink);
+
+      await waitFor(() => {
+        expect(global.scrollTo).toHaveBeenCalledWith({
+          top: expect.any(Number),
+          behavior: 'smooth',
+        });
+      });
+
+      // eslint-disable-next-line no-console
+      expect(console.warn).toHaveBeenCalledWith('Element with ID "main-content" exists but is not focusable.');
+    });
+
+    test('should warn if target element is not found', async () => {
+      const ComponentWithoutTarget = () => {
+        useScrollToContent();
+        return (
+          <>
+            <a href="#main-content" data-testid="skip-link">{messages.skipToContent.defaultMessage}</a>
+          </>
+        );
+      };
+
+      render(<ComponentWithoutTarget />);
+
+      const skipLink = screen.getByRole('link', { name: /skip to content/i });
+
+      await userEvent.click(skipLink);
+
+      await waitFor(() => {
+        // eslint-disable-next-line no-console
+        expect(console.warn).toHaveBeenCalledWith('Element with ID "main-content" not found.');
+      });
+    });
   });
 });

--- a/src/generic/messages.ts
+++ b/src/generic/messages.ts
@@ -36,6 +36,16 @@ const messages = defineMessages({
     defaultMessage: 'homepage',
     description: 'Text for url, telling them the page they will be navigated to',
   },
+  skipToContent: {
+    id: 'learning.generic.skipToContent',
+    defaultMessage: 'Skip to content',
+    description: 'Link text to skip to the main content of the page for accessibility',
+  },
+  mainContent: {
+    id: 'learning.generic.mainContent',
+    defaultMessage: 'Main Content',
+    description: 'Label for the main content area',
+  },
 });
 
 export default messages;

--- a/src/index.scss
+++ b/src/index.scss
@@ -466,3 +466,4 @@
 @import "course-tabs/course-tabs-navigation.scss";
 @import "courseware/course/sidebar/common/SidebarBase.scss";
 @import "courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss";
+@import "courseware/course/sequence/sequence-navigation/UnitButton.scss";


### PR DESCRIPTION
> [!NOTE]  
> This PR has been added to the product proposal to improve accessibility.
> [Product proposal ](https://github.com/openedx/platform-roadmap/issues/495)

## Issue
https://github.com/openedx/frontend-app-learning/issues/1879

## Description
Jump user's focus skipping two navigation menus above it

1. Progress page
2. Course unit
3. Dates page

## Testing instructions

**How get to the Skip to main content element above the header**

<img width="1728" height="782" alt="Знімок екрана 2025-12-02 о 12 47 40" src="https://github.com/user-attachments/assets/0a38b26c-856f-4992-85e5-cc070a0447f2" />


**Progress Page**

1. Go to Progress
2. Using the Tab key (Shift+Tab) get to the Skip to main content element above the header.
3. When user press the Enter or Space key, the focus should move to the Your progress heading.

https://github.com/user-attachments/assets/a941d345-2c00-43be-8e54-68f7b5c2b93b


**Course Unit Page**

1. Go to Course unit page.
2. Using the Tab key (Shift+Tab) get to the Skip to main content element above the header.
3. When user press the Enter or Space key, the focus should move to the active unit.



https://github.com/user-attachments/assets/7531dea0-63ff-4d70-a8ee-642b606e43db


**Dates Page**

1. Go to Dates page.
2. Using the Tab key (Shift+Tab) get to the Skip to main content element above the header.
3. When user press the Enter or Space key, the focus should move to the Your progress heading.


https://github.com/user-attachments/assets/92a45da5-eb2f-4e61-ac33-a9b284ca49d7

