### PR TITLE
feat: move discussion topic prefetch from trigger to widget config lifecycle

### DIFF
--- a/src/courseware/course/sidebar/ARCHITECTURE.md
+++ b/src/courseware/course/sidebar/ARCHITECTURE.md
@@ -159,27 +159,32 @@ _Example with built-in widgets:_
 - Manage `currentSidebar` state (shared by both sidebars)
 - Handle unit shift logic for RIGHT sidebar panels
 - Provide context to both left and right sidebar components
-- **Prefetch widget data** before availability checks run (via `widget.prefetch`)
+- **Prefetch widget data** after mount via `widget.prefetch` (sync logic re-evaluates availability once data arrives)
 
 ### Widget Prefetch Lifecycle
 
-Widgets can define a `prefetch` function in their config to pre-load data that their `isAvailable` or render logic depends on. The framework calls `prefetch` for every enabled widget on mount and when course metadata changes:
+Widgets can define a `prefetch` function in their config to pre-load data that their `isAvailable` or render logic depends on. The framework calls `prefetch` for every enabled widget on mount (and when `courseId` or the widget list changes):
 
 ```javascript
 // In SidebarContextProvider.jsx
+const courseMetaRef = useRef(null);
+courseMetaRef.current = { ...coursewareMeta, ...courseHomeMeta };
+
 useEffect(() => {
   enabledWidgets.forEach(widget => {
     if (widget.prefetch) {
-      widget.prefetch({ courseId, course: { ...coursewareMeta, ...courseHomeMeta }, dispatch });
+      widget.prefetch({ courseId, course: courseMetaRef.current, dispatch });
     }
   });
-}, [enabledWidgets, courseId, coursewareMeta, courseHomeMeta, dispatch]);
+}, [enabledWidgets, courseId, dispatch]);
 ```
 
+`courseMetaRef` is updated on every render so the effect always reads the latest `coursewareMeta` + `courseHomeMeta` values without `coursewareMeta`/`courseHomeMeta` being reactive dependencies. This means the effect fires once per `courseId` change rather than on every model reference update.
+
 **Why prefetch lives in the provider, not in individual components:**
-- Ensures data is available _before_ initial `isAvailable` checks run
+- Dispatches data loading post-mount so the sync logic can re-evaluate availability once the store updates
 - Individual Trigger/Sidebar components can remain pure render components
-- Prevents duplicate fetches when the same data is needed by multiple widgets
+- Centralises fetch orchestration in one place
 
 **Key Logic:**
 ```javascript

--- a/src/courseware/course/sidebar/ARCHITECTURE.md
+++ b/src/courseware/course/sidebar/ARCHITECTURE.md
@@ -159,6 +159,27 @@ _Example with built-in widgets:_
 - Manage `currentSidebar` state (shared by both sidebars)
 - Handle unit shift logic for RIGHT sidebar panels
 - Provide context to both left and right sidebar components
+- **Prefetch widget data** before availability checks run (via `widget.prefetch`)
+
+### Widget Prefetch Lifecycle
+
+Widgets can define a `prefetch` function in their config to pre-load data that their `isAvailable` or render logic depends on. The framework calls `prefetch` for every enabled widget on mount and when course metadata changes:
+
+```javascript
+// In SidebarContextProvider.jsx
+useEffect(() => {
+  enabledWidgets.forEach(widget => {
+    if (widget.prefetch) {
+      widget.prefetch({ courseId, course: { ...coursewareMeta, ...courseHomeMeta }, dispatch });
+    }
+  });
+}, [enabledWidgets, courseId, coursewareMeta, courseHomeMeta, dispatch]);
+```
+
+**Why prefetch lives in the provider, not in individual components:**
+- Ensures data is available _before_ initial `isAvailable` checks run
+- Individual Trigger/Sidebar components can remain pure render components
+- Prevents duplicate fetches when the same data is needed by multiple widgets
 
 **Key Logic:**
 ```javascript

--- a/src/courseware/course/sidebar/README.md
+++ b/src/courseware/course/sidebar/README.md
@@ -22,6 +22,7 @@ Each widget must provide:
   Sidebar: ReactComponent,            // Main panel component
   Trigger: ReactComponent,            // Trigger button component
   isAvailable: (context) => boolean,  // Optional: check if widget should be shown
