### PR TITLE
refactor: convert courseware search from Redux to React Query

### DIFF
--- a/src/course-home/courseware-search/CoursewareResultsFilter.jsx
+++ b/src/course-home/courseware-search/CoursewareResultsFilter.jsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router';
 import CoursewareSearchResults from './CoursewareSearchResults';
 import messages from './messages';
 import { useCoursewareSearchParams } from './hooks';
-import { useModel } from '../../generic/model-store';
+import { useCoursewareSearchResults } from './data/apiHooks';
 
 const filterAll = 'all';
 const filterTypes = ['text', 'video', 'sequence'];
@@ -16,15 +16,10 @@ const validFilters = [filterAll, ...filterTypes, filterOther];
 export const CoursewareSearchResultsFilter = () => {
   const intl = useIntl();
   const { courseId } = useParams();
-  const lastSearch = useModel('contentSearchResults', courseId);
-  const { filter: filterKeyword, setFilter } = useCoursewareSearchParams();
+  const { filter: filterKeyword, setFilter, query: searchKeyword } = useCoursewareSearchParams();
+  const { data: lastSearch } = useCoursewareSearchResults(courseId, searchKeyword);
 
-  if (!lastSearch) { return null; }
-
-  const { results: data = [] } = lastSearch;
-
-  // If there's no data, we show an empty result.
-  if (!data.length) { return <CoursewareSearchResults />; }
+  const { results: data = [] } = lastSearch ?? {};
 
   const results = useMemo(() => {
     // This reducer distributes the data into different groups to make it easy to
@@ -45,14 +40,20 @@ export const CoursewareSearchResultsFilter = () => {
   }, [lastSearch]);
 
   const tabKeys = Object.keys(results);
-  // Filter has no use if it has only 2 tabs (The "all" tab and another one with the same items).
-  if (tabKeys.length < 3) { return <CoursewareSearchResults results={results[filterAll]} />; }
 
   const filters = useMemo(() => tabKeys.map((key) => ({
     key,
     label: intl.formatMessage(messages[`filter:${key}`]),
     count: results[key].length,
   })), [results]);
+
+  if (!lastSearch) { return null; }
+
+  // If there's no data, we show an empty result.
+  if (!data.length) { return <CoursewareSearchResults />; }
+
+  // Filter has no use if it has only 2 tabs (The "all" tab and another one with the same items).
+  if (tabKeys.length < 3) { return <CoursewareSearchResults results={results[filterAll]} />; }
 
   const activeKey = validFilters.includes(filterKeyword) ? filterKeyword : filterAll;
 

--- a/src/course-home/courseware-search/CoursewareResultsFilter.test.jsx
+++ b/src/course-home/courseware-search/CoursewareResultsFilter.test.jsx
@@ -11,13 +11,11 @@ import {
 import { CoursewareSearchResultsFilter } from './CoursewareResultsFilter';
 import { useCoursewareSearchParams } from './hooks';
 import initializeStore from '../../store';
-import { useModel } from '../../generic/model-store';
+import { useCoursewareSearchResults } from './data/apiHooks';
 import searchResultsFactory from './test-data/search-results-factory';
 
 jest.mock('./hooks');
-jest.mock('../../generic/model-store', () => ({
-  useModel: jest.fn(),
-}));
+jest.mock('./data/apiHooks');
 
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
@@ -68,7 +66,7 @@ describe('CoursewareSearchResultsFilter', () => {
 
   describe('when returning full results', () => {
     beforeEach(() => {
-      useModel.mockReturnValue(searchResultsFactory());
+      useCoursewareSearchResults.mockReturnValue({ data: searchResultsFactory() });
       renderComponent();
     });
 
@@ -90,13 +88,12 @@ describe('CoursewareSearchResultsFilter', () => {
     beforeEach(async () => {
       // Get results for only videos
       const data = searchResultsFactory();
-      const onlyVideos = data.results.filter(({ type }) => type === 'video');
-      const filteredResults = {
+      const onlyVideos = {
         ...data,
-        results: onlyVideos,
+        results: data.results.filter(({ type }) => type === 'video'),
       };
 
-      useModel.mockReturnValue(filteredResults);
+      useCoursewareSearchResults.mockReturnValue({ data: onlyVideos });
       await renderComponent();
     });
 
@@ -111,13 +108,15 @@ describe('CoursewareSearchResultsFilter', () => {
 
   describe('when there are not results', () => {
     beforeEach(async () => {
-      useModel.mockReturnValue(searchResultsFactory('blah', {
-        results: [],
-        filters: [],
-        total: 0,
-        maxScore: null,
-        ms: 5,
-      }));
+      useCoursewareSearchResults.mockReturnValue({
+        data: searchResultsFactory('blah', {
+          results: [],
+          filters: [],
+          total: 0,
+          maxScore: null,
+          ms: 5,
+        }),
+      });
       await renderComponent();
     });
 

--- a/src/course-home/courseware-search/CoursewareSearch.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router';
-import { useDispatch } from 'react-redux';
 import { sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
@@ -9,27 +8,27 @@ import {
 import {
   Close,
 } from '@openedx/paragon/icons';
-import { setShowSearch } from '../data/slice';
-import { useCoursewareSearchParams, useElementBoundingBox, useLockScroll } from './hooks';
+import { useCoursewareSearch } from './CoursewareSearchContext';
+import {
+  useCoursewareSearchFeatureFlag, useCoursewareSearchParams, useElementBoundingBox, useLockScroll,
+} from './hooks';
 import messages from './messages';
 
 import CoursewareSearchForm from './CoursewareSearchForm';
 import CoursewareSearchResultsFilterContainer from './CoursewareResultsFilter';
-import { updateModel, useModel } from '../../generic/model-store';
-import { searchCourseContent } from '../data/thunks';
+import { useModel } from '../../generic/model-store';
+import { useCoursewareSearchResults } from './data/apiHooks';
 
-const CoursewareSearch = ({ ...sectionProps }) => {
+const CoursewareSearchModal = ({ ...sectionProps }) => {
   const { formatMessage } = useIntl();
   const { courseId } = useParams();
   const { query: searchKeyword, setQuery, clearSearchParams } = useCoursewareSearchParams();
-  const dispatch = useDispatch();
+  const { close: closeSearch } = useCoursewareSearch();
   const { org } = useModel('courseHomeMeta', courseId);
   const {
-    loading,
-    searchKeyword: lastSearchKeyword,
-    errors,
-    total,
-  } = useModel('contentSearchResults', courseId);
+    data, isLoading, isError,
+  } = useCoursewareSearchResults(courseId, searchKeyword);
+  const total = data?.total;
   const dialogRef = useRef();
 
   useLockScroll();
@@ -39,17 +38,6 @@ const CoursewareSearch = ({ ...sectionProps }) => {
 
   const clearSearch = () => {
     clearSearchParams();
-    dispatch(updateModel({
-      modelType: 'contentSearchResults',
-      model: {
-        id: courseId,
-        searchKeyword: '',
-        results: [],
-        errors: undefined,
-        loading:
-        false,
-      },
-    }));
   };
 
   const handleSubmit = (value) => {
@@ -65,7 +53,6 @@ const CoursewareSearch = ({ ...sectionProps }) => {
       keyword: value,
     });
 
-    dispatch(searchCourseContent(courseId, value));
     setQuery(value);
   };
 
@@ -76,7 +63,7 @@ const CoursewareSearch = ({ ...sectionProps }) => {
 
   const close = () => {
     clearSearch();
-    dispatch(setShowSearch(false));
+    closeSearch();
   };
 
   const handlePopState = () => close();
@@ -110,11 +97,11 @@ const CoursewareSearch = ({ ...sectionProps }) => {
   const handleSearchClose = () => close();
 
   let status = 'idle';
-  if (loading) {
+  if (isLoading) {
     status = 'loading';
-  } else if (errors) {
+  } else if (isError) {
     status = 'error';
-  } else if (lastSearchKeyword) {
+  } else if (data) {
     status = 'results';
   }
 
@@ -160,7 +147,7 @@ const CoursewareSearch = ({ ...sectionProps }) => {
                     aria-relevant="all"
                     aria-atomic="true"
                     data-testid="courseware-search-summary"
-                  >{formatMessage(messages.searchResultsLabel, { total, keyword: lastSearchKeyword })}
+                  >{formatMessage(messages.searchResultsLabel, { total, keyword: searchKeyword })}
                   </div>
                 ) : null}
                 <CoursewareSearchResultsFilterContainer />
@@ -171,6 +158,15 @@ const CoursewareSearch = ({ ...sectionProps }) => {
       </div>
     </dialog>
   );
+};
+
+const CoursewareSearch = (props) => {
+  const { show } = useCoursewareSearch();
+  const enabled = useCoursewareSearchFeatureFlag();
+
+  if (!enabled || !show) { return null; }
+
+  return <CoursewareSearchModal {...props} />;
 };
 
 export default CoursewareSearch;

--- a/src/course-home/courseware-search/CoursewareSearch.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.test.jsx
@@ -12,35 +12,24 @@ import {
   within,
 } from '../../setupTest';
 import { CoursewareSearch } from './index';
-import { useElementBoundingBox, useLockScroll, useCoursewareSearchParams } from './hooks';
+import {
+  useCoursewareSearchFeatureFlag, useElementBoundingBox, useLockScroll, useCoursewareSearchParams,
+} from './hooks';
+import { useCoursewareSearch } from './CoursewareSearchContext';
+import { useCoursewareSearchResults } from './data/apiHooks';
 import initializeStore from '../../store';
-import { searchCourseContent } from '../data/thunks';
-import { setShowSearch } from '../data/slice';
-import { updateModel, useModel } from '../../generic/model-store';
+import { useModel } from '../../generic/model-store';
 
 jest.mock('./hooks');
+jest.mock('./CoursewareSearchContext');
+jest.mock('./data/apiHooks');
 jest.mock('../../generic/model-store', () => ({
   ...jest.requireActual('../../generic/model-store'),
-  updateModel: jest.fn(),
   useModel: jest.fn(),
 }));
 
 jest.mock('@edx/frontend-platform/analytics', () => ({
   sendTrackingLogEvent: jest.fn(),
-}));
-
-jest.mock('../data/thunks', () => ({
-  searchCourseContent: jest.fn(),
-}));
-
-jest.mock('../data/slice', () => ({
-  setShowSearch: jest.fn(),
-}));
-
-const mockDispatch = jest.fn();
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: () => mockDispatch,
 }));
 
 const decodedCourseId = 'course-v1:edX+DemoX+Demo_Course';
@@ -50,13 +39,8 @@ const pathname = `/course/${decodedCourseId}/${decodedSequenceId}/${decodedUnitI
 
 const tabsTopPosition = 128;
 
-const defaultProps = {
-  org: 'edX',
-  loading: false,
-  searchKeyword: '',
-  errors: undefined,
-  total: 0,
-};
+const org = 'edX';
+const mockClose = jest.fn();
 
 const defaultSearchParams = {
   query: '',
@@ -83,20 +67,9 @@ function renderComponent(props = {}) {
   return container;
 }
 
-const mockModels = ((props = defaultProps) => {
-  useModel.mockReturnValue({
-    ...defaultProps,
-    ...props,
-  });
-
-  updateModel.mockReturnValue({
-    type: 'MOCK_ACTION',
-    payload: {
-      modelType: 'contentSearchResults',
-      model: defaultProps,
-    },
-  });
-});
+const mockResults = ({ data, isLoading = false, isError = false } = {}) => {
+  useCoursewareSearchResults.mockReturnValue({ data, isLoading, isError });
+};
 
 const mockSearchParams = ((params) => {
   const props = { ...defaultSearchParams, ...params };
@@ -107,7 +80,10 @@ describe('CoursewareSearch', () => {
   beforeAll(() => initializeMockApp());
 
   beforeEach(() => {
-    mockModels();
+    useModel.mockReturnValue({ org });
+    useCoursewareSearchFeatureFlag.mockReturnValue(true);
+    useCoursewareSearch.mockReturnValue({ show: true, close: mockClose });
+    mockResults();
     mockSearchParams();
   });
 
@@ -145,7 +121,7 @@ describe('CoursewareSearch', () => {
       });
 
       expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
-      expect(setShowSearch).toHaveBeenCalledWith(false);
+      expect(mockClose).toHaveBeenCalled();
     });
   });
 
@@ -170,7 +146,7 @@ describe('CoursewareSearch', () => {
   });
 
   describe('when submitting an empty search', () => {
-    it('should clear the search by dispatch updateModel', async () => {
+    it('should clear the search params', async () => {
       renderComponent();
 
       await waitFor(() => {
@@ -178,30 +154,19 @@ describe('CoursewareSearch', () => {
         fireEvent.click(submit);
       });
 
-      expect(updateModel).toHaveBeenCalledWith({
-        modelType: 'contentSearchResults',
-        model: {
-          id: decodedCourseId,
-          searchKeyword: '',
-          results: [],
-          errors: undefined,
-          loading: false,
-        },
-      });
+      expect(defaultSearchParams.clearSearchParams).toHaveBeenCalled();
     });
   });
 
   describe('when submitting a search', () => {
     it('should show a loading state', () => {
-      mockModels({
-        loading: true,
-      });
+      mockResults({ isLoading: true });
       renderComponent();
 
       expect(screen.queryByTestId('courseware-search-spinner')).toBeInTheDocument();
     });
 
-    it('should call searchCourseContent', async () => {
+    it('should update the search query on submit', async () => {
       renderComponent();
 
       const searchKeyword = 'course';
@@ -217,38 +182,31 @@ describe('CoursewareSearch', () => {
       });
 
       expect(sendTrackingLogEvent).toHaveBeenCalledWith('edx.course.home.courseware_search.submit', {
-        org_key: defaultProps.org,
+        org_key: org,
         courserun_key: decodedCourseId,
         event_type: 'searchKeyword',
         keyword: searchKeyword,
       });
-      expect(searchCourseContent).toHaveBeenCalledWith(decodedCourseId, searchKeyword);
+      expect(defaultSearchParams.setQuery).toHaveBeenCalledWith(searchKeyword);
     });
 
     it('should show an error state if any', () => {
-      mockModels({
-        errors: ['foo'],
-      });
+      mockResults({ isError: true });
       renderComponent();
 
       expect(screen.queryByTestId('courseware-search-error')).toBeInTheDocument();
     });
 
     it('should not show a summary if there are no results', () => {
-      mockModels({
-        searchKeyword: 'test',
-        total: 0,
-      });
+      mockResults({ data: { total: 0 } });
       renderComponent();
 
       expect(screen.queryByTestId('courseware-search-summary')).not.toBeInTheDocument();
     });
 
     it('should show a summary for the results within a container with aria-live="polite"', () => {
-      mockModels({
-        searchKeyword: 'fubar',
-        total: 1,
-      });
+      mockSearchParams({ query: 'fubar' });
+      mockResults({ data: { total: 1 } });
       renderComponent();
 
       const results = screen.queryByTestId('courseware-search-results');
@@ -259,12 +217,9 @@ describe('CoursewareSearch', () => {
   });
 
   describe('when clearing the search input', () => {
-    it('should clear the search by dispatch updateModel', async () => {
+    it('should clear the search params', async () => {
       mockSearchParams({ query: 'fubar' });
-      mockModels({
-        searchKeyword: 'fubar',
-        total: 2,
-      });
+      mockResults({ data: { total: 2 } });
       renderComponent();
 
       await waitFor(() => {
@@ -272,16 +227,7 @@ describe('CoursewareSearch', () => {
         fireEvent.change(input, { target: { value: '' } });
       });
 
-      expect(updateModel).toHaveBeenCalledWith({
-        modelType: 'contentSearchResults',
-        model: {
-          id: decodedCourseId,
-          searchKeyword: '',
-          results: [],
-          errors: undefined,
-          loading: false,
-        },
-      });
+      expect(defaultSearchParams.clearSearchParams).toHaveBeenCalled();
     });
   });
 });

--- a/src/course-home/courseware-search/CoursewareSearchContext.test.tsx
+++ b/src/course-home/courseware-search/CoursewareSearchContext.test.tsx
@@ -1,0 +1,30 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { CoursewareSearchProvider, useCoursewareSearch } from './CoursewareSearchContext';
+
+const wrapper = ({ children }) => <CoursewareSearchProvider>{children}</CoursewareSearchProvider>;
+
+describe('CoursewareSearchContext', () => {
+  it('throws when used outside a provider', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useCoursewareSearch())).toThrow(
+      'useCoursewareSearch must be used within a CoursewareSearchProvider',
+    );
+    consoleError.mockRestore();
+  });
+
+  it('starts closed', () => {
+    const { result } = renderHook(() => useCoursewareSearch(), { wrapper });
+    expect(result.current.show).toBe(false);
+  });
+
+  it('open() shows the search and close() hides it', () => {
+    const { result } = renderHook(() => useCoursewareSearch(), { wrapper });
+
+    act(() => result.current.open());
+    expect(result.current.show).toBe(true);
+
+    act(() => result.current.close());
+    expect(result.current.show).toBe(false);
+  });
+});

--- a/src/course-home/courseware-search/CoursewareSearchContext.tsx
+++ b/src/course-home/courseware-search/CoursewareSearchContext.tsx
@@ -1,0 +1,31 @@
+import React, {
+  createContext, useContext, useMemo, useState, ReactNode,
+} from 'react';
+
+interface CoursewareSearchContextValue {
+  show: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+const CoursewareSearchContext = createContext<CoursewareSearchContextValue | null>(null);
+
+export const CoursewareSearchProvider = ({ children }: { children: ReactNode }) => {
+  const [show, setShow] = useState(false);
+
+  const value = useMemo<CoursewareSearchContextValue>(() => ({
+    show,
+    open: () => setShow(true),
+    close: () => setShow(false),
+  }), [show]);
+
+  return <CoursewareSearchContext.Provider value={value}>{children}</CoursewareSearchContext.Provider>;
+};
+
+export const useCoursewareSearch = (): CoursewareSearchContextValue => {
+  const context = useContext(CoursewareSearchContext);
+  if (!context) {
+    throw new Error('useCoursewareSearch must be used within a CoursewareSearchProvider');
+  }
+  return context;
+};

--- a/src/course-home/courseware-search/CoursewareSearchToggle.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchToggle.jsx
@@ -2,23 +2,18 @@ import React, { useEffect } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 import { ManageSearch } from '@openedx/paragon/icons';
-import { useDispatch } from 'react-redux';
 import messages from './messages';
 import { useCoursewareSearchFeatureFlag, useCoursewareSearchParams } from './hooks';
-import { setShowSearch } from '../data/slice';
+import { useCoursewareSearch } from './CoursewareSearchContext';
 
 const CoursewareSearchToggle = () => {
   const intl = useIntl();
-  const dispatch = useDispatch();
+  const { open } = useCoursewareSearch();
   const enabled = useCoursewareSearchFeatureFlag();
   const { query } = useCoursewareSearchParams();
 
-  const handleSearchOpenClick = () => {
-    dispatch(setShowSearch(true));
-  };
-
   useEffect(() => {
-    if (enabled && !!query) { handleSearchOpenClick(); }
+    if (enabled && !!query) { open(); }
   }, [enabled]);
 
   if (!enabled) { return null; }
@@ -30,7 +25,7 @@ const CoursewareSearchToggle = () => {
         size="sm"
         className="p-1 mt-2 mr-2"
         aria-label={intl.formatMessage(messages.searchOpenAction)}
-        onClick={handleSearchOpenClick}
+        onClick={open}
         data-testid="courseware-search-open-button"
         iconAfter={ManageSearch}
       >

--- a/src/course-home/courseware-search/CoursewareSearchToggle.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchToggle.test.jsx
@@ -7,24 +7,19 @@ import {
   screen,
   waitFor,
 } from '../../setupTest';
-import { fetchCoursewareSearchSettings } from '../data/thunks';
-import { setShowSearch } from '../data/slice';
 import { CoursewareSearchToggle } from './index';
+import { useCoursewareSearchFeatureFlag } from './hooks';
+import { useCoursewareSearch } from './CoursewareSearchContext';
 
-const mockDispatch = jest.fn();
+const mockOpen = jest.fn();
 const mockCoursewareSearchParams = jest.fn();
 
-jest.mock('../data/thunks');
-jest.mock('../data/slice');
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: () => mockDispatch,
-}));
+jest.mock('./CoursewareSearchContext');
 
 jest.mock('./hooks', () => ({
   ...jest.requireActual('./hooks'),
   useCoursewareSearchParams: () => mockCoursewareSearchParams,
+  useCoursewareSearchFeatureFlag: jest.fn(),
 }));
 
 const coursewareSearch = {
@@ -49,43 +44,45 @@ describe('CoursewareSearchToggle', () => {
     initializeMockApp();
   });
 
+  beforeEach(() => {
+    useCoursewareSearch.mockReturnValue({ show: false, open: mockOpen, close: jest.fn() });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('Should not render when the waffle flag is disabled', async () => {
-    fetchCoursewareSearchSettings.mockImplementation(() => Promise.resolve({ enabled: false }));
+    useCoursewareSearchFeatureFlag.mockReturnValue(false);
     mockSearchParams();
 
     await act(async () => renderComponent());
     await waitFor(() => {
-      expect(fetchCoursewareSearchSettings).toHaveBeenCalledTimes(1);
+      expect(useCoursewareSearchFeatureFlag).toHaveBeenCalled();
       expect(screen.queryByTestId('courseware-search-open-button')).not.toBeInTheDocument();
     });
   });
 
   it('Should render when the waffle flag is enabled', async () => {
-    fetchCoursewareSearchSettings.mockImplementation(() => Promise.resolve({ enabled: true }));
+    useCoursewareSearchFeatureFlag.mockReturnValue(true);
     mockSearchParams();
 
     await act(async () => renderComponent());
 
     await waitFor(() => {
-      expect(fetchCoursewareSearchSettings).toHaveBeenCalledTimes(1);
+      expect(useCoursewareSearchFeatureFlag).toHaveBeenCalled();
       expect(screen.queryByTestId('courseware-search-open-button')).toBeInTheDocument();
     });
   });
 
-  it('Should dispatch setShowSearch(true) when clicking the search button', async () => {
-    fetchCoursewareSearchSettings.mockImplementation(() => Promise.resolve({ enabled: true }));
+  it('Should open search when clicking the search button', async () => {
+    useCoursewareSearchFeatureFlag.mockReturnValue(true);
     mockSearchParams();
 
     await act(async () => renderComponent());
     const button = await screen.findByTestId('courseware-search-open-button');
     fireEvent.click(button);
 
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
-    expect(setShowSearch).toHaveBeenCalledTimes(1);
-    expect(setShowSearch).toHaveBeenCalledWith(true);
+    expect(mockOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/course-home/courseware-search/data/apiHooks.test.tsx
+++ b/src/course-home/courseware-search/data/apiHooks.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { getCoursewareSearchEnabled, searchCourseContentFromAPI } from '../../data/api';
+import mapSearchResponse from '../map-search-response';
+import { useCoursewareSearchEnabled, useCoursewareSearchResults } from './apiHooks';
+
+jest.mock('../../data/api');
+jest.mock('../map-search-response');
+
+const buildWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+describe('courseware-search apiHooks', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('useCoursewareSearchEnabled', () => {
+    it('fetches the feature flag for the course', async () => {
+      (getCoursewareSearchEnabled as jest.Mock).mockResolvedValue({ enabled: true });
+      const { wrapper } = buildWrapper();
+
+      const { result } = renderHook(() => useCoursewareSearchEnabled('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(getCoursewareSearchEnabled).toHaveBeenCalledWith('course-1');
+      expect(result.current.data).toEqual({ enabled: true });
+    });
+  });
+
+  describe('useCoursewareSearchResults', () => {
+    it('does not fetch when there is no keyword', () => {
+      const { wrapper } = buildWrapper();
+
+      renderHook(() => useCoursewareSearchResults('course-1', ''), { wrapper });
+
+      expect(searchCourseContentFromAPI).not.toHaveBeenCalled();
+    });
+
+    it('fetches and maps the results when there is a keyword', async () => {
+      const response = { results: [{ id: '1' }] };
+      (searchCourseContentFromAPI as jest.Mock).mockResolvedValue({ data: response });
+      (mapSearchResponse as jest.Mock).mockReturnValue({ results: [{ id: '1' }], total: 1 });
+      const { wrapper } = buildWrapper();
+
+      const { result } = renderHook(() => useCoursewareSearchResults('course-1', 'test'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(searchCourseContentFromAPI).toHaveBeenCalledWith('course-1', 'test');
+      expect(mapSearchResponse).toHaveBeenCalledWith(response, 'test');
+      expect(result.current.data).toEqual({ results: [{ id: '1' }], total: 1 });
+    });
+  });
+});

--- a/src/course-home/courseware-search/data/apiHooks.ts
+++ b/src/course-home/courseware-search/data/apiHooks.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCoursewareSearchEnabled, searchCourseContentFromAPI } from '../../data/api';
+import mapSearchResponse from '../map-search-response';
+import { coursewareSearchQueryKeys } from './queryKeys';
+
+export const useCoursewareSearchEnabled = (courseId: string) => useQuery({
+  queryKey: coursewareSearchQueryKeys.enabled(courseId),
+  queryFn: () => getCoursewareSearchEnabled(courseId),
+  retry: false,
+});
+
+export const useCoursewareSearchResults = (courseId: string, keyword: string) => useQuery({
+  queryKey: coursewareSearchQueryKeys.results(courseId, keyword),
+  queryFn: async () => {
+    const { data } = await searchCourseContentFromAPI(courseId, keyword);
+    return mapSearchResponse(data, keyword);
+  },
+  enabled: !!keyword,
+});

--- a/src/course-home/courseware-search/data/queryKeys.ts
+++ b/src/course-home/courseware-search/data/queryKeys.ts
@@ -1,0 +1,7 @@
+import { appId } from '@src/constants';
+
+export const coursewareSearchQueryKeys = {
+  all: [appId, 'coursewareSearch'] as const,
+  enabled: (courseId: string) => [...coursewareSearchQueryKeys.all, 'enabled', courseId] as const,
+  results: (courseId: string, keyword: string) => [...coursewareSearchQueryKeys.all, 'results', courseId, keyword] as const,
+};

--- a/src/course-home/courseware-search/hooks.js
+++ b/src/course-home/courseware-search/hooks.js
@@ -1,27 +1,13 @@
-import { useState, useEffect, useLayoutEffect } from 'react';
+import { useState, useLayoutEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 import { debounce } from 'lodash';
-import { fetchCoursewareSearchSettings } from '../data/thunks';
+import { useCoursewareSearchEnabled } from './data/apiHooks';
 
 const DEBOUNCE_WAIT = 100; // ms
 
 export function useCoursewareSearchFeatureFlag() {
   const { courseId } = useParams();
-  const [enabled, setEnabled] = useState(false);
-
-  useEffect(() => {
-    fetchCoursewareSearchSettings(courseId).then(response => setEnabled(response.enabled));
-  }, [courseId]);
-
-  return enabled;
-}
-
-export function useCoursewareSearchState() {
-  const enabled = useCoursewareSearchFeatureFlag();
-  const show = useSelector(state => state.courseHome.showSearch);
-
-  return { show: enabled && show };
+  return useCoursewareSearchEnabled(courseId).data?.enabled ?? false;
 }
 
 export function useElementBoundingBox(elementId) {

--- a/src/course-home/courseware-search/hooks.test.jsx
+++ b/src/course-home/courseware-search/hooks.test.jsx
@@ -1,18 +1,15 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useParams, useSearchParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { fetchCoursewareSearchSettings } from '../data/thunks';
 import {
   useCoursewareSearchFeatureFlag,
   useCoursewareSearchParams,
-  useCoursewareSearchState,
   useElementBoundingBox,
   useLockScroll,
 } from './hooks';
+import { useCoursewareSearchEnabled } from './data/apiHooks';
 
-jest.mock('react-redux');
 jest.mock('react-router-dom');
-jest.mock('../data/thunks');
+jest.mock('./data/apiHooks');
 
 describe('CoursewareSearch Hooks', () => {
   const courses = {
@@ -21,7 +18,7 @@ describe('CoursewareSearch Hooks', () => {
   };
 
   beforeEach(() => {
-    fetchCoursewareSearchSettings.mockImplementation((courseId) => Promise.resolve(courses[courseId]));
+    useCoursewareSearchEnabled.mockImplementation((courseId) => ({ data: courses[courseId] }));
   });
 
   afterEach(() => {
@@ -38,45 +35,14 @@ describe('CoursewareSearch Hooks', () => {
 
     it('should return true if feature is enabled', async () => {
       const hook = await renderTestHook();
-      await waitFor(() => expect(fetchCoursewareSearchSettings).toBeCalledTimes(1));
+      await waitFor(() => expect(useCoursewareSearchEnabled).toBeCalledTimes(1));
       expect(hook.result.current).toBe(true);
     });
 
     it('should return false if feature is disabled', async () => {
       const hook = await renderTestHook(false);
-      await waitFor(() => expect(fetchCoursewareSearchSettings).toBeCalledTimes(1));
+      await waitFor(() => expect(useCoursewareSearchEnabled).toBeCalledTimes(1));
       expect(hook.result.current).toBe(false);
-    });
-  });
-
-  describe('useCoursewareSearchState', () => {
-    const renderTestHook = async ({ enabled, showSearch }) => {
-      useParams.mockImplementation(() => ({ courseId: enabled ? 123 : 456 }));
-      const mockedStoreState = { courseHome: { showSearch } };
-      useSelector.mockImplementation(selector => selector(mockedStoreState));
-
-      let hook;
-      await act(async () => { (hook = renderHook(() => useCoursewareSearchState())); });
-      return hook;
-    };
-
-    it('should return show: true if feature is enabled and showSearch is true', async () => {
-      const hook = await renderTestHook({ enabled: true, showSearch: true });
-
-      expect(hook.result.current).toEqual({ show: true });
-    });
-
-    it('should return show: false in any other case', async () => {
-      let hook;
-
-      hook = await renderTestHook({ enabled: true, showSearch: false });
-      expect(hook.result.current).toEqual({ show: false });
-
-      hook = await renderTestHook({ enabled: false, showSearch: true });
-      expect(hook.result.current).toEqual({ show: false });
-
-      hook = await renderTestHook({ enabled: false, showSearch: false });
-      expect(hook.result.current).toEqual({ show: false });
     });
   });
 

--- a/src/course-home/courseware-search/index.js
+++ b/src/course-home/courseware-search/index.js
@@ -1,3 +1,4 @@
 /* eslint-disable import/prefer-default-export */
 export { default as CoursewareSearchToggle } from './CoursewareSearchToggle';
 export { default as CoursewareSearch } from './CoursewareSearch';
+export { CoursewareSearchProvider, useCoursewareSearch } from './CoursewareSearchContext';

--- a/src/course-home/data/redux.test.js
+++ b/src/course-home/data/redux.test.js
@@ -268,38 +268,6 @@ describe('Data layer integration tests', () => {
     });
   });
 
-  describe('Test fetchCoursewareSearchSettings', () => {
-    it('Should return enabled as true when enabled', async () => {
-      const apiUrl = `${getConfig().LMS_BASE_URL}/courses/${courseId}/courseware-search/enabled/`;
-      axiosMock.onGet(apiUrl).reply(200, { enabled: true });
-
-      const { enabled } = await thunks.fetchCoursewareSearchSettings(courseId);
-
-      expect(axiosMock.history.get[0].url).toEqual(apiUrl);
-      expect(enabled).toBe(true);
-    });
-
-    it('Should return enabled as false when disabled', async () => {
-      const apiUrl = `${getConfig().LMS_BASE_URL}/courses/${courseId}/courseware-search/enabled/`;
-      axiosMock.onGet(apiUrl).reply(200, { enabled: false });
-
-      const { enabled } = await thunks.fetchCoursewareSearchSettings(courseId);
-
-      expect(axiosMock.history.get[0].url).toEqual(apiUrl);
-      expect(enabled).toBe(false);
-    });
-
-    it('Should return enabled as false on error', async () => {
-      const apiUrl = `${getConfig().LMS_BASE_URL}/courses/${courseId}/courseware-search/enabled/`;
-      axiosMock.onGet(apiUrl).networkError();
-
-      const { enabled } = await thunks.fetchCoursewareSearchSettings(courseId);
-
-      expect(axiosMock.history.get[0].url).toEqual(apiUrl);
-      expect(enabled).toBe(false);
-    });
-  });
-
   describe('Test fetchExamAttemptsData', () => {
     const sequenceIds = [
       'block-v1:edX+DemoX+Demo_Course+type@sequential+block@12345',

--- a/src/course-home/data/slice.js
+++ b/src/course-home/data/slice.js
@@ -17,7 +17,6 @@ const slice = createSlice({
     toastBodyText: null,
     toastBodyLink: null,
     toastHeader: '',
-    showSearch: false,
     examsData: null,
     errorMessage: null,
     errorCode: null,
@@ -57,9 +56,6 @@ const slice = createSlice({
       state.toastBodyText = linkText;
       state.toastHeader = header;
     },
-    setShowSearch: (state, { payload }) => {
-      state.showSearch = payload;
-    },
     setExamsData: (state, { payload }) => {
       state.examsData = payload;
     },
@@ -73,7 +69,6 @@ export const {
   fetchTabRequest,
   fetchTabSuccess,
   setCallToActionToast,
-  setShowSearch,
   setExamsData,
 } = slice.actions;
 

--- a/src/course-home/data/slice.test.js
+++ b/src/course-home/data/slice.test.js
@@ -12,7 +12,6 @@ describe('course home data slice', () => {
         toastBodyText: '',
         toastBodyLink: null,
         toastHeader: '',
-        showSearch: false,
         examsData: null,
       };
 
@@ -51,7 +50,6 @@ describe('course home data slice', () => {
         toastBodyText: '',
         toastBodyLink: null,
         toastHeader: '',
-        showSearch: false,
         examsData: [{ id: 1, examName: 'Old Exam' }],
       };
 
@@ -81,7 +79,6 @@ describe('course home data slice', () => {
         toastBodyText: '',
         toastBodyLink: null,
         toastHeader: '',
-        showSearch: false,
         examsData: [{ id: 1, examName: 'Some Exam' }],
       };
 
@@ -101,7 +98,6 @@ describe('course home data slice', () => {
         toastBodyText: '',
         toastBodyLink: null,
         toastHeader: '',
-        showSearch: false,
         examsData: [{ id: 1, examName: 'Some Exam' }],
       };
 
@@ -121,7 +117,6 @@ describe('course home data slice', () => {
         toastBodyText: 'Toast message',
         toastBodyLink: 'http://example.com',
         toastHeader: 'Toast Header',
-        showSearch: true,
         examsData: null,
       };
 
@@ -138,7 +133,6 @@ describe('course home data slice', () => {
       // Verify other properties remain unchanged
       expect(newState.courseStatus).toBe(initialState.courseStatus);
       expect(newState.courseId).toBe(initialState.courseId);
-      expect(newState.showSearch).toBe(initialState.showSearch);
       expect(newState.toastBodyText).toBe(initialState.toastBodyText);
     });
   });

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -13,12 +13,10 @@ import {
   postDismissWelcomeMessage,
   postRequestCert,
   getLiveTabIframe,
-  getCoursewareSearchEnabled,
-  searchCourseContentFromAPI,
 } from './api';
 
 import {
-  addModel, updateModel,
+  addModel,
 } from '../../generic/model-store';
 
 import {
@@ -29,8 +27,6 @@ import {
   setCallToActionToast,
   setExamsData,
 } from './slice';
-
-import mapSearchResponse from '../courseware-search/map-search-response';
 
 const eventTypes = {
   POST_EVENT: 'post_event',
@@ -163,73 +159,6 @@ export function processEvent(eventData, getTabData) {
         dispatch(setCallToActionToast({ header, link, linkText }));
       });
     }
-  };
-}
-
-export async function fetchCoursewareSearchSettings(courseId) {
-  try {
-    const { enabled } = await getCoursewareSearchEnabled(courseId);
-    return { enabled };
-  } catch (e) {
-    return { enabled: false };
-  }
-}
-
-export function searchCourseContent(courseId, searchKeyword) {
-  return async (dispatch) => {
-    const start = new Date();
-
-    dispatch(addModel({
-      modelType: 'contentSearchResults',
-      model: {
-        id: courseId,
-        searchKeyword,
-        results: [],
-        errors: undefined,
-        loading: true,
-      },
-    }));
-
-    let data;
-    let curatedResponse;
-    let errors;
-    try {
-      ({ data } = await searchCourseContentFromAPI(courseId, searchKeyword));
-      curatedResponse = mapSearchResponse(data, searchKeyword);
-    } catch (e) {
-      // TODO: Remove when publishing to prod. Just temporary for performance debugging.
-      // eslint-disable-next-line no-console
-      console.error('Error on Courseware Search: ', e.message);
-      errors = e.message;
-    }
-
-    dispatch(updateModel({
-      modelType: 'contentSearchResults',
-      model: {
-        ...curatedResponse,
-        id: courseId,
-        searchKeyword,
-        errors,
-        loading: false,
-      },
-    }));
-
-    const end = new Date();
-    const clientMs = (end - start);
-    const {
-      took, total, maxScore, accessDeniedCount,
-    } = data;
-
-    // TODO: Remove when publishing to prod. Just temporary for performance debugging.
-    // eslint-disable-next-line no-console
-    console.table({
-      'Search Keyword': searchKeyword,
-      'Client time (ms)': clientMs,
-      'Server time (ms)': took,
-      'Total matches': total,
-      'Max score': maxScore,
-      'Access denied count': accessDeniedCount,
-    });
   };
 }
 

--- a/src/course-tabs/CourseTabsNavigation.test.jsx
+++ b/src/course-tabs/CourseTabsNavigation.test.jsx
@@ -3,11 +3,13 @@ import { AppProvider } from '@edx/frontend-platform/react';
 import {
   initializeMockApp, render, screen,
 } from '../setupTest';
-import { useCoursewareSearchState, useCoursewareSearchParams } from '../course-home/courseware-search/hooks';
+import { useCoursewareSearchFeatureFlag, useCoursewareSearchParams } from '../course-home/courseware-search/hooks';
+import { useCoursewareSearch } from '../course-home/courseware-search/CoursewareSearchContext';
 import { CourseTabsNavigation } from './index';
 import initializeStore from '../store';
 
 jest.mock('../course-home/courseware-search/hooks');
+jest.mock('../course-home/courseware-search/CoursewareSearchContext');
 
 const mockDispatch = jest.fn();
 const coursewareSearch = {
@@ -39,7 +41,8 @@ describe('Course Tabs Navigation', () => {
   });
 
   beforeEach(() => {
-    useCoursewareSearchState.mockImplementation(() => ({ show: false }));
+    useCoursewareSearch.mockReturnValue({ show: false, open: jest.fn(), close: jest.fn() });
+    useCoursewareSearchFeatureFlag.mockReturnValue(true);
     useCoursewareSearchParams.mockReturnValue(coursewareSearch);
   });
 
@@ -71,13 +74,15 @@ describe('Course Tabs Navigation', () => {
   });
 
   it('should NOT render CoursewareSearch if the flag is off', () => {
+    useCoursewareSearch.mockReturnValue({ show: true, open: jest.fn(), close: jest.fn() });
+    useCoursewareSearchFeatureFlag.mockReturnValue(false);
     renderComponent();
 
     expect(screen.queryByTestId('courseware-search-dialog')).not.toBeInTheDocument();
   });
 
   it('should render CoursewareSearch if the flag is on', () => {
-    useCoursewareSearchState.mockImplementation(() => ({ show: true }));
+    useCoursewareSearch.mockReturnValue({ show: true, open: jest.fn(), close: jest.fn() });
     renderComponent();
 
     expect(screen.queryByTestId('courseware-search-dialog')).toBeInTheDocument();

--- a/src/course-tabs/CourseTabsNavigation.tsx
+++ b/src/course-tabs/CourseTabsNavigation.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { CoursewareSearch, CoursewareSearchToggle } from '@src/course-home/courseware-search';
-import { useCoursewareSearchState } from '@src/course-home/courseware-search/hooks';
 import { CourseTabLinksSlot } from '@src/plugin-slots/CourseTabLinksSlot';
 import Tabs from '@src/generic/tabs/Tabs';
 import messages from './messages';
@@ -21,7 +20,6 @@ const CourseTabsNavigation = ({
   tabs,
 }:CourseTabsNavigationProps) => {
   const intl = useIntl();
-  const { show } = useCoursewareSearchState();
 
   return (
     <div id="courseTabsNavigation" className="mb-3 course-tabs-navigation">
@@ -40,7 +38,7 @@ const CourseTabsNavigation = ({
           </div>
         </div>
       </div>
-      {show && <CoursewareSearch />}
+      <CoursewareSearch />
     </div>
   );
 };

--- a/src/plugin-slots/CourseTabsNavigationSlot/index.tsx
+++ b/src/plugin-slots/CourseTabsNavigationSlot/index.tsx
@@ -1,8 +1,11 @@
 import { CourseTabsNavigation, type CourseTabsNavigationProps } from '@src/course-tabs';
+import { CoursewareSearchProvider } from '@src/course-home/courseware-search';
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
 export const CourseTabsNavigationSlot = ({ tabs, activeTabSlug }: CourseTabsNavigationProps) => (
-  <PluginSlot id="org.openedx.frontend.learning.course_tabs_navigation.v1">
-    <CourseTabsNavigation tabs={tabs} activeTabSlug={activeTabSlug} />
-  </PluginSlot>
+  <CoursewareSearchProvider>
+    <PluginSlot id="org.openedx.frontend.learning.course_tabs_navigation.v1">
+      <CourseTabsNavigation tabs={tabs} activeTabSlug={activeTabSlug} />
+    </PluginSlot>
+  </CoursewareSearchProvider>
 );


### PR DESCRIPTION
## Summary

Converts the **courseware search** feature from Redux to React Query, per [OEP-0067 ADR-0010](https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0067/decisions/frontend/0010-react-query.html). Part of the Redux → React Query migration (#1946), **stacked on the product-tours conversion** (the branch below).

Behavior is preserved — same open/close, spinner-per-search, results and "Results for …" summary, client-side type-filter tabs, deep-link auto-open, and close/backspace clear. Verified with the full test suite **and** a live manual smoke pass.

## What changed

- **React Query data layer:** `courseware-search/data/queryKeys.ts` (rooted at appId, keyed by the URL keyword) + `data/apiHooks.ts` — `useCoursewareSearchResults` (a `useQuery` keyed off `?q=`, `enabled` when there's a keyword) and `useCoursewareSearchEnabled` (the feature-flag check, `retry: false` to match the original one-shot fail-to-false).
- **Client state → context:** `CoursewareSearchContext` (`show`/`open`/`close`) replaces the `showSearch` slice member. The provider wraps the **`PluginSlot`** in `CourseTabsNavigationSlot`, so a plugin in that slot can still hook into search via the exported `useCoursewareSearch()` — Redux made `showSearch` globally reachable, and this preserves that capability rather than burying it in local state.
- **Consumers:** `CoursewareSearch` (panel) and `CoursewareResultsFilter` read results from the query (`isLoading`/`isError`/`data`) instead of the `contentSearchResults` model; the type-filter tabs stay **client-side** (the API returns a flat list, so switching tabs doesn't refetch); `CoursewareSearchToggle` / `CourseTabsNavigation` use the context.
- **Redux removed:** the `searchCourseContent` + `fetchCoursewareSearchSettings` thunks, the `setShowSearch`/`showSearch` members of the course-home slice, and the `contentSearchResults` model write.
- **Opportunistic fix:** corrected a rules-of-hooks ordering in `CoursewareResultsFilter` (two `useMemo`s were running after early returns).
- **Search-on-type readiness:** architected — following `frontend-app-catalog`'s search — so switching to search-on-type later is an input-handler-only change (debounce + `keepPreviousData`), with no rework of the query, query key, or client state. See the decision log.

## Testing

**Automated:** `npm run types`, `npm run lint`, `npm run build`, and the full `npm test` suite pass.

**Manual smoke (dev, with the `courseware.mfe_courseware_search` flag on):** toggle open (scroll-lock, no URL change) → submit → spinner → results + "Results for …" summary → filter tabs drive `?f=` → `?q=` set on submit → close/backspace clear → deep-link auto-opens and runs the search on the right tab → a second search blanks + re-spins (matches the on-submit baseline). No search-related console errors.

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — Redux → React Query: courseware search

Working notes for this PR (part of the wider Redux → React Query migration,
#1946). **Not checked in** — referenced when opening the PR. Stacked on the
product-tours conversion (#1968).

## Scope

Convert the `courseware-search` feature off Redux:
- **`searchCourseContent` thunk** (writes the `contentSearchResults` model) → a
  React Query query keyed by the URL search keyword.
- **`setShowSearch` action + `showSearch` state** (client UI flag) → a
  `CoursewareSearchProvider` React context (see *Client state* below).
- **`fetchCoursewareSearchSettings`** (already a plain async fn, not Redux) → a
  `useQuery` for the feature flag (dedupe/caching; improvement, not Redux removal).

Removes the thunk, the `setShowSearch`/`showSearch` slice members, and one
`models` write (`contentSearchResults`). The courseHome slice stays (tab
machinery).

## Architecture: search-on-type readiness (from frontend-app-catalog)

We convert **on-submit** now (faithful to current behavior), but architect so
adopting **search-on-type** later is an input-handler-only change — no rework of
the React Query hook, query key, or client state. Basis: `frontend-app-catalog`'s
search, which landed search-on-type *starting from* an on-submit design without
touching its query layer ([catalog PR #42], tracker [#48], polish [#76]). The
load-bearing lesson from that thread: *"only searching using `onSubmit` is hiding
issues"* — on-submit masks the state bugs (cyclic re-renders, flicker, stale
results) that on-type exposes, so build the query/state layer right up front.

**Query hook** — `useCoursewareSearchResults(courseId, keyword)`:
- `queryKey: [appId, courseId, 'search', keyword]` — the term is in the key.
  The `?f=` type filter stays **client-side** on the results (as today,
  `CoursewareResultsFilter`), so it is **not** in the key (unlike catalog, which
  keyed filters into the query).
- **`placeholderData: keepPreviousData` — deliberately NOT added now** (deferred to
  the search-on-type work). Tested the current behavior: a second search (with the
  panel open) **blanks the results and shows the spinner** each time. That's the
  *correct* feedback for search-on-**click** (a click should visibly start a fresh
  search), and only becomes wrong for search-on-**type** (where you want the
  previous results to stay put between keystrokes). Since this PR stays on-click, we
  **keep the faithful blank+spinner behavior** — spinner driven off `isPending`
  (default), no `placeholderData`.
  - **On-type follow-up:** add `placeholderData: keepPreviousData` **and** drive the
    spinner off `isFetching` (not `isPending`) so previous results persist while the
    next keystroke's fetch runs (also gives out-of-order-response protection without
    an `AbortSignal`). This is a small, localized query-hook + spinner change — it
    does **not** touch the query key, the term/URL flow, or the client state, so the
    on-type-readiness goal holds. (Note: the v5 form is the imported helper
    `placeholderData: keepPreviousData`; the `keepPreviousData: true` *boolean
    option* was removed in v5, but the helper import remains — catalog's
    `(prev) => prev` is the exact inline equivalent.)
- **`enabled: !!keyword`** — courseware search is **idle-when-empty** (shows
  nothing until you search), unlike catalog's browse-all-when-empty (no `enabled`).
  Orthogonal to on-type. **No** min-length gating (catalog deliberately didn't).

**Loading status uses `isLoading` (= `isPending && isFetching`), not `isFetching`
or `isPending` alone.** In v5 the disabled (no-keyword) query is `isPending: true`
with `fetchStatus: 'idle'`, so `isPending` alone would show a spinner at the idle
state; `isFetching` alone would flash the spinner on a background focus-refetch
(data present). `isLoading` is true only while fetching with no data to show —
which reproduces the baseline exactly (spinner on each fresh/new-keyword search,
nothing at idle) and degrades gracefully if a background refetch ever runs. It also
means we don't need `refetchOnWindowFocus: false` here (unlike the tours query): a
focus refetch is invisible because `isLoading` stays false while data is present.

**Feature-flag query** — `useCoursewareSearchEnabled(courseId)` uses **`retry: false`**
(consumer reads `data?.enabled ?? false`). This matches the original
`fetchCoursewareSearchSettings`, which wrapped `getCoursewareSearchEnabled` in a
`try/catch` and returned `{ enabled: false }` one-shot: fail fast to "not enabled"
rather than retrying a "should I show this button" probe. The results query keeps
the bare-client default retry.

**Term flow / choke point** — the keyword stays in the URL (`?q=`, via
`useCoursewareSearchParams`); `handleSubmit → setQuery` is the single choke point.
Adopting on-type later = debounce the input's `onChange → setQuery` in a **separate
input hook**, with `setSearchParams(..., { replace: true })` (avoid history spam)
and a **`lastQueryRef`** guard on the debounced dispatch — *not* the live term — to
avoid the cyclic re-fire catalog hit, and don't fully control the input `value`
while debouncing (their "repeating" bug). None of that touches the query hook or
the `showSearch` state.

[catalog PR #42]: https://github.com/openedx/frontend-app-catalog/pull/42
[#48]: https://github.com/openedx/frontend-app-catalog/issues/48
[#76]: https://github.com/openedx/frontend-app-catalog/pull/76

## Client state (`showSearch`) → context, not local state

`showSearch` becomes a **`CoursewareSearchProvider`** context (`show` + `open()` +
`close()`), exported from the feature alongside a `useCoursewareSearch()` hook.

**Why context and not lifted local state** (the first instinct — `CourseTabsNavigation`
is the single common parent of the toggle + panel). Redux's `showSearch` was
*globally* readable, so a plugin dropped into `CourseTabsNavigationSlot` could hook
into search today via `useSelector`/`dispatch`. That's not an official API (no
`pluginProp`), so breaking a plugin's old Redux code is acceptable — but making it
*impossible* to interact with search would be a needless capability regression.
Local state (or a context buried inside the default `CourseTabsNavigation`) would
do exactly that: a plugin that **wraps or replaces** the nav via the slot renders
*outside* it and couldn't reach the state. Context also keeps the state with the
search feature (not the nav component) and drops prop-drilling — consistent with
the tours conversion and OEP-0067.

**Placement:** the provider wraps the **`PluginSlot`** inside `CourseTabsNavigationSlot`,
so everything the slot renders — the default nav, the toggle, the panel, *and* any
plugin — is inside it and can call the exported `useCoursewareSearch()`. It has to
sit above the `PluginSlot` (not inside `CourseTabsNavigation`) precisely so
slot plugins keep access. The panel stays conditionally mounted
(`{show && <CoursewareSearch />}`) so its `showModal()`/scroll-lock mount effects
still fire on open; `CourseTabsNavigation` reads `show` for that gate, the toggle
reads `open`, the panel reads `close`.

**Lifecycle:** the provider is per-tab, so `show` resets on tab navigation — but
this is **unobservable**, because search can't be open across a tab change: the
panel is a modal (`dialog.showModal()`) that inerts the background (the tab bar
isn't clickable while it's open), closing via the X clears the query string, and
`popstate` is wired to close it. So per-tab scope is fine; Redux's global
persistence of `showSearch` had no reachable effect here.

**Follow-up option:** if we later want a first-class API rather than "import our
hook," expose search controls as a `pluginProp` on the slot. Not needed now.

## Results filtering stays client-side

The `/search/{courseId}` endpoint returns a **flat array of all results** — it takes
no filter param. `CoursewareResultsFilter` partitions that array **client-side** (a
`useMemo` reducer) by each result's `type` into buckets (`all` + `text` / `video` /
`sequence` / `other`), renders one Paragon `<Tab>` per non-empty bucket, and the
`?f=` param just selects which already-computed bucket to show. Switching filters
does **not** refetch. (It also skips the tabs when there'd be < 3, i.e. "all" plus
a single identical bucket.)

- **In RQ, the grouping logic stays put** in `CoursewareResultsFilter`; only the
  **source** of the flat array changes: `useModel('contentSearchResults', courseId)`
  → `data.results` from `useCoursewareSearchResults(courseId, keyword)`. The `?f=`
  tab selection is untouched.
- **The `?f=` filter is deliberately NOT in the query key** — switching tabs must
  not refetch (matches today). This is the key contrast with catalog, which put
  filters *in* the query because its API filtered server-side.
- **Opportunistic fix (rules of hooks):** today `CoursewareResultsFilter` calls its
  `useMemo`s *after* two early returns (`if (!lastSearch) return null`,
  `if (!data.length) return …`) — a conditional-hooks violation that happens to
  work. While rewiring this file, hoist the early returns **below** the hooks so
  the hooks always run.

## Results-summary label keyword: use the URL term, drop `lastSearchKeyword`

The results summary reads `Results for "<keyword>":`. The original sourced that
keyword from the **model** (`contentSearchResults.searchKeyword`, aliased
`lastSearchKeyword`) — the keyword the *displayed results* are for — separate from
`searchKeyword` (the current URL/`?q=` term). The RQ port uses **`searchKeyword`
(the URL term)** and drops `lastSearchKeyword`.

**Why that's correct, not a regression:**
- **In the on-submit flow the two always coincide when the summary is visible.**
  The URL only changes on submit (`setQuery`, same handler that starts the fetch);
  while fetching, `status === 'loading'` hides the summary; when results arrive the
  model's keyword equals the submitted value equals the URL. So `lastSearchKeyword`
  was redundant here — the original read from the model only because results +
  keyword were stored together, not to guard a differ-case. (The existing test's
  `model='fubar'` / URL=`''` split is an artificial mock, not a real state.)
- **frontend-app-catalog does exactly this** — its "Search results for {query}"
  heading uses the live input/URL `searchString`, *not* the term the data is for,
  and it does **not** guard the `keepPreviousData` mismatch window (heading shows
  the new term while the list still shows the previous term mid-fetch). Catalog
  PR #42 even **removed** a dedicated "last search query" heading state in favor of
  the live term. So using the URL term matches the reference even under
  search-on-type.

**Consequences:** no need to echo the keyword back in the query data (an earlier
idea, dropped); and **no on-type follow-up** for the label — the URL term is the
intended behavior for on-type too. If we ever wanted the label to always match the
on-screen rows under `keepPreviousData` (stricter than catalog), we'd derive it
from the query data instead — but that's a deliberate deviation we're not making.

## Tests & coverage

- **`CoursewareSearchContext.test.tsx`** — provider/hook unit tests (initial `show`,
  `open`/`close`, the throw-outside-provider). These were the biggest patch gap
  since every consumer test mocks the context.
- **`data/apiHooks.test.tsx`** — `useCoursewareSearchEnabled` and
  `useCoursewareSearchResults` (fetch + `mapSearchResponse`, and the `enabled` gate
  that skips fetching with no keyword); also exercises `queryKeys`.
- Consumer tests (`CoursewareSearch`, `CoursewareResultsFilter`, `CoursewareSearchToggle`,
  `CourseTabsNavigation`, `hooks`) were updated to mock the query + context instead
  of the model/thunk/slice.
- **Deliberately did NOT add a `CourseTabsNavigationSlot` test.** The only way to
  cover the slot's provider wrapper is to assert its *default content is
  `CourseTabsNavigation`* — which over-commits a test to a default the Slot API
  intentionally leaves replaceable. So the few provider-wrapper lines there stay
  uncovered on purpose rather than baking in that assumption.

## Current behavior (baseline — from live manual testing on master)

Feature gated by the `courseware.mfe_courseware_search` CourseWaffleFlag
(`COURSEWARE_MICROFRONTEND_SEARCH_ENABLED`); the `/courseware-search/enabled/`
endpoint just checks that flag, which is what makes the "Content search" toggle
appear in the course tab bar.

- **Open:** the dialog covers everything below the header/masquerade bar (anchored
  under `courseTabsNavigation`), showing the "Search this course" idle state (title
  + search box + button). Opening does **not** change the URL. Background scroll is
  locked while open (`useLockScroll`).
- **Typing vs submitting:** typing in the box does **not** change the URL; only
  **submitting** (the search button) sets `?q=<term>`. (`onChange` only clears on
  empty; `handleSubmit` calls `setQuery`.) → this is why keying the query off the
  URL keyword is faithful: it re-runs on submit, not per keystroke.

- **Submitting a search:** shows a spinner while loading, then results. Above the
  results, a summary line reads **`Results for "<keyword>":`** — there is **no
  numeric count** (the `searchResultsLabel` message only uses `{keyword}`; `total`
  is passed but unused, and only gates whether the summary renders, via
  `total > 0`). Results have filter tabs — **all content / text / other** — backed
  by the `?f=` URL param (`CoursewareResultsFilter`): text → `f=text`,
  other → `f=other`. Each **result row** is a content-type icon (a "T" for text vs
  a document icon for other) + the unit **title with a per-result match-count
  badge** (e.g. "Code Grading 3") + a **breadcrumb path** to the unit. (Confirmed
  against a live screenshot.)
- **Closing / clearing:** the X clears `?q=`/`?f=` and the results; reopening
  starts fresh. **Backspacing the box to empty also clears** the query param and
  results immediately — no submit needed (`handleOnChange`: `if (!value)
  clearSearch()`). Feels odd but **preserved** as-is.
- **Deep link:** loading a course URL that already has `?q=<term>` (and optional
  `?f=`) **auto-opens** the search dialog and runs the search, landing on the
  `?f=` results tab. Two effects: `CoursewareSearchToggle` opens when
  `enabled && query`; `CoursewareSearch` runs `handleSubmit` on mount when there's
  a keyword. The URL-keyed query preserves this (it auto-runs off the URL keyword
  on load); the auto-open becomes: initialize the lifted `showSearch` from
  `enabled && query`.

### Known quirks (preserve-vs-fix TBD during conversion)

- **Closing the dialog stamps empty `?q=&f=` onto the URL**, even when no search
  was performed. Cause: `close()` → `clearSearch()` → `clearSearchParams()` does
  `setSearchParams({ q: '', f: '' })` (the `initSearchParams`), and React Router
  writes empty-valued params. Lives in `useCoursewareSearchParams` (a URL hook,
  orthogonal to the Redux work). Almost certainly unintended — candidate for an
  opportunistic fix (remove the params, or don't touch the URL when nothing to
  clear) when we rework `close()`.
- **"All content" filter is represented two ways.** On first search the
  all-content tab is active with `f=` (blank), but explicitly clicking the
  all-content tab sets `f=all`. So the same filter is both `""` and `"all"`.
  Cosmetic URL inconsistency in `CoursewareResultsFilter`; candidate to normalize.

<!-- more baseline behavior to be added as manual documentation continues -->


</details>

Closes #1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

