### PR TITLE
style: Add per-tab-page class to LoadedTabPage for easier per-tab styling

### DIFF
--- a/src/tab-page/LoadedTabPage.tsx
+++ b/src/tab-page/LoadedTabPage.tsx
@@ -79,7 +79,7 @@ const LoadedTabPage = ({
         streakDiscountCouponEnabled={streakDiscountCouponEnabled}
         verifiedMode={verifiedMode}
       />
-      <main className="d-flex flex-column flex-grow-1">
+      <main className={`d-flex flex-column flex-grow-1 ${activeTabSlug}-tab-page`}>
         <AlertList
           topic="outline"
           className="mx-5 mt-3"


### PR DESCRIPTION
 ### Summary                                                                                                                                                                  
                                                                                                                                                                              
Adds a dynamic CSS class to `LoadedTabPage`, so each course tab page (e.g. outline, progress, dates, discussion) gets a unique, predictable class name that can be targeted for tab-specific styling.                                                                                         
                                                                                                                                                                              
 ### Description                                                                                                                                                              
                                                                                                                                                                              
Without the changes in this PR it difficult to apply styles scoped to a single tab (for example, adjusting heading colors only on the Progress tab) without resorting to fragile selectors based on content or position.        
                                                                                       
 This change appends the active tab's slug as a class allowing theme authors to target specific tab pages. 