### PR TITLE
refactor: convert course-home CTA toast from Redux to a React ToastProvider

### DIFF
--- a/src/course-home/data/apiHooks.test.tsx
+++ b/src/course-home/data/apiHooks.test.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import MockAdapter from 'axios-mock-adapter';
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { initializeMockApp } from '../../setupTest';
+import { ToastProvider, useToast } from '../../generic/ToastContext';
+import { useResetDeadlines, usePostEvent } from './apiHooks';
+
+const { loggingService } = initializeMockApp();
+
+const buildWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+describe('course-home apiHooks', () => {
+  let axiosMock: MockAdapter;
+
+  beforeEach(() => {
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    loggingService.logError.mockReset();
+  });
+
+  describe('useResetDeadlines', () => {
+    const resetUrl = `${getConfig().LMS_BASE_URL}/api/course_experience/v1/reset_course_deadlines`;
+
+    it('POSTs and surfaces the server response as an open toast', async () => {
+      axiosMock.onPost(resetUrl).reply(201, {
+        header: 'test-toast-header', link: 'test-toast-link', link_text: 'test-toast-body',
+      });
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => ({ reset: useResetDeadlines(), toast: useToast() }), { wrapper });
+
+      await act(async () => { await result.current.reset.mutateAsync({ courseId: 'course-1', model: 'dates' }); });
+
+      expect(axiosMock.history.post[0].data).toEqual(
+        '{"course_key":"course-1","research_event_data":{"location":"dates-tab"}}',
+      );
+      expect(result.current.toast.toastContent).toEqual({
+        message: 'test-toast-header',
+        action: { label: 'test-toast-body', href: 'test-toast-link' },
+      });
+      expect(result.current.toast.isToastOpen).toBe(true);
+    });
+
+    it('omits the toast action when the response has no link text', async () => {
+      axiosMock.onPost(resetUrl).reply(200, { header: 'done', link: null, link_text: '' });
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => ({ reset: useResetDeadlines(), toast: useToast() }), { wrapper });
+
+      await act(async () => { await result.current.reset.mutateAsync({ courseId: 'course-1', model: 'outline' }); });
+
+      expect(result.current.toast.toastContent).toEqual({ message: 'done', action: undefined });
+      expect(result.current.toast.isToastOpen).toBe(true);
+    });
+
+    it('logs the error when the POST fails', async () => {
+      axiosMock.onPost(resetUrl).reply(500);
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useResetDeadlines(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({ courseId: 'course-1', model: 'dates' }).catch(() => {});
+      });
+
+      await waitFor(() => expect(loggingService.logError).toHaveBeenCalled());
+    });
+  });
+
+  describe('usePostEvent', () => {
+    const postUrl = 'http://example.com/post-event';
+
+    it('POSTs to the event url and surfaces the response as an open toast', async () => {
+      axiosMock.onPost(postUrl).reply(200, {
+        header: 'post-header', link: 'post-link', link_text: 'post-body',
+      });
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => ({ post: usePostEvent(), toast: useToast() }), { wrapper });
+
+      await act(async () => {
+        await result.current.post.mutateAsync({
+          postData: { url: postUrl, bodyParams: { courseId: 'course-1' } },
+          researchEventData: { location: 'unit' },
+        });
+      });
+
+      expect(axiosMock.history.post[0].url).toEqual(postUrl);
+      expect(result.current.toast.toastContent).toEqual({
+        message: 'post-header',
+        action: { label: 'post-body', href: 'post-link' },
+      });
+      expect(result.current.toast.isToastOpen).toBe(true);
+    });
+
+    it('logs the error when the POST fails', async () => {
+      axiosMock.onPost(postUrl).reply(500);
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => usePostEvent(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          postData: { url: postUrl, bodyParams: { courseId: 'course-1' } },
+          researchEventData: { location: 'unit' },
+        }).catch(() => {});
+      });
+
+      await waitFor(() => expect(loggingService.logError).toHaveBeenCalled());
+    });
+  });
+});

--- a/src/course-home/data/apiHooks.ts
+++ b/src/course-home/data/apiHooks.ts
@@ -1,0 +1,47 @@
+import { logError } from '@edx/frontend-platform/logging';
+import { useMutation } from '@tanstack/react-query';
+
+import { useToast, ToastContent } from '@src/generic/ToastContext';
+import { executePostFromPostEvent, postCourseDeadlines } from './api';
+
+interface CallToActionResponse {
+  header: string;
+  link: string;
+  link_text: string;
+}
+
+interface PostData {
+  url: string;
+  bodyParams: { courseId: string };
+}
+
+const toastFrom = ({ header, link, link_text: linkText }: CallToActionResponse): ToastContent => ({
+  message: header,
+  action: linkText ? { label: linkText, href: link } : undefined,
+});
+
+export const useResetDeadlines = () => {
+  const { setToastContent, openToast } = useToast();
+  return useMutation({
+    mutationFn: ({ courseId, model }: { courseId: string; model: string }) => postCourseDeadlines(courseId, model),
+    onSuccess: ({ data }) => {
+      setToastContent(toastFrom(data));
+      openToast();
+    },
+    onError: (error) => logError(error),
+  });
+};
+
+export const usePostEvent = () => {
+  const { setToastContent, openToast } = useToast();
+  return useMutation({
+    mutationFn: ({ postData, researchEventData }: { postData: PostData; researchEventData: unknown }) => (
+      executePostFromPostEvent(postData, researchEventData)
+    ),
+    onSuccess: ({ data }) => {
+      setToastContent(toastFrom(data));
+      openToast();
+    },
+    onError: (error) => logError(error),
+  });
+};

--- a/src/course-home/data/index.js
+++ b/src/course-home/data/index.js
@@ -2,7 +2,6 @@ export {
   fetchDatesTab,
   fetchOutlineTab,
   fetchProgressTab,
-  resetDeadlines,
   deprecatedSaveCourseGoal,
   saveWeeklyLearningGoal,
 } from './thunks';

--- a/src/course-home/data/redux.test.js
+++ b/src/course-home/data/redux.test.js
@@ -237,25 +237,6 @@ describe('Data layer integration tests', () => {
     });
   });
 
