### PR TITLE
fix: add npm override for axios (CVE-2025-58754)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
       }
     ],
     "normalizeFilenames": "^.+?(\\..+?)\\.\\w+$"
+  },
+  "overrides": {
+    "axios": "^1.9.1"
   }
 }


### PR DESCRIPTION
## Summary

Add npm `overrides` for axios to address [CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754) (Denial of Service via massive data schemas in Node.js).

**CVSS:** 7.5 (High)

### Why npm overrides instead of bumping frontend-platform?

The vulnerable axios version (1.9.0) is a **transitive dependency** of `@edx/frontend-platform`. The fix was shipped in `frontend-platform` v8.5.5+ (axios ≥1.13.5), but this MFE's release branch pins `frontend-platform ^8.3.1`.

Bumping `frontend-platform` from 8.3.x to 8.5.x on a frozen release branch carries risk of breaking changes that were not tested against this release. The [npm overrides](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides) mechanism is the standard npm approach to force a transitive dependency to a safe version without changing the parent package version.

**Note:** `release/verawood` already ships with `frontend-platform ^8.7.0` (axios 1.15.0) and is **not affected** by this vulnerability.

### frontend-platform → axios version timeline

| frontend-platform | axios | Status |
|---|---|---|
| 8.3.1 | 1.8.2 | Safe |
| 8.4.0 – 8.5.0 | 1.9.0 | **Vulnerable (CVE-2025-58754)** |
| 8.5.5 | 1.13.5 | Fixed |
| 8.5.6+ | 1.15.0 | Fixed |

### Change

```json
"overrides": {
  "axios": "^1.9.1"
}
```

This forces npm to resolve axios to ≥1.9.1 across the entire dependency tree, including the copy bundled by `@edx/frontend-platform`.

### Test plan

- [ ] MFE builds successfully with the override
- [ ] Verify resolved axios version in node_modules is ≥1.9.1
- [ ] Smoke test core MFE functionality

### References

- [CVE-2025-58754 - NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)
- [CVE-2025-58754 - GitLab Advisory](https://advisories.gitlab.com/pkg/npm/axios/CVE-2025-58754/)
- [Microsoft: Mitigating the Axios npm supply chain compromise](https://www.microsoft.com/en-us/security/blog/2026/04/01/mitigating-the-axios-npm-supply-chain-compromise/)
- [npm overrides documentation](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides)
- [HeroDevs: Guide to NPM Overrides](https://www.herodevs.com/blog-posts/a-guide-to-npm-overrides-take-control-of-your-dependencies)
- [frontend-platform axios fix (v8.5.5)](https://github.com/openedx/frontend-platform/commit/1c02a0f6)