### PR TITLE
Fix: change the color of completion stock to be primary color instead of info color

### DIFF
--- a/src/course-home/progress-tab/course-completion/CompletionDonutChart.scss
+++ b/src/course-home/progress-tab/course-completion/CompletionDonutChart.scss
@@ -56,7 +56,7 @@
 
 .donut-ring, .donut-segment, .donut-hole {
   &.complete-stroke {
-    stroke: var(--pgn-color-info-500);
+    stroke: var(--pgn-color-primary-500);
   }
 
   &.divider-stroke {


### PR DESCRIPTION
## Description:
This PR change the course completion donut circle from info color to primary. 

Before:
<img width="1461" height="476" alt="image" src="https://github.com/user-attachments/assets/a2b0c2bd-9fa8-4498-9373-826068e79005" />

After:
<img width="1461" height="476" alt="image" src="https://github.com/user-attachments/assets/d74b92e6-6048-4980-a610-cdc7dc9a8719" />

