### PR TITLE
refactor: convert TabPage to TypeScript

### DIFF
--- a/src/tab-page/TabPage.test.jsx
+++ b/src/tab-page/TabPage.test.jsx
@@ -24,6 +24,7 @@ const mockUseToast = (overrides = {}) => useToast.mockReturnValue({
 
 describe('Tab Page', () => {
   const mockData = {
+    courseId: 'test-course',
     courseStatus: 'loaded',
   };
 

--- a/src/tab-page/TabPage.tsx
+++ b/src/tab-page/TabPage.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { type ReactNode } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom';
@@ -11,6 +10,10 @@ import PageLoading from '../generic/PageLoading';
 import { getAccessDeniedRedirectUrl } from '../shared/access';
 import { useModel } from '../generic/model-store';
 import { useToast } from '../generic/ToastContext';
+import type { RootState } from '../store';
+import {
+  LOADING, LOADED, DENIED, type StatusValue,
+} from '../constants';
 
 import genericMessages from '../generic/messages';
 import messages from './messages';
@@ -18,20 +21,30 @@ import LoadedTabPage from './LoadedTabPage';
 import LaunchCourseHomeTourButton from '../product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton';
 import { TourProvider } from '../product-tours/TourContext';
 
-const TabPage = (props) => {
+interface TabPageProps {
+  activeTabSlug: string;
+  courseId?: string;
+  courseStatus: StatusValue;
+  metadataModel: string;
+  unitId?: string;
+  children?: ReactNode;
+}
+
+const TabPage = ({
+  activeTabSlug,
+  courseId,
+  courseStatus,
+  metadataModel,
+  unitId,
+  children,
+}: TabPageProps) => {
   const intl = useIntl();
   const {
-    activeTabSlug,
-    courseId,
-    courseStatus,
-    metadataModel,
-  } = props;
-  const {
     errorMessage: courseHomeErrorMessage,
-  } = useSelector(state => state.courseHome);
+  } = useSelector((state: RootState) => state.courseHome);
   const {
     errorMessage: coursewareErrorMessage,
-  } = useSelector(state => state.courseware);
+  } = useSelector((state: RootState) => state.courseware);
   const errorMessage = courseHomeErrorMessage || coursewareErrorMessage;
   const { toastContent, isToastOpen, closeToast } = useToast();
   const {
@@ -42,7 +55,7 @@ const TabPage = (props) => {
     title,
   } = useModel('courseHomeMeta', courseId);
 
-  if (courseStatus === 'denied') {
+  if (courseStatus === DENIED) {
     const redirectUrl = getAccessDeniedRedirectUrl(courseId, activeTabSlug, courseAccess, start);
     if (redirectUrl) {
       return (<Navigate to={redirectUrl} replace />);
@@ -51,15 +64,15 @@ const TabPage = (props) => {
 
   return (
     <TourProvider>
-      {['loaded', 'denied'].includes(courseStatus) && (
+      {(courseStatus === LOADED || courseStatus === DENIED) && (
         <>
           <Toast
-            action={toastContent?.action ?? null}
+            action={toastContent?.action}
             closeLabel={intl.formatMessage(genericMessages.close)}
             onClose={closeToast}
             show={isToastOpen}
           >
-            {toastContent?.message}
+            {toastContent?.message ?? ''}
           </Toast>
           {metadataModel === 'courseHomeMeta' && (<LaunchCourseHomeTourButton srOnly />)}
         </>
@@ -67,16 +80,23 @@ const TabPage = (props) => {
 
       <HeaderSlot courseOrg={org} courseNumber={number} courseTitle={title} />
 
-      {courseStatus === 'loading' && (
+      {courseStatus === LOADING && (
         <PageLoading srMessage={intl.formatMessage(messages.loading)} />
       )}
 
-      {['loaded', 'denied'].includes(courseStatus) && (
-        <LoadedTabPage {...props} />
+      {(courseStatus === LOADED || courseStatus === DENIED) && courseId && (
+        <LoadedTabPage
+          activeTabSlug={activeTabSlug}
+          courseId={courseId}
+          metadataModel={metadataModel}
+          unitId={unitId}
+        >
+          {children}
+        </LoadedTabPage>
       )}
 
       {/* courseStatus 'failed' and any other unexpected course status. */}
-      {(!['loading', 'loaded', 'denied'].includes(courseStatus)) && (
+      {courseStatus !== LOADING && courseStatus !== LOADED && courseStatus !== DENIED && (
         <p className="text-center py-5 mx-auto" style={{ maxWidth: '30em' }}>
           {errorMessage || intl.formatMessage(messages.failure)}
         </p>
@@ -84,19 +104,6 @@ const TabPage = (props) => {
       <FooterSlot />
     </TourProvider>
   );
-};
-
-TabPage.defaultProps = {
-  courseId: null,
-  unitId: null,
-};
-
-TabPage.propTypes = {
-  activeTabSlug: PropTypes.string.isRequired,
-  courseId: PropTypes.string,
-  courseStatus: PropTypes.string.isRequired,
-  metadataModel: PropTypes.string.isRequired,
-  unitId: PropTypes.string,
 };
 
 export default TabPage;


### PR DESCRIPTION
## Summary

Converts the shared `src/tab-page/TabPage.jsx` → `TabPage.tsx` as a **standalone, behavior-preserving** refactor. Part of the Redux → React Query migration (#1946), Phase 3 (course-home), **stacked on the CTA-toast conversion** (#1982, the branch below). Tracked by #1985.

Isolating the mechanical `.jsx → .tsx` conversion in its own layer keeps it a clean, reviewable diff — so later course-home changes to `TabPage` build on an already-TypeScript component instead of mixing a conversion together with feature changes.

Principle: a **pure conversion** — only the changes TypeScript actually forces. Structure, control flow, the string-status constants, and the destructured props signature are kept as-is, so the diff reads ~1:1.

## What changed

- **`TabPage.jsx` → `TabPage.tsx`:** typed `TabPageProps` (`courseId?`/`unitId?` optional, `courseStatus: StatusValue`, `children?: ReactNode`); structure and control flow unchanged.
- **Typed selectors:** the two `useSelector` reads use the store's exported `RootState` (`ReturnType<typeof store.getState>`), imported type-only — not a bespoke interface or a `Partial`.
- **The `&& courseId` guard** (the one behavior-adjacent change): `LoadedTabPage` requires `courseId: string`, but `TabPage`'s `courseId` is optional (`null` until the course loads). Rendering it under `&& courseId` narrows the type to `string` **without a cast and without loosening `LoadedTabPage`'s contract**. Behavior-identical in the app — `loaded`/`denied` always imply a `courseId`.
- **Status checks:** kept the `LOADING`/`LOADED`/`DENIED` constants, compared with `===` — not `[].includes`, which won't type-check against literal-typed constants without an `as StatusValue[]` cast.
- **Dependency in #1982 (below):** `ToastContent.message` is narrowed `ReactNode → string` there so Paragon's string-only `<Toast>` slot type-checks once `TabPage` is TypeScript. It lives in the toast PR because that's where `ToastContext` is introduced, and the mismatch only surfaces once `TabPage` is TS.

## Testing

`nvm use && npm run types && npm run lint && npm test` — all green. `TabPage.test.jsx` passes 7/7; its one unrealistic `{ courseStatus: 'loaded' }` fixture (no `courseId`) gains a realistic `courseId: 'test-course'` so the "displays Loaded Tab Page" test still asserts `LoadedTabPage` renders under the `&& courseId` guard. Git records the file as a rename (`TabPage.jsx` → `TabPage.tsx`, ~65% similarity). No behavior change.

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — convert `TabPage` to TypeScript

Working notes for this PR (untracked; referenced when opening the PR). Part of the
Redux → React Query migration (#1946). This is a **standalone conversion PR**: it
converts `TabPage.jsx` → `TabPage.tsx` with no behavior change, isolated in its own
layer so later course-home changes to `TabPage` build on an already-TypeScript
component (a small, reviewable diff instead of a conversion + feature change tangled
together).

**Principle:** a pure conversion — only the changes TypeScript actually forces.
Structure, control flow, string-status constants, and the destructured props
signature are kept as-is so the diff reads 1:1.

## The `&& courseId` guard (the one behavior-adjacent change — needs justifying)

`LoadedTabPage` requires `courseId: string`, but `TabPage`'s `courseId` is
**optional** (`string | undefined`): its callers (`TabContainer`,
`CoursewareContainer`) pass it from Redux, where it's `null` until the course
loads, and the original `propTypes` declared it optional. The original rendered
`<LoadedTabPage {...props} />` on loaded/denied **unconditionally** — fine in JS
(untyped spread), a type error in TS (optional → required).

**Decision.** Render `LoadedTabPage` only when `courseId` is present:
```tsx
{(courseStatus === LOADED || courseStatus === DENIED) && courseId && (
  <LoadedTabPage activeTabSlug={activeTabSlug} courseId={courseId} … />
)}
```
The `&& courseId` narrows `courseId` to `string`, satisfying `LoadedTabPage`'s
required prop **without a cast and without loosening its contract**.

**Behavior.** In the app, `loaded`/`denied` always imply a `courseId`, so
`LoadedTabPage` renders exactly as before. The only case that differs is a
`loaded`-with-no-`courseId` state, which doesn't occur in production.
`TabPage.test.jsx` had one such *unrealistic* fixture (`{ courseStatus: 'loaded' }`
with no `courseId`); it now includes a realistic `courseId: 'test-course'` (a
loaded tab always has a course), so the "displays Loaded Tab Page" test still
asserts `LoadedTabPage` renders.

**Rejected:**
- `courseId={courseId as string}` / `{...(props as LoadedTabPageProps)}` — a cast
  that asserts a non-null the type doesn't guarantee.
- Making `LoadedTabPage.courseId` optional — loosens a component that genuinely
  needs a `courseId` (it fetches course metadata by it).

## Toast typing (two Paragon `<Toast>` mismatches the `.jsx` masked)

- **`children: string` vs `ToastContent.message: ReactNode`.** Fixed at the
  source, not with a cast: narrowed **`ToastContent.message` to `string`** in
  `ToastContext.tsx`. It's only ever set to the API `header` (a string) and it
  feeds a `string`-only Paragon slot, so `ReactNode` was an over-broad type. Render
  is `{toastContent?.message ?? ''}` — the `?? ''` supplies the required `string`
  when there's no toast. (This edit lives in the toast PR **#1982** directly below,
  since that's where `ToastContext` is introduced; the mismatch only surfaces once
  `TabPage` is TS, so it's carried in that layer.)
- **`action?: ToastAction` (no `null`) vs the original `action={… ?? null}`.**
  Dropped the `?? null` → `action={toastContent?.action}`. `toastContent?.action`
  is `ToastAction | undefined` (optional chaining never yields `null`, and
  `action?:` is `… | undefined`), so it's equivalent to the old value and matches
  Paragon's optional prop.

## `useSelector` typing → the store's real `RootState`

Typed the selector state with `RootState` (`ReturnType<typeof store.getState>`,
already exported from `src/store.ts`), imported **type-only**
(`import type { RootState } from '../store'`). Kept the original destructure form
— `const { errorMessage: courseHomeErrorMessage } = useSelector((state: RootState) => state.courseHome)`
— rather than a bespoke interface or a `Partial<RootState>` (not a partial: we
want those slices present).

## Status checks: constants + `===` (not `[].includes`)

Kept the existing `LOADING`/`LOADED`/`DENIED` constants and compared with `===`.
Did **not** keep the original `['loaded','denied'].includes(courseStatus)` idiom:
the constants are literal-typed, so `[LOADED, DENIED]` infers as
`('loaded' | 'denied')[]` and `.includes(courseStatus: StatusValue)` won't
type-check (it'd need an `as StatusValue[]` cast). The original only worked because
bare string literals widen to `string[]`. `===` keeps the constants with no cast.
No `showContent`-style helper — the two-value check is inlined in the two places it
appears.

## Type-only imports

`import type { RootState }` (whole import is a type); inline `type` for
`StatusValue` (shares the `constants` value import) and `ReactNode` (shares the
`react` default value import).

## Verification

`npm run types` / `lint` / `test` all green; `TabPage.test.jsx` 7/7. `TabPage.jsx`
is removed (git records a rename to `TabPage.tsx`, ~65% similarity). No behavior
change.

</details>

Closes #1985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
