### PR TITLE
fix: translation message

### DIFF
--- a/src/course-home/progress-tab/grades/messages.ts
+++ b/src/course-home/progress-tab/grades/messages.ts
@@ -224,7 +224,7 @@ const messages = defineMessages({
     description: 'It the text precede the sum of weighted grades of all the assignment',
   },
   weightedGradeSummaryTooltip: {
-    id: 'progress.weightedGradeSummary',
+    id: 'progress.weightedGradeSummaryTooltip',
     defaultMessage: 'Your raw weighted grade summary is {rawGrade} and rounds to {roundedGrade}.',
     description: 'Tooltip content that explains the rounding of the summary versus individual assignments',
   },


### PR DESCRIPTION
On the progress page instead of showing:
`Your current weighted grade summary` at least on pt_PT locale it was shown the tooltip message.

I think this is happening because there are a duplicated `id` **"_progress.weightedGradeSummary_"** on the `src/course-home/progress-tab/grades/messages.ts` file.

Screen capture on NAU Platform:

<img width="1013" height="362" alt="image" src="https://github.com/user-attachments/assets/eae81cee-8451-418c-955d-ee911c9398c9" />
