### PR TITLE
fix: handle undefined assignmentTypeGradeSummary in progress tab

### DIFF
--- a/src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx
@@ -48,10 +48,10 @@ const CourseGradeFooter = ({ passingGrade }) => {
   const courseId = useContextId();
 
   const {
-    assignmentTypeGradeSummary,
-    courseGrade: { isPassing, letterGrade },
-    gradingPolicy: { gradeRange },
-  } = useModel('progress', courseId);
+    assignmentTypeGradeSummary = [],
+    courseGrade: { isPassing, letterGrade } = {},
+    gradingPolicy: { gradeRange = {} } = {},
+  } = useModel('progress', courseId) || { courseGrade: {}, gradingPolicy: {} };
 
   const latestDueDate = getLatestDueDateInFuture(assignmentTypeGradeSummary);
   const wideScreen = useWindowSize().width >= breakpoints.medium.minWidth;

--- a/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
@@ -12,13 +12,11 @@ const CurrentGradeTooltip = ({ tooltipClassName }) => {
   const intl = useIntl();
   const courseId = useContextId();
 
+  const modelData = useModel('progress', courseId);
   const {
-    assignmentTypeGradeSummary,
-    courseGrade: {
-      isPassing,
-      percent,
-    },
-  } = useModel('progress', courseId);
+    assignmentTypeGradeSummary = [],
+    courseGrade: { isPassing, percent } = {},
+  } = modelData || { courseGrade: {} };
 
   const currentGrade = Number((percent * 100).toFixed(0));
 

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummary.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummary.jsx
@@ -10,8 +10,8 @@ const GradeSummary = () => {
   const courseId = useContextId();
 
   const {
-    assignmentTypeGradeSummary,
-  } = useModel('progress', courseId);
+    assignmentTypeGradeSummary = [],
+  } = useModel('progress', courseId) || {};
 
   const [allOfSomeAssignmentTypeIsLocked, setAllOfSomeAssignmentTypeIsLocked] = useState(false);
 


### PR DESCRIPTION
### Description

This PR fixes a runtime crash (white screen) occurring on the **Progress** tab in the Learning MFE.

**The Issue:**
After upgrading from Sumac to Ulmo, we observed that the `useModel('progress', ...)` hook occasionally returns `undefined` or incomplete data during the initial render phase. This causes `TypeError` crashes when the code attempts to access array methods (such as `.some()`, `.length`) or pass these variables to utility functions (like `getLatestDueDateInFuture`).

**Specific errors observed in the console:**
- `TypeError: Cannot read properties of undefined (reading 'some')` in `CurrentGradeTooltip.jsx`
- `TypeError: Cannot read properties of undefined (reading 'length')` in `GradeSummary.jsx`
- `TypeError: Cannot read properties of undefined (reading 'forEach')` (via utils) in `CourseGradeFooter.jsx`

**The Fix:**
I have applied defensive coding practices by assigning default empty arrays (`[]`) and objects (`{}`) to the destructured variables from `useModel`. This ensures that the components can render safely even if the API response is delayed or the model data is not yet fully populated.

### Changes

- **src/courseware/course/course-grade/CourseGradeFooter.jsx**: Added default values for `assignmentTypeGradeSummary`, `courseGrade`, and `gradeRange`.
- **src/courseware/course/course-grade/CurrentGradeTooltip.jsx**: Added default values for `assignmentTypeGradeSummary` and `courseGrade`.
- **src/courseware/course/grade-summary/GradeSummary.jsx**: Added default value for `assignmentTypeGradeSummary` to prevent `.length` check failure.

### Testing Instructions

1. Navigate to the Learning MFE for any course.
2. Click on the **Progress** tab.
3. Verify that the page loads successfully without a white screen crash.
4. Check the browser console to ensure no `TypeError: Cannot read properties of undefined` errors are logged related to grade summaries.


<img width="1436" height="773" alt="Screenshot 2026-01-22 at 13 52 20" src="https://github.com/user-attachments/assets/aae63162-b493-40e3-9af0-cee368a07010" />