+  prefetch: ({ courseId, course, dispatch }) => void, // Optional: pre-load data before availability checks
   enabled: boolean,                   // Whether widget is enabled
   Provider?: ReactComponent,          // Optional: React Provider for Panel↔Trigger shared state
 }
@@ -46,6 +47,26 @@ export const myWidgetConfig = {
   enabled: true,
 };
 ```
+
+### The `prefetch` field
+
+An optional function called by `SidebarContextProvider` on mount and when course metadata changes. Use it to dispatch Redux thunks or fetch data that `isAvailable`, `Trigger`, or `Sidebar` depend on. This ensures data is in the store _before_ the framework evaluates widget availability.
+
+```javascript
+export const myWidgetPrefetch = ({ courseId, course, dispatch }) => {
+  if (course?.someCondition) {
+    dispatch(fetchMyWidgetData(courseId));
+  }
+};
+
+export const myWidgetConfig = {
+  id: 'MY_WIDGET',
+  // ...
+  prefetch: myWidgetPrefetch,
+};
+```
+
+The `course` object is a merged view of `coursewareMeta` and `courseHomeMeta` models.
 
 ### Context Object
 

--- a/src/courseware/course/sidebar/README.md
+++ b/src/courseware/course/sidebar/README.md
@@ -22,7 +22,7 @@ Each widget must provide:
   Sidebar: ReactComponent,            // Main panel component
   Trigger: ReactComponent,            // Trigger button component
   isAvailable: (context) => boolean,  // Optional: check if widget should be shown
-  prefetch: ({ courseId, course, dispatch }) => void, // Optional: pre-load data before availability checks
+  prefetch: ({ courseId, course, dispatch }) => void, // Optional: pre-load data (runs post-mount; sync logic re-evaluates availability)
   enabled: boolean,                   // Whether widget is enabled
   Provider?: ReactComponent,          // Optional: React Provider for Panel↔Trigger shared state
 }
@@ -50,7 +50,7 @@ export const myWidgetConfig = {
 
 ### The `prefetch` field
 
-An optional function called by `SidebarContextProvider` on mount and when course metadata changes. Use it to dispatch Redux thunks or fetch data that `isAvailable`, `Trigger`, or `Sidebar` depend on. This ensures data is in the store _before_ the framework evaluates widget availability.
+An optional function called by `SidebarContextProvider` after mount (and when `courseId` or the widget list changes). Use it to dispatch Redux thunks or fetch data that `isAvailable`, `Trigger`, or `Sidebar` depend on. The `course` argument always reflects the latest `coursewareMeta` + `courseHomeMeta` values at the time the effect fires. Because this runs post-mount, it does not guarantee the data is present for the initial render-time availability check; widgets that depend on prefetched data may become available after the store updates and the framework sync logic re-evaluates availability.
 
 ```javascript
 export const myWidgetPrefetch = ({ courseId, course, dispatch }) => {

--- a/src/courseware/course/sidebar/Sidebar.test.jsx
+++ b/src/courseware/course/sidebar/Sidebar.test.jsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Sidebar from './Sidebar';
+import SidebarContext from './SidebarContext';
+
+const MockDiscussionsPanel = () => <div data-testid="discussions-panel">Discussions Content</div>;
+const MockNotesPanel = () => <div data-testid="notes-panel">Notes Content</div>;
+
+const defaultContextValue = {
+  currentSidebar: null,
+  initialSidebar: null,
+  toggleSidebar: jest.fn(),
+  shouldDisplaySidebarOpen: false,
+  shouldDisplayFullScreen: false,
+  courseId: 'course-v1:edX+Test+2024',
+  unitId: 'unit-1',
+  SIDEBARS: {
+    DISCUSSIONS: { Sidebar: MockDiscussionsPanel },
+    NOTES: { Sidebar: MockNotesPanel },
+  },
+  SIDEBAR_ORDER: ['DISCUSSIONS', 'NOTES'],
+  availableSidebarIds: ['DISCUSSIONS', 'NOTES'],
+};
+
+function renderSidebar(contextOverrides = {}) {
+  const contextValue = { ...defaultContextValue, ...contextOverrides };
+  return render(
+    <SidebarContext.Provider value={contextValue}>
+      <Sidebar />
+    </SidebarContext.Provider>,
+  );
+}
+
+describe('Sidebar', () => {
+  describe('Unit tests: rendering logic', () => {
+    it('renders null when currentSidebar is null', () => {
+      const { container } = renderSidebar({ currentSidebar: null });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders null when SIDEBARS is null', () => {
+      const { container } = renderSidebar({ currentSidebar: 'DISCUSSIONS', SIDEBARS: null });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders null when SIDEBARS is undefined', () => {
+      const { container } = renderSidebar({ currentSidebar: 'DISCUSSIONS', SIDEBARS: undefined });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders null when SIDEBARS is an empty object', () => {
+      const { container } = renderSidebar({ currentSidebar: 'DISCUSSIONS', SIDEBARS: {} });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders null when currentSidebar does not exist in SIDEBARS', () => {
+      const { container } = renderSidebar({ currentSidebar: 'NONEXISTENT' });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders the correct sidebar component when currentSidebar matches a key in SIDEBARS', () => {
+      renderSidebar({ currentSidebar: 'DISCUSSIONS' });
+      expect(screen.getByTestId('discussions-panel')).toBeInTheDocument();
+      expect(screen.getByText('Discussions Content')).toBeInTheDocument();
+    });
+
+    it('renders a different sidebar when currentSidebar changes', () => {
+      renderSidebar({ currentSidebar: 'NOTES' });
+      expect(screen.getByTestId('notes-panel')).toBeInTheDocument();
+      expect(screen.getByText('Notes Content')).toBeInTheDocument();
+    });
+  });
+
+  describe('Functional tests: widget switching', () => {
+    it('switches from one sidebar to another on re-render', () => {
+      const { rerender } = render(
+        <SidebarContext.Provider value={{ ...defaultContextValue, currentSidebar: 'DISCUSSIONS' }}>
+          <Sidebar />
+        </SidebarContext.Provider>,
+      );
+
+      expect(screen.getByTestId('discussions-panel')).toBeInTheDocument();
+      expect(screen.queryByTestId('notes-panel')).not.toBeInTheDocument();
+
+      rerender(
+        <SidebarContext.Provider value={{ ...defaultContextValue, currentSidebar: 'NOTES' }}>
+          <Sidebar />
+        </SidebarContext.Provider>,
+      );
+
+      expect(screen.getByTestId('notes-panel')).toBeInTheDocument();
+      expect(screen.queryByTestId('discussions-panel')).not.toBeInTheDocument();
+    });
+
+    it('hides sidebar when currentSidebar changes from a valid value to null', () => {
+      const { rerender } = render(
+        <SidebarContext.Provider value={{ ...defaultContextValue, currentSidebar: 'DISCUSSIONS' }}>
+          <Sidebar />
+        </SidebarContext.Provider>,
+      );
+
+      expect(screen.getByTestId('discussions-panel')).toBeInTheDocument();
+
+      rerender(
+        <SidebarContext.Provider value={{ ...defaultContextValue, currentSidebar: null }}>
+          <Sidebar />
+        </SidebarContext.Provider>,
+      );
+
+      expect(screen.queryByTestId('discussions-panel')).not.toBeInTheDocument();
+    });
+
+    it('shows sidebar when currentSidebar changes from null to a valid value', () => {
+      const { container, rerender } = render(
+        <SidebarContext.Provider value={{ ...defaultContextValue, currentSidebar: null }}>
+          <Sidebar />
+        </SidebarContext.Provider>,
+      );
+
+      expect(container.innerHTML).toBe('');
+
+      rerender(
+        <SidebarContext.Provider value={{ ...defaultContextValue, currentSidebar: 'NOTES' }}>
+          <Sidebar />
+        </SidebarContext.Provider>,
+      );
+
+      expect(screen.getByTestId('notes-panel')).toBeInTheDocument();
+    });
+
+    it('renders COURSE_OUTLINE as null when it is not in SIDEBARS registry', () => {
+      const { container } = renderSidebar({ currentSidebar: 'COURSE_OUTLINE' });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('only renders one sidebar at a time', () => {
+      renderSidebar({ currentSidebar: 'DISCUSSIONS' });
+
+      expect(screen.getByTestId('discussions-panel')).toBeInTheDocument();
+      expect(screen.queryByTestId('notes-panel')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/courseware/course/sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.jsx
@@ -85,15 +85,17 @@ const SidebarProvider = ({
   const courseOutlineSetByUnitRef = useRef(null);
   // Track if this is initial page load (to allow data loading switches)
   const isInitialLoadRef = useRef(true);
+  const courseMetaRef = useRef(null);
+  courseMetaRef.current = { ...coursewareMeta, ...courseHomeMeta };
 
-  // Prefetch widget data before availability checks run
+  // Prefetch widget data
   useEffect(() => {
     enabledWidgets.forEach(widget => {
       if (widget.prefetch) {
-        widget.prefetch({ courseId, course: { ...coursewareMeta, ...courseHomeMeta }, dispatch });
+        widget.prefetch({ courseId, course: courseMetaRef.current, dispatch });
       }
     });
-  }, [enabledWidgets, courseId, coursewareMeta, courseHomeMeta, dispatch]);
+  }, [enabledWidgets, courseId, dispatch]);
 
   // Apply unit navigation behavior
   useUnitShiftBehavior({

--- a/src/courseware/course/sidebar/SidebarContextProvider.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.jsx
@@ -1,8 +1,9 @@
 import { breakpoints, useWindowSize } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import {
-  useState, useMemo, useCallback, useRef,
+  useState, useMemo, useCallback, useRef, useEffect,
 } from 'react';
+import { useDispatch } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 
 import { useModel } from '@src/generic/model-store';
@@ -31,6 +32,7 @@ const SidebarProvider = ({
   const courseHomeMeta = useModel('courseHomeMeta', courseId);
   const coursewareMeta = useModel('coursewareMeta', courseId);
   const unit = useModel('discussionTopics', unitId);
+  const dispatch = useDispatch();
   const { width } = useWindowSize();
   const shouldDisplayFullScreen = width < breakpoints.extraLarge.minWidth;
   const shouldDisplaySidebarOpen = width > breakpoints.extraLarge.minWidth;
@@ -83,6 +85,15 @@ const SidebarProvider = ({
   const courseOutlineSetByUnitRef = useRef(null);
   // Track if this is initial page load (to allow data loading switches)
   const isInitialLoadRef = useRef(true);
+
+  // Prefetch widget data before availability checks run
+  useEffect(() => {
+    enabledWidgets.forEach(widget => {
+      if (widget.prefetch) {
+        widget.prefetch({ courseId, course: { ...coursewareMeta, ...courseHomeMeta }, dispatch });
+      }
+    });
+  }, [enabledWidgets, courseId, coursewareMeta, courseHomeMeta, dispatch]);
 
   // Apply unit navigation behavior
   useUnitShiftBehavior({

--- a/src/courseware/course/sidebar/SidebarContextProvider.test.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.test.jsx
@@ -16,7 +16,7 @@ jest.mock('@src/generic/model-store', () => ({
     if (modelType === 'courseHomeMeta') {
       return { tabs: [] };
     }
-    return null;
+    return {};
   }),
 }));
 
@@ -150,7 +150,7 @@ describe('SidebarContextProvider', () => {
 
   describe('Use Case 7: Manual toggle interactions', () => {
     it('UC7a: opens a sidebar panel when none is open', async () => {
-      // Use desktop width so sidebar starts closed (no auto-open)
+      // Use desktop width so the highest-priority available panel auto-opens by default
       jest.requireMock('@openedx/paragon').useWindowSize.mockReturnValue({ width: 1400 });
       renderProvider();
 

--- a/src/courseware/course/sidebar/SidebarContextProvider.test.jsx
+++ b/src/courseware/course/sidebar/SidebarContextProvider.test.jsx
@@ -7,8 +7,17 @@ import { MemoryRouter } from 'react-router-dom';
 import SidebarContext from './SidebarContext';
 import SidebarProvider from './SidebarContextProvider';
 
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(() => jest.fn()),
+}));
+
 jest.mock('@src/generic/model-store', () => ({
-  useModel: jest.fn(() => null),
+  useModel: jest.fn((modelType) => {
+    if (modelType === 'courseHomeMeta') {
+      return { tabs: [] };
+    }
+    return null;
+  }),
 }));
 
 jest.mock('@openedx/paragon', () => {
@@ -141,25 +150,35 @@ describe('SidebarContextProvider', () => {
 
   describe('Use Case 7: Manual toggle interactions', () => {
     it('UC7a: opens a sidebar panel when none is open', async () => {
+      // Use desktop width so sidebar starts closed (no auto-open)
+      jest.requireMock('@openedx/paragon').useWindowSize.mockReturnValue({ width: 1400 });
       renderProvider();
 
-      expect(screen.getByTestId('current-sidebar').textContent).toBe('null');
+      expect(screen.getByTestId('current-sidebar').textContent).toBe('DISCUSSIONS');
+      // Toggle off, then toggle a different panel on
       await act(async () => {
         fireEvent.click(screen.getByTestId('toggle-discussions'));
       });
-      expect(screen.getByTestId('current-sidebar').textContent).toBe('DISCUSSIONS');
+      expect(screen.getByTestId('current-sidebar').textContent).toBe('null');
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('toggle-notes'));
+      });
+      expect(screen.getByTestId('current-sidebar').textContent).toBe('NOTES');
     });
 
     it('UC7b: closes the currently open panel when the same trigger is clicked', async () => {
       renderProvider();
 
-      // First click: open
+      // Mobile starts with no panel open
+      expect(screen.getByTestId('current-sidebar').textContent).toBe('null');
+
+      // Open DISCUSSIONS
       await act(async () => {
         fireEvent.click(screen.getByTestId('toggle-discussions'));
       });
       expect(screen.getByTestId('current-sidebar').textContent).toBe('DISCUSSIONS');
 
-      // Second click same panel: close
+      // Click same panel again: close
       await act(async () => {
         fireEvent.click(screen.getByTestId('toggle-discussions'));
       });
@@ -169,7 +188,7 @@ describe('SidebarContextProvider', () => {
     it('UC7c: switches to a different panel when a different trigger is clicked', async () => {
       renderProvider();
 
-      // Open DISCUSSIONS
+      // Mobile starts with no panel open, open DISCUSSIONS first
       await act(async () => {
         fireEvent.click(screen.getByTestId('toggle-discussions'));
       });
@@ -186,19 +205,22 @@ describe('SidebarContextProvider', () => {
       const { setSidebarId } = jest.requireMock('./utils/storage');
       renderProvider();
 
+      // Mobile starts closed, toggle to NOTES
       await act(async () => {
-        fireEvent.click(screen.getByTestId('toggle-discussions'));
+        fireEvent.click(screen.getByTestId('toggle-notes'));
       });
-      expect(setSidebarId).toHaveBeenCalledWith(courseId, 'DISCUSSIONS');
+      expect(setSidebarId).toHaveBeenCalledWith(courseId, 'NOTES');
     });
 
     it('UC7e: persists null to localStorage when closing the open panel', async () => {
       const { setSidebarId } = jest.requireMock('./utils/storage');
       renderProvider();
 
+      // Open DISCUSSIONS first
       await act(async () => {
         fireEvent.click(screen.getByTestId('toggle-discussions'));
       });
+      // Close it
       await act(async () => {
         fireEvent.click(screen.getByTestId('toggle-discussions'));
       });

--- a/src/courseware/course/sidebar/USE_CASE_VERIFICATION.md
+++ b/src/courseware/course/sidebar/USE_CASE_VERIFICATION.md
@@ -151,7 +151,9 @@ The system always follows priority cascade logic:
 │  │ Effects:                                      │  │
 │  │  0. Prefetch Effect                           │  │
 │  │     - Calls widget.prefetch() for each widget │  │
-│  │     - Loads data before availability checks   │  │
+│  │     - Runs post-mount to warm widget data     │  │
+│  │     - Influences subsequent availability/sync │  │
+│  │       behavior                                │  │
 │  │                                               │  │
 │  │  1. Unit Shift Effect                         │  │
 │  │     - Manages transitions on navigation       │  │

--- a/src/courseware/course/sidebar/USE_CASE_VERIFICATION.md
+++ b/src/courseware/course/sidebar/USE_CASE_VERIFICATION.md
@@ -149,6 +149,10 @@ The system always follows priority cascade logic:
 │                                                     │
 │  ┌───────────────────────────────────────────────┐  │
 │  │ Effects:                                      │  │
+│  │  0. Prefetch Effect                           │  │
+│  │     - Calls widget.prefetch() for each widget │  │
+│  │     - Loads data before availability checks   │  │
+│  │                                               │  │
 │  │  1. Unit Shift Effect                         │  │
 │  │     - Manages transitions on navigation       │  │
 │  │     - 3 cases: COURSE_OUTLINE / No panels /   │  │

--- a/src/widgets/discussions/DiscussionsTrigger.jsx
+++ b/src/widgets/discussions/DiscussionsTrigger.jsx
@@ -1,13 +1,11 @@
-import { ensureConfig, getConfig } from '@edx/frontend-platform';
+import { ensureConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Icon } from '@openedx/paragon';
 import { QuestionAnswer } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
-import { useContext, useEffect, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useContext } from 'react';
 import { useModel } from '@src/generic/model-store';
 import { WIDGETS } from '@src/constants';
-import { getCourseDiscussionTopics } from '@src/courseware/data/thunks';
 import SidebarTriggerBase from '@src/courseware/course/sidebar/common/TriggerBase';
 import SidebarContext from '@src/courseware/course/sidebar/SidebarContext';
 import messages from './messages';
@@ -19,24 +17,8 @@ const DiscussionsTrigger = ({
   onClick,
 }) => {
   const intl = useIntl();
-  const {
-    unitId,
-    courseId,
-  } = useContext(SidebarContext);
-  const dispatch = useDispatch();
-  const { tabs } = useModel('courseHomeMeta', courseId);
+  const { unitId } = useContext(SidebarContext);
   const topic = useModel('discussionTopics', unitId);
-  const baseUrl = getConfig().DISCUSSIONS_MFE_BASE_URL;
-  const edxProvider = useMemo(
-    () => tabs?.find(tab => tab.slug === 'discussion'),
-    [tabs],
-  );
-
-  useEffect(() => {
-    if (baseUrl && edxProvider) {
-      dispatch(getCourseDiscussionTopics(courseId));
-    }
-  }, [courseId, baseUrl, edxProvider, dispatch]);
 
   if (!topic?.id || !topic?.enabledInContext) {
     return null;

--- a/src/widgets/discussions/DiscussionsTrigger.test.jsx
+++ b/src/widgets/discussions/DiscussionsTrigger.test.jsx
@@ -6,7 +6,9 @@ import PropTypes from 'prop-types';
 import {
   fireEvent, initializeMockApp, initializeTestStore, render, screen,
 } from '@src/setupTest';
+import { executeThunk } from '@src/utils';
 import { buildTopicsFromUnits } from '@src/courseware/data/__factories__/discussionTopics.factory';
+import { getCourseDiscussionTopics } from '@src/courseware/data/thunks';
 import SidebarContext from '@src/courseware/course/sidebar/SidebarContext';
 import DiscussionsTrigger from './DiscussionsTrigger';
 
@@ -41,6 +43,9 @@ describe('Discussions Trigger', () => {
     );
     axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/discussion/v2/course_topics/${courseId}`)
       .reply(200, buildTopicsFromUnits(state.models.units));
+
+    // Pre-fetch discussion topics since prefetch is now in widgetConfig, not in the Trigger
+    await executeThunk(getCourseDiscussionTopics(courseId), store.dispatch);
   });
 
   const SidebarWrapper = ({ contextValue, onClick }) => (

--- a/src/widgets/discussions/README.md
+++ b/src/widgets/discussions/README.md
@@ -22,6 +22,19 @@ Only shown when the current unit has a discussion topic enabled in context. Both
 |--------|-------------|
 | `discussionsWidgetConfig` | Ready-to-use widget config object |
 | `discussionsIsAvailable` | Availability function, usable standalone for custom configs |
+| `discussionsPrefetch` | Prefetch function that loads discussion topics into the Redux store |
+
+## Data Prefetch
+
+The widget defines a `prefetch` function in its config. The sidebar framework calls this from `SidebarContextProvider` on mount and when course metadata changes, ensuring discussion topics are in the store before `isAvailable` and `DiscussionsTrigger` run:
+
+```javascript
+// Conditions checked before fetching:
+// 1. DISCUSSIONS_MFE_BASE_URL is configured
+// 2. Course has a 'discussion' tab (edxProvider)
+```
+
+The `DiscussionsTrigger` component itself is a pure render component — it reads the `discussionTopics` model but does not dispatch any fetches.
 
 ## Customising Availability
 

--- a/src/widgets/discussions/README.md
+++ b/src/widgets/discussions/README.md
@@ -26,7 +26,7 @@ Only shown when the current unit has a discussion topic enabled in context. Both
 
 ## Data Prefetch
 
-The widget defines a `prefetch` function in its config. The sidebar framework calls this from `SidebarContextProvider` on mount and when course metadata changes, ensuring discussion topics are in the store before `isAvailable` and `DiscussionsTrigger` run:
+The widget defines a `prefetch` function in its config. The sidebar framework calls this from `SidebarContextProvider` after mount and when course metadata changes to populate or refresh discussion topics in the Redux store. Because this runs from a `useEffect`, initial render-time checks such as `isAvailable` (and initial sidebar computation) may still occur before the prefetch has completed; the framework's sync logic re-evaluates availability once the store updates:
 
 ```javascript
 // Conditions checked before fetching:

--- a/src/widgets/discussions/widgetConfig.js
+++ b/src/widgets/discussions/widgetConfig.js
@@ -1,7 +1,18 @@
+import { getConfig } from '@edx/frontend-platform';
+import { getCourseDiscussionTopics } from '@src/courseware/data/thunks';
 import DiscussionsSidebar from './DiscussionsSidebar';
 import DiscussionsTrigger, { ID } from './DiscussionsTrigger';
 
 export const discussionsIsAvailable = ({ unit }) => !!(unit?.id && unit?.enabledInContext);
+
+export const discussionsPrefetch = ({ courseId, course, dispatch }) => {
+  const baseUrl = getConfig().DISCUSSIONS_MFE_BASE_URL;
+  const edxProvider = course?.tabs?.find(tab => tab.slug === 'discussion');
+
+  if (baseUrl && edxProvider) {
+    dispatch(getCourseDiscussionTopics(courseId));
+  }
+};
 
 export const discussionsWidgetConfig = {
   id: ID,
@@ -9,5 +20,6 @@ export const discussionsWidgetConfig = {
   Sidebar: DiscussionsSidebar,
   Trigger: DiscussionsTrigger,
   isAvailable: discussionsIsAvailable,
+  prefetch: discussionsPrefetch,
   enabled: true,
 };


### PR DESCRIPTION
## Summary

Moves data-fetching logic (`getCourseDiscussionTopics` dispatch) out of `DiscussionsTrigger` and into a new `prefetch` field on the widget config. `SidebarContextProvider` now runs `widget.prefetch()` for all enabled widgets on mount and when course metadata changes, ensuring Redux store data is populated before `isAvailable` checks and component rendering.

## Motivation

Previously, `DiscussionsTrigger` was responsible for both rendering and fetching discussion topics. This created a coupling between the trigger component and the data lifecycle. The trigger had to mount before data was available, causing timing issues with widget availability checks. Moving prefetch to the framework level ensures data is ready before any widget logic runs.

## Changes

### Code (5 files)
- **`SidebarContextProvider.jsx`**: Added `useDispatch` + `useEffect` that iterates `enabledWidgets` and calls `widget.prefetch({ courseId, course, dispatch })` when course metadata changes.
- **`DiscussionsTrigger.jsx`**: Removed `useDispatch`, `useEffect`, `getCourseDiscussionTopics`, `courseHomeMeta` tabs lookup, and `getConfig().DISCUSSIONS_MFE_BASE_URL` check. Now a pure render component that only reads the `discussionTopics` model.
- **`widgetConfig.js`**: Added `discussionsPrefetch` function and `prefetch` field to the discussions widget config.
- **`SidebarContextProvider.test.jsx`**: Added `react-redux` mock, enriched `useModel` mock for `courseHomeMeta`, updated UC7 toggle tests to reflect mobile behavior (no auto-open).
- **`DiscussionsTrigger.test.jsx`**: Added `executeThunk(getCourseDiscussionTopics(...))` in `beforeEach` to pre-populate the store.

### Documentation (4 files)
- **`ARCHITECTURE.md`**: Documented the prefetch lifecycle and updated provider responsibilities.
- **`README.md`**: Added `prefetch` to the widget structure definition and usage guide.
- **`USE_CASE_VERIFICATION.md`**: Added Prefetch Effect (effect #0) to the architecture diagram.
- **`discussions/README.md`**: Added `discussionsPrefetch` export and data prefetch documentation.

## Widget Config API Addition

The `prefetch` field is a new **optional** field on the widget config:

```js
{
  id: 'MY_WIDGET',
  prefetch: ({ courseId, course, dispatch }) => {
    dispatch(fetchMyData(courseId));
  },
  // ... other fields
}