-  describe('Test resetDeadlines', () => {
-    it('Should reset course deadlines', async () => {
-      const resetUrl = `${getConfig().LMS_BASE_URL}/api/course_experience/v1/reset_course_deadlines`;
-      const model = 'dates';
-      axiosMock.onPost(resetUrl).reply(201, {});
-
-      const getTabDataMock = jest.fn(() => ({
-        type: 'MOCK_ACTION',
-      }));
-
-      await executeThunk(thunks.resetDeadlines(courseId, model, getTabDataMock), store.dispatch);
-
-      expect(axiosMock.history.post[0].url).toEqual(resetUrl);
-      expect(axiosMock.history.post[0].data).toEqual(`{"course_key":"${courseId}","research_event_data":{"location":"dates-tab"}}`);
-
-      expect(getTabDataMock).toHaveBeenCalledWith(courseId);
-    });
-  });
-
   describe('Test dismissWelcomeMessage', () => {
     it('Should dismiss welcome message', async () => {
       const dismissUrl = `${getConfig().LMS_BASE_URL}/api/course_home/dismiss_welcome_message`;

--- a/src/course-home/data/slice.js
+++ b/src/course-home/data/slice.js
@@ -14,9 +14,6 @@ const slice = createSlice({
     courseStatus: 'loading',
     courseId: null,
     proctoringPanelStatus: 'loading',
-    toastBodyText: null,
-    toastBodyLink: null,
-    toastHeader: '',
     examsData: null,
     errorMessage: null,
     errorCode: null,
@@ -46,16 +43,6 @@ const slice = createSlice({
       state.targetUserId = payload.targetUserId;
       state.courseStatus = LOADED;
     },
-    setCallToActionToast: (state, { payload }) => {
-      const {
-        header,
-        link,
-        linkText,
-      } = payload;
-      state.toastBodyLink = link;
-      state.toastBodyText = linkText;
-      state.toastHeader = header;
-    },
     setExamsData: (state, { payload }) => {
       state.examsData = payload;
     },
@@ -68,7 +55,6 @@ export const {
   fetchTabFailure,
   fetchTabRequest,
   fetchTabSuccess,
-  setCallToActionToast,
   setExamsData,
 } = slice.actions;
 

--- a/src/course-home/data/slice.test.js
+++ b/src/course-home/data/slice.test.js
@@ -9,9 +9,6 @@ describe('course home data slice', () => {
         metadataModel: 'courseHomeCourseMetadata',
         proctoringPanelStatus: 'loading',
         tabFetchStates: {},
-        toastBodyText: '',
-        toastBodyLink: null,
-        toastHeader: '',
         examsData: null,
       };
 
@@ -47,9 +44,6 @@ describe('course home data slice', () => {
         metadataModel: 'courseHomeCourseMetadata',
         proctoringPanelStatus: 'loading',
         tabFetchStates: {},
-        toastBodyText: '',
-        toastBodyLink: null,
-        toastHeader: '',
         examsData: [{ id: 1, examName: 'Old Exam' }],
       };
 
@@ -76,9 +70,6 @@ describe('course home data slice', () => {
         metadataModel: 'courseHomeCourseMetadata',
         proctoringPanelStatus: 'loading',
         tabFetchStates: {},
-        toastBodyText: '',
-        toastBodyLink: null,
-        toastHeader: '',
         examsData: [{ id: 1, examName: 'Some Exam' }],
       };
 
@@ -95,9 +86,6 @@ describe('course home data slice', () => {
         metadataModel: 'courseHomeCourseMetadata',
         proctoringPanelStatus: 'loading',
         tabFetchStates: {},
-        toastBodyText: '',
-        toastBodyLink: null,
-        toastHeader: '',
         examsData: [{ id: 1, examName: 'Some Exam' }],
       };
 
@@ -114,9 +102,6 @@ describe('course home data slice', () => {
         metadataModel: 'courseHomeCourseMetadata',
         proctoringPanelStatus: 'complete',
         tabFetchStates: { progress: 'loaded' },
-        toastBodyText: 'Toast message',
-        toastBodyLink: 'http://example.com',
-        toastHeader: 'Toast Header',
         examsData: null,
       };
 
@@ -133,7 +118,6 @@ describe('course home data slice', () => {
       // Verify other properties remain unchanged
       expect(newState.courseStatus).toBe(initialState.courseStatus);
       expect(newState.courseId).toBe(initialState.courseId);
-      expect(newState.toastBodyText).toBe(initialState.toastBodyText);
     });
   });
 });

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -1,13 +1,10 @@
 import { logError } from '@edx/frontend-platform/logging';
-import { camelCaseObject } from '@edx/frontend-platform';
 import {
-  executePostFromPostEvent,
   getCourseHomeCourseMetadata,
   getDatesTabData,
   getExamsData,
   getOutlineTabData,
   getProgressTabData,
-  postCourseDeadlines,
   deprecatedPostCourseGoals,
   postWeeklyLearningGoal,
   postDismissWelcomeMessage,
@@ -24,11 +21,10 @@ import {
   fetchTabFailure,
   fetchTabRequest,
   fetchTabSuccess,
-  setCallToActionToast,
   setExamsData,
 } from './slice';
 
-const eventTypes = {
+export const eventTypes = {
   POST_EVENT: 'post_event',
 };
 
@@ -118,48 +114,12 @@ export function requestCert(courseId) {
   return async () => postRequestCert(courseId);
 }
 
-export function resetDeadlines(courseId, model, getTabData) {
-  return async (dispatch) => {
-    postCourseDeadlines(courseId, model).then(response => {
-      const { data } = response;
-      const {
-        header,
-        link,
-        link_text: linkText,
-      } = data;
-      dispatch(getTabData(courseId));
-      dispatch(setCallToActionToast({ header, link, linkText }));
-    });
-  };
-}
-
 export async function deprecatedSaveCourseGoal(courseId, goalKey) {
   return deprecatedPostCourseGoals(courseId, goalKey);
 }
 
 export async function saveWeeklyLearningGoal(courseId, daysPerWeek, subscribedToReminders) {
   return postWeeklyLearningGoal(courseId, daysPerWeek, subscribedToReminders);
-}
-
-export function processEvent(eventData, getTabData) {
-  return async (dispatch) => {
-    // Pulling this out early so the data doesn't get camelCased and is easier
-    // to use when it's passed to the backend
-    const { research_event_data: researchEventData } = eventData;
-    const event = camelCaseObject(eventData);
-    if (event.eventName === eventTypes.POST_EVENT) {
-      executePostFromPostEvent(event.postData, researchEventData).then(response => {
-        const { data } = response;
-        const {
-          header,
-          link,
-          link_text: linkText,
-        } = data;
-        dispatch(getTabData(event.postData.bodyParams.courseId));
-        dispatch(setCallToActionToast({ header, link, linkText }));
-      });
-    }
-  };
 }
 
 export function fetchExamAttemptsData(courseId, sequenceIds) {

--- a/src/course-home/dates-tab/DatesTab.test.jsx
+++ b/src/course-home/dates-tab/DatesTab.test.jsx
@@ -20,6 +20,7 @@ import initializeStore from '../../store';
 import { TabContainer } from '../../tab-page';
 import { appendBrowserTimezoneToUrl } from '../../utils';
 import { UserMessagesProvider } from '../../generic/user-messages';
+import { ToastProvider } from '../../generic/ToastContext';
 
 initializeMockApp();
 jest.mock('@edx/frontend-platform/analytics');
@@ -36,16 +37,18 @@ describe('DatesTab', () => {
       <AppProvider store={store}>
         <QueryClientProvider client={createTestQueryClient()}>
           <UserMessagesProvider>
-            <Routes>
-              <Route
-                path="/course/:courseId/dates"
-                element={(
-                  <TabContainer tab="dates" fetch={fetchDatesTab} slice="courseHome">
-                    <DatesTab />
-                  </TabContainer>
-                )}
-              />
-            </Routes>
+            <ToastProvider>
+              <Routes>
+                <Route
+                  path="/course/:courseId/dates"
+                  element={(
+                    <TabContainer tab="dates" fetch={fetchDatesTab} slice="courseHome">
+                      <DatesTab />
+                    </TabContainer>
+                  )}
+                />
+              </Routes>
+            </ToastProvider>
           </UserMessagesProvider>
         </QueryClientProvider>
       </AppProvider>

--- a/src/course-home/discussion-tab/DiscussionTab.test.jsx
+++ b/src/course-home/discussion-tab/DiscussionTab.test.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { Factory } from 'rosie';
 import { UserMessagesProvider } from '../../generic/user-messages';
+import { ToastProvider } from '../../generic/ToastContext';
 import {
   createTestQueryClient, initializeMockApp, messageEvent, screen, waitFor,
 } from '../../setupTest';
@@ -32,16 +33,18 @@ describe('DiscussionTab', () => {
       <AppProvider store={store}>
         <QueryClientProvider client={createTestQueryClient()}>
           <UserMessagesProvider>
-            <Routes>
-              <Route
-                path="/course/:courseId/discussion"
-                element={(
-                  <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
-                    <DiscussionTab />
-                  </TabContainer>
-                )}
-              />
-            </Routes>
+            <ToastProvider>
+              <Routes>
+                <Route
+                  path="/course/:courseId/discussion"
+                  element={(
+                    <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
+                      <DiscussionTab />
+                    </TabContainer>
+                  )}
+                />
+              </Routes>
+            </ToastProvider>
           </UserMessagesProvider>
         </QueryClientProvider>
       </AppProvider>

--- a/src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx
+++ b/src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx
@@ -10,7 +10,7 @@ import {
   Col,
 } from '@openedx/paragon';
 
-import { resetDeadlines } from '../data';
+import { useResetDeadlines } from '../data/apiHooks';
 import { useModel } from '../../generic/model-store';
 import messages from './messages';
 
@@ -31,6 +31,7 @@ const ShiftDatesAlert = ({ fetch, model }) => {
   } = datesBannerInfo;
 
   const dispatch = useDispatch();
+  const resetDeadlines = useResetDeadlines();
 
   if (!missedDeadlines || missedGatedContent || hasEnded) {
     return null;
@@ -48,7 +49,10 @@ const ShiftDatesAlert = ({ fetch, model }) => {
             variant="primary"
             size="sm"
             className="w-xs-100 w-md-auto"
-            onClick={() => dispatch(resetDeadlines(courseId, model, fetch))}
+            onClick={() => resetDeadlines.mutate(
+              { courseId, model },
+              { onSuccess: () => dispatch(fetch(courseId)) },
+            )}
           >
             {intl.formatMessage(messages.shiftDatesButton)}
           </Button>

--- a/src/courseware/CoursewareContainer.test.jsx
+++ b/src/courseware/CoursewareContainer.test.jsx
@@ -13,6 +13,7 @@ import { Factory } from 'rosie';
 import MockAdapter from 'axios-mock-adapter';
 
 import { UserMessagesProvider } from '../generic/user-messages';
+import { ToastProvider } from '../generic/ToastContext';
 import tabMessages from '../tab-page/messages';
 import { createTestQueryClient, initializeMockApp, waitFor } from '../setupTest';
 import { DECODE_ROUTES } from '../constants';
@@ -95,15 +96,17 @@ describe('CoursewareContainer', () => {
       <AppProvider store={store} wrapWithRouter={false}>
         <QueryClientProvider client={createTestQueryClient()}>
           <UserMessagesProvider>
-            <Routes>
-              {DECODE_ROUTES.COURSEWARE.map((route) => (
-                <Route
-                  key={route}
-                  path={route}
-                  element={<CoursewareContainer />}
-                />
-              ))}
-            </Routes>
+            <ToastProvider>
+              <Routes>
+                {DECODE_ROUTES.COURSEWARE.map((route) => (
+                  <Route
+                    key={route}
+                    path={route}
+                    element={<CoursewareContainer />}
+                  />
+                ))}
+              </Routes>
+            </ToastProvider>
           </UserMessagesProvider>
         </QueryClientProvider>
       </AppProvider>

--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
@@ -6,7 +6,6 @@ import { logError } from '@edx/frontend-platform/logging';
 import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { fetchCourse } from '@src/courseware/data';
-import { processEvent } from '@src/course-home/data/thunks';
 import { useEventListener } from '@src/generic/hooks';
 import { useSequenceNavigationMetadata } from '@src/courseware/course/sequence/sequence-navigation/hooks';
 
@@ -15,8 +14,10 @@ import { messageTypes } from '../constants';
 import useIFrameBehavior, { iframeBehaviorState } from './useIFrameBehavior';
 
 const mockNavigate = jest.fn();
+const mockMutate = jest.fn();
 
 jest.mock('@edx/frontend-platform', () => ({
+  ...jest.requireActual('@edx/frontend-platform'),
   getConfig: jest.fn(),
 }));
 
@@ -40,7 +41,10 @@ jest.mock('@src/courseware/data', () => ({
   fetchCourse: jest.fn(),
 }));
 jest.mock('@src/course-home/data/thunks', () => ({
-  processEvent: jest.fn((...args) => ({ processEvent: args })),
+  eventTypes: { POST_EVENT: 'post_event' },
+}));
+jest.mock('@src/course-home/data/apiHooks', () => ({
+  usePostEvent: () => ({ mutate: mockMutate }),
 }));
 jest.mock('@src/generic/hooks', () => ({
   useEventListener: jest.fn(),
@@ -349,12 +353,30 @@ describe('useIFrameBehavior hook', () => {
       });
       it('registers an event handler to process fetchCourse events.', () => {
         mockState(defaultStateVals);
+        fetchCourse.mockReturnValue('fetch-course-action');
         const { result } = renderHook(() => useIFrameBehavior(props));
         result.current.handleIFrameLoad();
-        const eventName = 'test-event-name';
-        const event = { data: { event_name: eventName } };
+        const event = {
+          data: {
+            event_name: 'post_event',
+            post_data: { url: 'post-url', body_params: { course_id: 'course-1' } },
+            research_event_data: { location: 'unit' },
+          },
+        };
         window.onmessage(event);
-        expect(dispatch).toHaveBeenCalledWith(processEvent(event.data, fetchCourse));
+
+        expect(mockMutate).toHaveBeenCalledWith(
+          {
+            postData: { url: 'post-url', bodyParams: { courseId: 'course-1' } },
+            researchEventData: { location: 'unit' },
+          },
+          { onSuccess: expect.any(Function) },
+        );
+
+        const { onSuccess } = mockMutate.mock.calls[0][1];
+        onSuccess();
+        expect(fetchCourse).toHaveBeenCalledWith('course-1');
+        expect(dispatch).toHaveBeenCalledWith('fetch-course-action');
       });
       it('updates initial iframe visibility on load', () => {
         const { result } = renderHook(() => useIFrameBehavior(props));

--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { getConfig } from '@edx/frontend-platform';
+import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -8,7 +8,8 @@ import { throttle } from 'lodash';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { fetchCourse } from '@src/courseware/data';
-import { processEvent } from '@src/course-home/data/thunks';
+import { usePostEvent } from '@src/course-home/data/apiHooks';
+import { eventTypes } from '@src/course-home/data/thunks';
 import { useEventListener } from '@src/generic/hooks';
 import { getSequenceId } from '@src/courseware/data/selectors';
 import { useModel } from '@src/generic/model-store';
@@ -34,6 +35,7 @@ const useIFrameBehavior = ({
   useLoadBearingHook(id);
 
   const dispatch = useDispatch();
+  const postEvent = usePostEvent();
   const activeSequenceId = useSelector(getSequenceId);
   const navigate = useNavigate();
   const activeSequence = useModel('sequences', activeSequenceId);
@@ -150,6 +152,22 @@ const useIFrameBehavior = ({
   * could have given us a 4xx or 5xx response.
   */
 
+  const handlePostMessageEvent = (e: MessageEvent) => {
+    if (!e.data?.event_name) {
+      return;
+    }
+    // Pull this out before camelCasing so it stays in the shape the backend expects.
+    const { research_event_data: researchEventData } = e.data;
+    const event = camelCaseObject(e.data);
+    if (event.eventName !== eventTypes.POST_EVENT) {
+      return;
+    }
+    postEvent.mutate(
+      { postData: event.postData, researchEventData },
+      { onSuccess: () => dispatch(fetchCourse(event.postData.bodyParams.courseId)) },
+    );
+  };
+
   const handleIFrameLoad = () => {
     if (!hasLoaded) {
       setShowError(true);
@@ -161,11 +179,7 @@ const useIFrameBehavior = ({
         iframeUrl,
       });
     }
-    window.onmessage = (e) => {
-      if (e.data.event_name) {
-        dispatch(processEvent(e.data, fetchCourse));
-      }
-    };
+    window.onmessage = handlePostMessageEvent;
 
     // Update the visibility of the iframe in case the element is already visible.
     updateIframeVisibility();

--- a/src/generic/ToastContext.test.tsx
+++ b/src/generic/ToastContext.test.tsx
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { ToastProvider, useToast } from './ToastContext';
+
+const wrapper = ({ children }) => <ToastProvider>{children}</ToastProvider>;
+
+describe('ToastContext', () => {
+  it('throws when used outside a provider', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useToast())).toThrow(
+      'useToast must be used within a ToastProvider',
+    );
+    consoleError.mockRestore();
+  });
+
+  it('starts with no content and closed', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    expect(result.current.toastContent).toBeNull();
+    expect(result.current.isToastOpen).toBe(false);
+  });
+
+  it('setToastContent sets the content without opening the toast', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    const content = { message: 'hello', action: { label: 'go', href: '/x' } };
+
+    act(() => result.current.setToastContent(content));
+
+    expect(result.current.toastContent).toEqual(content);
+    expect(result.current.isToastOpen).toBe(false);
+  });
+
+  it('openToast and closeToast toggle visibility without touching content', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    const content = { message: 'hello' };
+    act(() => result.current.setToastContent(content));
+
+    act(() => result.current.openToast());
+    expect(result.current.isToastOpen).toBe(true);
+    expect(result.current.toastContent).toEqual(content);
+
+    act(() => result.current.closeToast());
+    expect(result.current.isToastOpen).toBe(false);
+    expect(result.current.toastContent).toEqual(content);
+  });
+});

--- a/src/generic/ToastContext.tsx
+++ b/src/generic/ToastContext.tsx
@@ -1,0 +1,41 @@
+import React, {
+  createContext, useContext, useMemo, useState, ReactNode,
+} from 'react';
+
+export interface ToastContent {
+  message: string;
+  action?: { label: string; href?: string; onClick?: () => void };
+}
+
+interface ToastContextValue {
+  toastContent: ToastContent | null;
+  setToastContent: (toast: ToastContent | null) => void;
+  isToastOpen: boolean;
+  openToast: () => void;
+  closeToast: () => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toastContent, setToastContent] = useState<ToastContent | null>(null);
+  const [isToastOpen, setIsToastOpen] = useState(false);
+
+  const value = useMemo<ToastContextValue>(() => ({
+    toastContent,
+    setToastContent,
+    isToastOpen,
+    openToast: () => setIsToastOpen(true),
+    closeToast: () => setIsToastOpen(false),
+  }), [toastContent, isToastOpen]);
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+};
+
+export const useToast = (): ToastContextValue => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -31,6 +31,7 @@ import { fetchCourse } from './courseware/data';
 import { store } from './store';
 import NoticesProvider from './generic/notices';
 import PathFixesProvider from './generic/path-fixes';
+import { ToastProvider } from './generic/ToastContext';
 import LiveTab from './course-home/live-tab/LiveTab';
 import CourseAccessErrorPage from './generic/CourseAccessErrorPage';
 import DecodePageRoute from './decode-page-route';
@@ -54,100 +55,102 @@ subscribe(APP_READY, () => {
             <NoticesProvider>
               <UserMessagesProvider>
                 <div className="app-container">
-                  <Routes>
-                    <Route path="*" element={<PageWrap><PageNotFound /></PageWrap>} />
-                    <Route path={ROUTES.UNSUBSCRIBE} element={<PageWrap><GoalUnsubscribe /></PageWrap>} />
-                    <Route path={ROUTES.REDIRECT} element={<PageWrap><CoursewareRedirectLandingPage /></PageWrap>} />
-                    <Route
-                      path={ROUTES.PREFERENCES_UNSUBSCRIBE}
-                      element={
-                        <PageWrap><PreferencesUnsubscribe /></PageWrap>
-                      }
-                    />
-                    <Route
-                      path={DECODE_ROUTES.ACCESS_DENIED}
-                      element={<DecodePageRoute><CourseAccessErrorPage /></DecodePageRoute>}
-                    />
-                    <Route
-                      path={DECODE_ROUTES.HOME}
-                      element={(
-                        <DecodePageRoute>
-                          <TabContainer tab="outline" fetch={fetchOutlineTab} slice="courseHome">
-                            <OutlineTab />
-                          </TabContainer>
-                        </DecodePageRoute>
-                      )}
-                    />
-                    <Route
-                      path={DECODE_ROUTES.LIVE}
-                      element={(
-                        <DecodePageRoute>
-                          <TabContainer tab="lti_live" fetch={fetchLiveTab} slice="courseHome">
-                            <LiveTab />
-                          </TabContainer>
-                        </DecodePageRoute>
-                      )}
-                    />
-                    <Route
-                      path={DECODE_ROUTES.DATES}
-                      element={(
-                        <DecodePageRoute>
-                          <TabContainer tab="dates" fetch={fetchDatesTab} slice="courseHome">
-                            <DatesTab />
-                          </TabContainer>
-                        </DecodePageRoute>
-                      )}
-                    />
-                    <Route
-                      path={DECODE_ROUTES.DISCUSSION}
-                      element={(
-                        <DecodePageRoute>
-                          <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
-                            <DiscussionTab />
-                          </TabContainer>
-                        </DecodePageRoute>
-                      )}
-                    />
-                    {DECODE_ROUTES.PROGRESS.map((route) => (
+                  <ToastProvider>
+                    <Routes>
+                      <Route path="*" element={<PageWrap><PageNotFound /></PageWrap>} />
+                      <Route path={ROUTES.UNSUBSCRIBE} element={<PageWrap><GoalUnsubscribe /></PageWrap>} />
+                      <Route path={ROUTES.REDIRECT} element={<PageWrap><CoursewareRedirectLandingPage /></PageWrap>} />
                       <Route
-                        key={route}
-                        path={route}
+                        path={ROUTES.PREFERENCES_UNSUBSCRIBE}
+                        element={
+                          <PageWrap><PreferencesUnsubscribe /></PageWrap>
+                      }
+                      />
+                      <Route
+                        path={DECODE_ROUTES.ACCESS_DENIED}
+                        element={<DecodePageRoute><CourseAccessErrorPage /></DecodePageRoute>}
+                      />
+                      <Route
+                        path={DECODE_ROUTES.HOME}
                         element={(
                           <DecodePageRoute>
-                            <TabContainer
-                              tab="progress"
-                              fetch={fetchProgressTab}
-                              slice="courseHome"
-                              isProgressTab
-                            >
-                              <ProgressTab />
+                            <TabContainer tab="outline" fetch={fetchOutlineTab} slice="courseHome">
+                              <OutlineTab />
                             </TabContainer>
                           </DecodePageRoute>
-                        )}
-                      />
-                    ))}
-                    <Route
-                      path={DECODE_ROUTES.COURSE_END}
-                      element={(
-                        <DecodePageRoute>
-                          <TabContainer tab="courseware" fetch={fetchCourse} slice="courseware">
-                            <CourseExit />
-                          </TabContainer>
-                        </DecodePageRoute>
                       )}
-                    />
-                    {DECODE_ROUTES.COURSEWARE.map((route) => (
+                      />
                       <Route
-                        key={route}
-                        path={route}
+                        path={DECODE_ROUTES.LIVE}
                         element={(
                           <DecodePageRoute>
-                            <CoursewareContainer />
+                            <TabContainer tab="lti_live" fetch={fetchLiveTab} slice="courseHome">
+                              <LiveTab />
+                            </TabContainer>
                           </DecodePageRoute>
-                        )}
+                      )}
                       />
-                    ))}
-                  </Routes>
+                      <Route
+                        path={DECODE_ROUTES.DATES}
+                        element={(
+                          <DecodePageRoute>
+                            <TabContainer tab="dates" fetch={fetchDatesTab} slice="courseHome">
+                              <DatesTab />
+                            </TabContainer>
+                          </DecodePageRoute>
+                      )}
+                      />
+                      <Route
+                        path={DECODE_ROUTES.DISCUSSION}
+                        element={(
+                          <DecodePageRoute>
+                            <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
+                              <DiscussionTab />
+                            </TabContainer>
+                          </DecodePageRoute>
+                      )}
+                      />
+                      {DECODE_ROUTES.PROGRESS.map((route) => (
+                        <Route
+                          key={route}
+                          path={route}
+                          element={(
+                            <DecodePageRoute>
+                              <TabContainer
+                                tab="progress"
+                                fetch={fetchProgressTab}
+                                slice="courseHome"
+                                isProgressTab
+                              >
+                                <ProgressTab />
+                              </TabContainer>
+                            </DecodePageRoute>
+                        )}
+                        />
+                      ))}
+                      <Route
+                        path={DECODE_ROUTES.COURSE_END}
+                        element={(
+                          <DecodePageRoute>
+                            <TabContainer tab="courseware" fetch={fetchCourse} slice="courseware">
+                              <CourseExit />
+                            </TabContainer>
+                          </DecodePageRoute>
+                      )}
+                      />
+                      {DECODE_ROUTES.COURSEWARE.map((route) => (
+                        <Route
+                          key={route}
+                          path={route}
+                          element={(
+                            <DecodePageRoute>
+                              <CoursewareContainer />
+                            </DecodePageRoute>
+                        )}
+                        />
+                      ))}
+                    </Routes>
+                  </ToastProvider>
                 </div>
               </UserMessagesProvider>
             </NoticesProvider>

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -17,6 +17,7 @@ import { reducer as courseHomeReducer } from './course-home/data';
 import { reducer as coursewareReducer } from './courseware/data/slice';
 import { reducer as modelsReducer } from './generic/model-store';
 import { UserMessagesProvider } from './generic/user-messages';
+import { ToastProvider } from './generic/ToastContext';
 
 import messages from './i18n';
 import { fetchCourse, fetchSequence } from './courseware/data';
@@ -266,7 +267,9 @@ function render(
       <AppProvider store={store || globalStore} wrapWithRouter={wrapWithRouter}>
         <QueryClientProvider client={testQueryClient}>
           <UserMessagesProvider>
-            {children}
+            <ToastProvider>
+              {children}
+            </ToastProvider>
           </UserMessagesProvider>
         </QueryClientProvider>
       </AppProvider>

--- a/src/tab-page/TabPage.jsx
+++ b/src/tab-page/TabPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom';
 
 import { Toast } from '@openedx/paragon';
@@ -10,11 +10,11 @@ import HeaderSlot from '../plugin-slots/HeaderSlot';
 import PageLoading from '../generic/PageLoading';
 import { getAccessDeniedRedirectUrl } from '../shared/access';
 import { useModel } from '../generic/model-store';
+import { useToast } from '../generic/ToastContext';
 
 import genericMessages from '../generic/messages';
 import messages from './messages';
 import LoadedTabPage from './LoadedTabPage';
-import { setCallToActionToast } from '../course-home/data/slice';
 import LaunchCourseHomeTourButton from '../product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton';
 import { TourProvider } from '../product-tours/TourContext';
 
@@ -27,16 +27,13 @@ const TabPage = (props) => {
     metadataModel,
   } = props;
   const {
-    toastBodyLink,
-    toastBodyText,
-    toastHeader,
     errorMessage: courseHomeErrorMessage,
   } = useSelector(state => state.courseHome);
   const {
     errorMessage: coursewareErrorMessage,
   } = useSelector(state => state.courseware);
   const errorMessage = courseHomeErrorMessage || coursewareErrorMessage;
-  const dispatch = useDispatch();
+  const { toastContent, isToastOpen, closeToast } = useToast();
   const {
     courseAccess,
     number,
@@ -57,15 +54,12 @@ const TabPage = (props) => {
       {['loaded', 'denied'].includes(courseStatus) && (
         <>
           <Toast
-            action={toastBodyText ? {
-              label: toastBodyText,
-              href: toastBodyLink,
-            } : null}
+            action={toastContent?.action ?? null}
             closeLabel={intl.formatMessage(genericMessages.close)}
-            onClose={() => dispatch(setCallToActionToast({ header: '', link: null, link_text: null }))}
-            show={!!(toastHeader)}
+            onClose={closeToast}
+            show={isToastOpen}
           >
-            {toastHeader}
+            {toastContent?.message}
           </Toast>
           {metadataModel === 'courseHomeMeta' && (<LaunchCourseHomeTourButton srOnly />)}
         </>

--- a/src/tab-page/TabPage.test.jsx
+++ b/src/tab-page/TabPage.test.jsx
@@ -1,17 +1,25 @@
 import React from 'react';
-import { getConfig } from '@edx/frontend-platform';
-import MockAdapter from 'axios-mock-adapter';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import {
-  initializeTestStore, logUnhandledRequests, render, screen,
+  initializeTestStore, render, screen,
 } from '../setupTest';
 import { TabPage } from './index';
-import { executeThunk } from '../utils';
-import * as thunks from '../course-home/data/thunks';
+import { useToast } from '../generic/ToastContext';
 
 // We should not test `LoadedTabPage` page here, as `TabPage` is used only for passing `passthroughProps`.
 jest.mock('./LoadedTabPage', () => function () {
   return <div data-testid="LoadedTabPage" />;
+});
+
+jest.mock('../generic/ToastContext', () => ({
+  ...jest.requireActual('../generic/ToastContext'),
+  useToast: jest.fn(),
+}));
+
+const mockUseToast = (overrides = {}) => useToast.mockReturnValue({
+  toastContent: null,
+  isToastOpen: false,
+  closeToast: jest.fn(),
+  ...overrides,
 });
 
 describe('Tab Page', () => {
@@ -21,6 +29,10 @@ describe('Tab Page', () => {
 
   beforeAll(async () => {
     await initializeTestStore({ excludeFetchCourse: true, excludeFetchSequence: true });
+  });
+
+  beforeEach(() => {
+    mockUseToast();
   });
 
   it('displays loading message', () => {
@@ -69,26 +81,12 @@ describe('Tab Page', () => {
     expect(screen.getByText('There was an error loading this course.')).toBeInTheDocument();
   });
 
-  it('displays Learning Toast', async () => {
-    const testStore = await initializeTestStore({ excludeFetchCourse: true, excludeFetchSequence: true }, false);
-    render(<TabPage {...mockData} />, { store: testStore, wrapWithRouter: true });
-
-    const resetUrl = `${getConfig().LMS_BASE_URL}/api/course_experience/v1/reset_course_deadlines`;
-    const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
-    axiosMock.onPost(resetUrl).reply(201, {
-      link: 'test-toast-link',
-      link_text: 'test-toast-body',
-      header: 'test-toast-header',
+  it('renders a toast from the toast context', () => {
+    mockUseToast({
+      toastContent: { message: 'test-toast-header', action: { label: 'test-toast-body', href: 'test-toast-link' } },
+      isToastOpen: true,
     });
-    logUnhandledRequests(axiosMock);
-
-    const getTabDataMock = jest.fn(() => ({
-      type: 'MOCK_ACTION',
-    }));
-    const model = 'outline';
-
-    await executeThunk(thunks.resetDeadlines('courseId', model, getTabDataMock), testStore.dispatch);
-
+    render(<TabPage {...mockData} />, { wrapWithRouter: true });
     expect(screen.getByText('test-toast-header')).toBeInTheDocument();
     expect(screen.getByText('test-toast-body')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Extracts the course-home **call-to-action toast** from Redux to a React context, and converts the two POSTs that feed it to React Query mutations. Part of the Redux → React Query migration (#1946), Phase 3 (course-home), **stacked on the courseware-search conversion** (#1970, the branch below). This is the prerequisite that lets the course-home tabs convert without a Redux toast bridge.

Behavior is preserved — same toast content, action link, auto-hide, and manual close, plus the same post-action data refresh — verified with the full test suite **and** a live manual smoke pass on both `master` and this branch (with a small fade-out improvement noted below).

## What changed

- **Toast state → React context:** new `ToastProvider`/`useToast` (`src/generic/ToastContext.tsx`), mounted once at the route root; `TabPage` renders the single Paragon `<Toast>` from it. Message and visibility are **decoupled** (`setToastContent` vs `openToast`/`closeToast`), removing the slice's `show={!!toastHeader}` content-vs-visibility fusion.
- **Writers → React Query mutations:** `useResetDeadlines` / `usePostEvent` in `src/course-home/data/apiHooks.ts`, following the `product-tours` mutation recipe. The hooks own only the POST + toast and are **Redux-free**; the transitional model-store refresh (`dispatch(getTabData)`) stays in each caller's `mutate` `onSuccess` until that data becomes an RQ query.
- **Redux removed:** the `resetDeadlines` + `processEvent` thunks (and the `resetDeadlines` re-export), and the `setCallToActionToast` reducer + `toastHeader`/`toastBodyText`/`toastBodyLink` fields from the course-home slice.
- **Courseware touch:** the `processEvent` postMessage parse/guard moves into `useIFrameBehavior` (`handlePostMessageEvent`), so `window.onmessage` is a bare reference; `eventTypes` is exported from `thunks.js`.
- **Bonus:** decoupling content from visibility removes a small glitch where the toast text blanked for a frame on auto-hide before fading.

## Testing

**Automated:** `npm run types`, `npm run lint`, `npm run build`, and the full `npm test` suite (106 suites, 896 passing) pass. New unit tests: `ToastContext.test.tsx` (incl. the decoupling) and `course-home/data/apiHooks.test.tsx` (axios-level POST → toast mapping + both `onError` paths). Own-wrapper suites that render `TabPage` (`DatesTab`, `DiscussionTab`, `CoursewareContainer`) get the provider.

**Manual smoke (dev, self-paced course with a missed deadline):** exercised **both** writers — `resetDeadlines` via the dates-tab "Shift due dates" banner (master + this branch) and `usePostEvent` via the LMS-rendered in-unit `post_event` banner (this branch). Toast content, auto-hide, and the post-action refresh match master; the fade-out is cleaner here (content persists through the animation instead of blanking).

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — Redux → React Query: course-home CTA toast

Working notes for this PR (part of the wider Redux → React Query migration,
#1946). **Not checked in** — referenced when opening the PR. First PR of Phase 3
(course-home), stacked on the courseware-search conversion (#1970).

## Scope & why the toast goes first

The course-home "call-to-action" toast is shared **client** state. It lives in
the `courseHome` slice (`toastHeader`/`toastBodyText`/`toastBodyLink` +
`setCallToActionToast`), is **read/rendered by the shared `TabPage`**, and is
**written by two POSTs**:
- `resetDeadlines` thunk → from `ShiftDatesAlert` (dates + outline tabs)
- `processEvent` thunk → from `useIFrameBehavior` (the **courseware** in-unit iframe)

Because `TabPage` is shared by every tab (and courseware), no course-home tab can
be considered de-Redux'd while the toast still reaches Redux. So the toast is
extracted first; the tabs then convert with no toast bridge.

**Two moves in this PR:** (1) the toast *client state* → a React `ToastProvider`
context; (2) the two POST *writers* that feed it → React Query mutations whose
`onSuccess` sets the toast.

**Verified: exactly one toast in the whole app** — the single Paragon `<Toast>` in
`TabPage.jsx`, backed only by those slice members. So this is a scoped extraction,
**not** a general toast framework.

## `ToastProvider`: state only, `TabPage` renders

New `src/generic/ToastContext.tsx`, mirroring `CoursewareSearchContext` (`useState`
+ `useMemo`, hook throws outside its provider). The provider owns **only state**;
`TabPage` keeps rendering the single `<Toast>`, now reading from `useToast()`
instead of `useSelector`. State in the provider, render in the consumer — the same
split as the courseware-search context. (We explicitly did **not** move the
`<Toast>` component into the provider.)

Named `ToastProvider`/`useToast`, not `CTAToast…`: nothing in the mechanism is
CTA-specific — it holds content and renders whatever it's handed. This is **not**
pre-building for hypothetical future toasts (there's only one today); it's just
naming the thing for what it is rather than for its single current caller.

Consumers call `useToast()` directly and the client state lives in the context —
no model-store hydration and no prop-drilling-with-fallback bridges. That's the
same shape as the courseware-search and product-tours conversions; the earlier
"hydrate the model store" / "lift to props" options were discarded as not matching
the established pattern.

**Placement:** mounted once at the route root in `src/index.jsx`, wrapping
`<Routes>` — the only common ancestor of both `TabPage` parents (`TabContainer`
and `CoursewareContainer`, which renders `TabPage` directly).

## Message and visibility are fully decoupled (the core design call)

The Redux slice fused content and visibility: `show={!!toastHeader}` derived
visibility from content presence, and closing meant clearing all three content
fields. **That fusion is the wart we're removing — not relocating into the
provider.** The context exposes two **independent** pieces of state:

- `toastContent: ToastContent | null` — the current notification content
- `isToastOpen: boolean` — whether the `<Toast>` is showing

Nothing couples them. Setting the content does **not** open the toast, and closing
does **not** clear the content. A writer that wants to surface a notification does
two explicit things: `setToastContent(...)` then `openToast()`. This was a
deliberate rejection of a `showToast(content)` helper that sets both — the "set
also opens" magic is exactly the coupling we're trying to leave behind. If that
means a mutation's `onSuccess` calls two functions, that's fine.

Closing only flips `isToastOpen`; the content stays in place, so Paragon's
auto-hide / close-button `onClose` (both wired to `closeToast`) fades the toast out
**with** its content rather than blanking it mid-animation.

Context value: `{ toastContent, setToastContent, isToastOpen, openToast, closeToast }`.

### Why the context carries content, not just a boolean

An early question was whether the context could hold only "should the toast show?"
and let `TabPage` supply the text. It can't: the toast text is **server-sourced** —
the POST response's `{ header, link, link_text }` *is* what's displayed, and there
is no client i18n copy for it to hardcode (unlike the dates *banner*, which does
have its own messages). So whatever emits the toast has to hand the content along;
the provider stores a `ToastContent`, not a bare flag, and the writer POSTs feed
`setToastContent` with the response.

### Naming

- **Type `ToastContent`** — not `ToastMessage` (it carries a `message` *and* an
  `action`, so "Message" undersells it), not `ToastData` ("Data" says nothing).
  Paragon's `<Toast>` takes `children` + `action`; together those are the toast's
  *content*.
- **Field/setter `toastContent`/`setToastContent`** — kept aligned with the type
  name.
- **`isToastOpen`, `openToast`, `closeToast`** — `toast`-prefixed because they're
  destructured from a general hook; a bare `isOpen`/`show` reads ambiguously at the
  call site. Mirrors `CoursewareSearchContext`'s `show`/`open`/`close`, extended
  with the content payload.

### `ToastContent` shape (derived from the real APIs, not invented)

Paragon `<Toast>` takes `children`, `action` (`{ label, href?, onClick? }`),
`show`, `onClose`, `closeLabel`, `delay`. `TabPage` today passes
`children=toastHeader`, `action={ label: toastBodyText, href: toastBodyLink }`,
`show=!!toastHeader`. Only `children` + `action` carry per-toast content; `show`
is now `isToastOpen`, and `closeLabel`/`delay` are constant. So:

```ts
export interface ToastContent {
  message: React.ReactNode;                                         // → Toast children
  action?: { label: string; href?: string; onClick?: () => void };  // → Toast action (Paragon's own shape)
}
```

## Writers → React Query mutations

New `src/course-home/data/apiHooks.ts` (first RQ hook in that folder), following
the repo's one established mutation recipe (`product-tours/data/apiHooks.ts`):
`useMutation` → `mutationFn` calls the existing `api.js` fn → `onError: logError`.
Reuses `postCourseDeadlines` / `executePostFromPostEvent` unchanged.

The two fire-and-forget thunks become `useResetDeadlines` and `usePostEvent`. Each
hook owns only the **permanent** behavior — the POST plus the two toast calls on
success — and a shared `toastFrom(response.data)` maps the server
`{ header, link, link_text }` to `ToastContent`. **The hook has zero Redux in it.**

Mutation variables are typed inline (`{ courseId, model }`, `{ postData,
researchEventData }`); only the nested post-event `postData` shape is pulled out as
a small `PostData` type, purely to keep that `mutationFn` signature under the line
limit — not a per-mutation `…Variables` interface.

Deletes both thunks (and the `resetDeadlines` re-export from `data/index.js`),
plus `setCallToActionToast` and the three toast fields from `slice.js`.

## The one transitional Redux seam lives in the caller, not the hook

Each writer also refreshed model-store data on success —
`dispatch(getTabData(courseId))`, i.e. `fetchDatesTab` / `fetchOutlineTab` /
`fetchCourse`. That data is **still Redux** (the model store) and doesn't convert
until the later Phase 3 tab PRs / Phase 4 (courseware). So the refresh has to stay
a `dispatch(...)` — an RQ→Redux call — for now.

We keep that call **out of the mutation hook** and fire it from the **caller's**
`mutate(vars, { onSuccess })`. Both `onSuccess`es run (the hook's toast first, then
the caller's refresh). This keeps `apiHooks.ts` Redux-free from day one: when that
data becomes an RQ query, delete the single caller line (or swap it for
`invalidateQueries`) and never touch the hook.

- `ShiftDatesAlert.jsx`: `resetDeadlines.mutate({ courseId, model }, { onSuccess: () => dispatch(fetch(courseId)) })` (`model`/`fetch` props unchanged; `dispatch` from the existing `useDispatch`).
- `useIFrameBehavior.ts`: `postEvent.mutate({ postData, researchEventData }, { onSuccess: () => dispatch(fetchCourse(...)) })`.

`processEvent`'s refresh (`fetchCourse`, courseware) is the longest-lived seam —
courseware data converts much later than the course-home tabs.

**Why not defer the toast until that data is RQ (toast-last)?** Extracting the
toast only once `fetchDatesTab`/`fetchOutlineTab`/`fetchCourse` are RQ queries
would avoid the seam entirely (the refresh would be `invalidateQueries` from day
one). We chose **toast-first** anyway: `TabPage` is shared, so leaving the toast in
Redux keeps *every* course-home tab Redux-coupled until courseware converts
(Phase 4, far off). Toast-first unblocks the tab conversions now; the price is one
clearly-temporary RQ→Redux line per caller, deleted as each data source converts.

## `processEvent` parse/guard moves into `useIFrameBehavior`

The postMessage parse/guard that lived in the `processEvent` thunk (pull
`research_event_data` out *before* camelCasing so it stays in the shape the backend
expects; `camelCaseObject`; check `eventName === POST_EVENT`) moves into a named
`handlePostMessageEvent` function in the hook, so `window.onmessage =
handlePostMessageEvent` is a bare reference rather than an inline block. `eventTypes`
is exported from `course-home/data/thunks.js` for the guard. **This PR therefore
touches the courseware iframe hook, not only course-home.**

## Tests

- **`ToastContext.test.tsx`** (new) — provider/hook unit tests (initial state,
  `setToastContent`, `openToast`/`closeToast`, throw-outside-provider); mirrors
  `CoursewareSearchContext.test.tsx`.
- **`course-home/data/apiHooks.test.tsx`** (new) — the **low-level** coverage:
  `renderHook` hosts `useResetDeadlines`/`usePostEvent` with an **axios-level
  MockAdapter** on the POST URL (same style as the old `TabPage` toast test), and
  asserts the server response is mapped into `toastContent` + `isToastOpen`, plus the
  POST body and the `onError → logError` path (both mutations). This is where the old
  TabPage "displays Learning Toast" data-path coverage **relocated to**, because the
  response→content mapping now lives in the hook — keeping the mock at the network
  level for parity rather than stubbing the api module. Mutations are driven with the
  `await act(async () => { await …mutateAsync(); })` form from
  `product-tours/data/apiHooks.test.tsx`. `apiHooks.ts` lands at 100%.
- **`TabPage.test.jsx`** — the toast test is **kept but narrowed** to TabPage's
  actual remaining job: "given a toast in the context, render it." It **mocks
  `useToast`** (via a one-line `mockUseToast` factory so the return shape is written
  once and each call passes only overrides) rather than driving a POST through the
  whole chain. Rationale: TabPage is now a pass-through renderer; testing the render
  belongs here, testing the server-data→content mapping belongs in the hook test.
  We rejected reconstructing the data path here with a contrived trigger component.
- **`setupTest.js`** — the shared `render()` wrapper gains `<ToastProvider>` (TabPage
  now calls `useToast`).
- **Any suite with its own provider wrapper (not `setupTest`'s `render()`) that
  renders `TabPage`** must add `<ToastProvider>` to that wrapper, since `TabPage`
  now calls `useToast()` and would otherwise throw. Found via the full run:
  - **`dates-tab/DatesTab.test.jsx`** — wrapper gains `<ToastProvider>`; the "shift
    due dates" test now exercises the full path end-to-end (click →
    `useResetDeadlines` → context → TabPage renders the toast), the real coverage of
    TabPage's render wiring.
  - **`discussion-tab/DiscussionTab.test.jsx`** — wrapper gains `<ToastProvider>`
    (renders `TabPage` via `TabContainer`).
  - **`courseware/CoursewareContainer.test.jsx`** — wrapper gains `<ToastProvider>`
    (`CoursewareContainer` renders `TabPage` directly).
- **`course-home/data/slice.test.js`** — drop the toast fields from the local
  fixtures.
- **`course-home/data/redux.test.js`** — remove the `resetDeadlines` thunk test
  (thunk deleted; coverage → `apiHooks.test.tsx`).
- **`useIFrameBehavior.test.js`** — the old `dispatch(processEvent(...))` assertion
  is invalid; mock `usePostEvent` and assert the parse/guard → `mutate(...)` (and its
  `onSuccess` refresh) instead. **Test name kept** ("registers an event handler to
  process fetchCourse events") — the handler still ends in a `fetchCourse` refresh,
  so only the body changed; the name was never inaccurate.

## Verification

`nvm use && npm run types && npm run lint && npm test && npm run build` — all green:
types clean, lint clean, full suite 106 suites / 896 passing (3 pre-existing skips),
build succeeds. `git grep` for `setCallToActionToast` / `toastHeader` /
`toastBodyText` / `toastBodyLink` and for a surviving `resetDeadlines`/`processEvent`
thunk (or `index.js` re-export) both come back clean.

## Manual testing (seeding the toast triggers via edx-when)

Both toast triggers need a **self-paced course with a missed suggested-schedule
deadline**:
- **Dates/Outline tab "Shift due dates"** → the `resetDeadlines` path.
- **In-unit courseware CTA** → the `processEvent` / `post_event` path.

That state requires a graded subsection with a **relative** due date, which **can't
be set through the course-authoring MFE**: `frontend-app-authoring` PR #976
deliberately hid the release/due-date fields for self-paced courses and never added
a relative-date field (legacy Studio's `custom_relative_dates` UI wasn't ported).
So the data is seeded directly via **`edx-when`** in the CMS shell rather than
authored in Studio:

1. Enable `course_experience.relative_dates` (LMS waffle) for the course; confirm with `RELATIVE_DATES_FLAG.is_enabled(course_key)`.
2. Find the graded subsection key (`modulestore().get_course(ck)` → chapters → sequentials, pick the one with `graded == True`).
3. `edx_when.api.set_dates_for_course(ck, [(subsection, {'due': timedelta(weeks=1)})])`.
4. Backdate that enrollment's `Schedule.start_date` (~30 days) so the due date is in the past → `dates_banner_info.missed_deadlines: true` → the button appears.

**Do not re-publish the course afterward** — a publish re-syncs edx-when from the
blocks' own fields (which have no due date) and wipes the manually-seeded date.

Then compare **master vs. this branch**: identical toast header/action, identical
auto-hide + manual close, and the post-action data refresh (banner clears / dates
shift) still fires. The only intended differences are the two noted under the
decoupling section (content persists through the fade-out; failed POSTs now log).

**Verified** on both master and this branch (self-paced course, seeded as above).
Behavior matches, with one confirmed *improvement*: on master the toast text blanks
for a frame on auto-hide before fading (closing nulls the content while
`show={!!toastHeader}` is still animating out); on this branch the content persists
and it fades cleanly — a direct payoff of decoupling content from visibility.

Both writers were exercised end-to-end: the `resetDeadlines` path via the
dates-tab "Shift due dates" banner (master + branch), and the `usePostEvent`
`post_event` path via the LMS-rendered in-unit missed-deadlines banner (branch).

**Coverage caveat:** every manual run rendered a **reset-deadlines** payload —
a `header` with **no action link** (the local env has no endpoint that returns a
different CTA, and `post_event` in this setup also points at reset-deadlines). So
the message-**with-action** variant (`toastContent.action` → the Paragon action
button) was *not* observed by eye; it rests on the unit tests
(`apiHooks.test` maps `{ header, link, link_text }` → `action`, and its
"omits the toast action when the response has no link text" case; `TabPage.test`
renders the action label) plus Paragon owning the present/absent-action render.
Given `TabPage` maps it in one line (`action={toastContent?.action ?? null}`), the
risk is low, but note it wasn't manually confirmed.

</details>

## Plan

<details>
<summary>Implementation plan (as approved — the type was later renamed `ToastMessage` → `ToastContent` during implementation; see the decision log)</summary>

# Plan: Convert the CTA toast from Redux to a React `ToastProvider`

## Context

Part of the Redux → React Query migration (Stage 1, issue #1946), **Phase 3
(course-home)**, stacked on #1970. Standalone prerequisite PR *before* converting
any course-home tab.

**Why this first:** the course-home "call-to-action" toast is shared **client**
state. It lives in the `courseHome` Redux slice (`toastHeader` / `toastBodyText`
/ `toastBodyLink` + the `setCallToActionToast` reducer), is **read/rendered by
the shared `TabPage`**, and is **written by two places**:
- `resetDeadlines` thunk → dispatched from `ShiftDatesAlert` (course-home: dates + outline)
- `processEvent` thunk → dispatched from `useIFrameBehavior.ts` (**courseware** in-unit iframe)

Because `TabPage` is shared across every tab (and courseware), a tab can't be
"converted" while it still reaches Redux for the toast. So we extract the toast
first, then the tabs convert with no toast bridge.

This PR de-Redux-es the toast path end to end — **two moves**: (1) the toast
*client state* → a React `ToastProvider`; (2) the two POST *writers* that feed it
(`resetDeadlines`, `processEvent`) → React Query mutations whose `onSuccess` sets
the toast. The only Redux left in the path afterward is the transitional
`dispatch(getTabData)` refresh, which the later tab PRs turn into
`invalidateQueries`.

**Toast landscape (verified):** exactly **one** toast in the whole app — the
single Paragon `<Toast>` in `TabPage.jsx`, backed only by those slice members.
No other toast/notification state exists.

## Design: a general `ToastProvider` (state only)

There's exactly **one** toast in the app today (the landscape note above), so
this isn't about future reuse — it's extracting the one toast out of Redux. The provider
owns **only the toast state**; `TabPage` renders the single `<Toast>` reading
from it. (State in the provider, render in the consumer — same split as
`CoursewareSearchContext`.) It's named `ToastProvider`/`useToast` rather than
`CTAToast…` simply because nothing in the mechanism is CTA-specific — it holds a
`ToastMessage` and renders whatever it's handed — not because we're pre-building
for hypothetical future toasts.

**Framing:** the Redux slice today fuses content and visibility — one
`show={!!toastHeader}` derivation, cleared together to close. That fusion is the
wart we're removing, **not** relocating into the provider. In the new design the
message and the open/closed state are **fully independent**:
- `toastMessage: ToastMessage | null` — the current notification content, written/cleared on its own.
- `isToastOpen: boolean` — whether the `<Toast>` is showing, opened/closed on its own.

Nothing couples them: setting the message does **not** open the toast, and
closing does **not** clear the message. A writer that wants to surface a
notification does two explicit things — `setToastMessage(...)` then `openToast()`
(e.g. an RQ mutation's `onSuccess` calls both). Paragon's auto-hide and the close
button both fire `onClose`, wired to `closeToast`, which only flips `isToastOpen`
— the content stays in place so the toast fades out with content, not blank.

**Shape — derived from the real APIs, not invented:**
- Paragon `<Toast>` (`node_modules/@openedx/paragon/dist/Toast/index.js`) takes `children`, `action` (`{ label, href?, onClick? }`), `show`, `onClose`, `closeLabel` (defaults to intl "Close"), `delay`.
- `TabPage` currently passes `children=toastHeader`, `action={ label: toastBodyText, href: toastBodyLink }`, `show=!!toastHeader`.
- Only `children` + `action` carry per-toast content; `show` is derived and the rest are constant. So the stored payload is exactly:

```ts
interface ToastMessage {
  message: React.ReactNode;                                        // → Toast children
  action?: { label: string; href?: string; onClick?: () => void }; // → Toast action (Paragon's own shape)
}
```

## Approach

**New** `src/generic/ToastContext.tsx` (TypeScript; mirrors `CoursewareSearchContext`
— `useState` + `useMemo`, hook throws outside provider):
- `ToastProvider` holds two **independent** state pieces and renders only `{children}` (no `<Toast>`):
  ```tsx
  const [toastMessage, setToastMessage] = useState<ToastMessage | null>(null);
  const [isToastOpen, setIsToastOpen] = useState(false);
  const value = useMemo(() => ({
    toastMessage, setToastMessage, isToastOpen,
    openToast:  () => setIsToastOpen(true),
    closeToast: () => setIsToastOpen(false),
  }), [toastMessage, isToastOpen]);
  ```
- `useToast()` → `{ toastMessage, setToastMessage, isToastOpen, openToast, closeToast }`. `toast`-prefixed names so they read correctly destructured from a general hook (`isOpen`/`show` would be ambiguous at the call site).

**Provider placement** — mounted once at the route root in `src/index.jsx`,
wrapping `<Routes>` (the only common ancestor of both `TabPage` parents:
`TabContainer` and `CoursewareContainer`, which renders `TabPage` directly).

**`TabPage.jsx` renders the `<Toast>` from context** — keeps the render and its
`Toast`/`genericMessages` imports; only the source swaps from Redux to `useToast()`:
```tsx
const { toastMessage, isToastOpen, closeToast } = useToast();
<Toast show={isToastOpen} onClose={closeToast} action={toastMessage?.action}
  closeLabel={intl.formatMessage(genericMessages.close)}>
  {toastMessage?.message}
</Toast>
```
Drop the `useSelector(state.courseHome)` toast fields and the `setCallToActionToast`
dispatch. (Leave its `errorMessage`/`courseHomeMeta` reads — out of scope.)

**Writers → React Query mutations** — the two thunks are fire-and-forget POSTs
(`.then` not awaited, no `.catch`) that on success `dispatch(getTabData(courseId))`
then `dispatch(setCallToActionToast(...))`. These are server-state calls, so they
become **mutations** in a new `src/course-home/data/apiHooks.ts` (first RQ hook in
that folder), following the only established mutation recipe in the repo
(`src/product-tours/data/apiHooks.ts`): `useMutation` → `mutationFn` calls the
existing `api.js` fn → `onSuccess(_data, vars)` → `onError: logError`. Reuse the
existing `postCourseDeadlines` / `executePostFromPostEvent` in `api.js` unchanged.

The **hook owns only the permanent behavior — POST + toast — and has zero Redux
in it**:

```ts
const toastFrom = ({ header, link, link_text: linkText }) => ({
  message: header,
  action: linkText ? { label: linkText, href: link } : undefined,
});

export const useResetDeadlines = () => {
  const { setToastMessage, openToast } = useToast();
  return useMutation({
    mutationFn: ({ courseId, model }) => postCourseDeadlines(courseId, model),
    onSuccess: ({ data }) => { setToastMessage(toastFrom(data)); openToast(); },
    onError: logError,
  });
};
// usePostEvent: same shape; mutationFn: ({ postData, researchEventData }) => executePostFromPostEvent(postData, researchEventData)
```

`onSuccess` is exactly the decoupled "two things" (`setToastMessage` then `openToast`).
No `queryKeys.ts`/`useQueryClient` yet — nothing RQ to invalidate until the data converts.

**Transitional refresh lives in the caller, not the hook** — the success refresh
(`fetchDatesTab`/`fetchOutlineTab`/`fetchCourse`) writes into the **Redux model
store**, which isn't converted until the later tab/courseware PRs. So the caller
fires it as a per-call `mutate(vars, { onSuccess })`; both `onSuccess`es run (the
hook's toast first, then the caller's refresh). This keeps the new `apiHooks.ts`
Redux-free from day one: when that data becomes an RQ query, you delete the one
caller line (or swap it for `invalidateQueries`) and never touch the hook.

**Call sites** (each already uses `useDispatch` today):
- `src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx`: `const resetDeadlines = useResetDeadlines();` → `onClick={() => resetDeadlines.mutate({ courseId, model }, { onSuccess: () => dispatch(fetch(courseId)) })}` (`model`/`fetch` props unchanged; `dispatch` from the existing `useDispatch`).
- `src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts`: `const postEvent = usePostEvent();`. The postMessage parse/guard that lived in `processEvent` (raw `research_event_data`, `camelCaseObject`, `eventName === POST_EVENT`) moves into the `window.onmessage` handler, which then calls `postEvent.mutate({ postData, researchEventData }, { onSuccess: () => dispatch(fetchCourse(postData.bodyParams.courseId)) })`. `eventTypes` is exported from `thunks.js` (or relocated) for the guard. **This PR therefore touches the courseware iframe hook, not only course-home.**

**Delete** `resetDeadlines` + `processEvent` from `thunks.js` and their `index.js`
re-exports; delete `setCallToActionToast` + the three toast fields from `slice.js`.

**Slice cleanup** — `src/course-home/data/slice.js`: remove `toastHeader` /
`toastBodyText` / `toastBodyLink` from initial state and the `setCallToActionToast`
reducer + export.

## Files

- **new** `src/generic/ToastContext.tsx` (+ `ToastContext.test.tsx`)
- **new** `src/course-home/data/apiHooks.ts` (+ `apiHooks.test.tsx`) — `useResetDeadlines`, `usePostEvent` mutations
- `src/index.jsx` — wrap `<Routes>` in `<ToastProvider>`
- `src/tab-page/TabPage.jsx` — render `<Toast>` from `useToast()` instead of the `state.courseHome` reads
- `src/course-home/data/thunks.js` — delete `resetDeadlines` + `processEvent`; export `eventTypes` for the iframe guard
- `src/course-home/data/index.js` — drop the `resetDeadlines` re-export
- `src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx` — `useResetDeadlines().mutate(...)`
- `src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts` — parse/guard + `usePostEvent().mutate(...)`
- `src/course-home/data/slice.js` — remove `setCallToActionToast` + the three toast fields
- Tests:
  - **new** `src/course-home/data/apiHooks.test.tsx` — `renderHook` + `mutate(...)` for `useResetDeadlines`/`usePostEvent`: assert the POST args and the toast calls (`setToastMessage`/`openToast`). The `getTabData` refresh is now the caller's concern, so it's asserted in the call-site tests below, not here. Absorbs the old `redux.test.js` `resetDeadlines` POST coverage.
  - `src/setupTest.js` — add `<ToastProvider>` to the shared `render()` wrapper (TabPage now calls `useToast`).
  - `src/course-home/dates-tab/DatesTab.test.jsx` — add `<ToastProvider>` to its own `component` wrapper; its "Shift due dates" → Toast assertion now runs through `useResetDeadlines` + the provider render.
  - `src/tab-page/TabPage.test.jsx` — wrap in `<ToastProvider>`; TabPage still renders the Toast (now fed from context), so its toast assertions stay.
  - `src/course-home/data/slice.test.js` — drop the toast initial-state fields + the `setCallToActionToast` reducer test.
  - `src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js` — the `dispatch(processEvent(...))` assertion (~line 357) is now invalid; mock `usePostEvent` and assert the parse/guard → `mutate(...)` instead.
  - `src/course-home/data/redux.test.js` — remove the `resetDeadlines` thunk test (thunk deleted; coverage moves to `apiHooks.test.tsx`).
- `decisions.md` (repo root, untracked) — decision log for the PR body: single-toast finding; general **state-only** `ToastProvider`, `TabPage` renders; message and open/close state **decoupled** (no auto-open on set); shape derived from Paragon's Toast API; writers → RQ mutations owning only POST + toast (Redux-free), with the transitional model-store refresh kept in the caller's `mutate` `onSuccess` so the hook never carries Redux; and why this touches the courseware iframe hook.

## Verification

- `nvm use && npm run types && npm run lint && npm test` (targeted first: `TabPage`, `DatesTab`, `slice`, `redux`, `useIFrameBehavior`, new `ToastContext` and `apiHooks` tests), then `npm run build`.
- `git grep -n "setCallToActionToast\|toastHeader\|toastBodyText\|toastBodyLink" src` → none in source; slice carries no toast state.
- `git grep -n "resetDeadlines\|processEvent" src` → only the new `apiHooks.ts` (`useResetDeadlines`/`usePostEvent`) and its callers/tests; no surviving thunk or `index.js` re-export.
- Manual smoke (dev, dates or outline tab with a missed deadline): click **Shift due dates** → Toast appears with the success header + action link and closes; button disappears after refetch. Confirm the in-unit courseware POST_EVENT path still toasts.
- Then `gh stack add` onto #1970, open the stacked PR as a draft, improve coverage, mark ready on your go.

</details>

Closes #1980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
