### PR TITLE
refactor: simplify the course-home tour button

### DIFF
--- a/src/course-home/dates-tab/DatesTab.jsx
+++ b/src/course-home/dates-tab/DatesTab.jsx
@@ -49,7 +49,6 @@ const DatesTab = () => {
       activeTabSlug="dates"
       courseId={courseId}
       courseStatus={{ metadataQuery, tabDataQuery }}
-      metadataModel="courseHomeMeta"
     >
       <div role="heading" aria-level="1" className="h2 my-3">
         {intl.formatMessage(messages.title)}

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -666,7 +666,7 @@ describe('Outline Tab', () => {
           },
         });
         await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
-        await act(async () => render(<TourProvider><LoadedTabPage metadataModel="courseHomeMeta" courseId={courseId} activeTabSlug="outline">...</LoadedTabPage></TourProvider>, { store }));
+        await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="outline">...</LoadedTabPage></TourProvider>, { store }));
         const instructorToolbar = await screen.getByTestId('instructor-toolbar');
         expect(instructorToolbar).toBeInTheDocument();
         expect(screen.getByText('This learner no longer has access to this course. Their access expired on', { exact: false })).toBeInTheDocument();
@@ -682,7 +682,7 @@ describe('Outline Tab', () => {
           },
         });
         await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
-        await act(async () => render(<TourProvider><LoadedTabPage metadataModel="courseHomeMeta" courseId={courseId} activeTabSlug="outline">...</LoadedTabPage></TourProvider>, { store }));
+        await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="outline">...</LoadedTabPage></TourProvider>, { store }));
         const instructorToolbar = await screen.getByTestId('instructor-toolbar');
         expect(instructorToolbar).toBeInTheDocument();
         expect(screen.queryByText('This learner no longer has access to this course. Their access expired on', { exact: false })).not.toBeInTheDocument();

--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -1432,7 +1432,7 @@ describe('Progress Tab', () => {
         },
       });
       await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage metadataModel="courseHomeMeta" courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
       expect(screen.getByTestId('instructor-toolbar')).toBeInTheDocument();
       expect(screen.getByText('This learner no longer has access to this course. Their access expired on', { exact: false })).toBeInTheDocument();
       expect(screen.getByText('1/1/2020', { exact: false })).toBeInTheDocument();
@@ -1446,7 +1446,7 @@ describe('Progress Tab', () => {
         },
       });
       await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage metadataModel="courseHomeMeta" courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
       expect(screen.queryByText('This learner no longer has access to this course. Their access expired on', { exact: false })).not.toBeInTheDocument();
       expect(screen.queryByText('1/1/2020', { exact: false })).not.toBeInTheDocument();
     });
@@ -1461,7 +1461,7 @@ describe('Progress Tab', () => {
         start: '2999-01-01T00:00:00Z',
       });
       await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage metadataModel="courseHomeMeta" courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
       expect(screen.getByTestId('instructor-toolbar')).toBeInTheDocument();
       expect(screen.getByText('This learner does not yet have access to this course. The course starts on', { exact: false })).toBeInTheDocument();
       expect(screen.getByText('1/1/2999', { exact: false })).toBeInTheDocument();
@@ -1474,7 +1474,7 @@ describe('Progress Tab', () => {
         start: '2999-01-01T00:00:00Z',
       });
       await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage metadataModel="courseHomeMeta" courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
       expect(screen.queryByText('This learner does not yet have access to this course. The course starts on', { exact: false })).not.toBeInTheDocument();
       expect(screen.queryByText('1/1/2999', { exact: false })).not.toBeInTheDocument();
     });

--- a/src/courseware/CoursewareContainer.jsx
+++ b/src/courseware/CoursewareContainer.jsx
@@ -345,7 +345,6 @@ class CoursewareContainer extends Component {
         courseId={courseId}
         unitId={routeUnitId}
         courseStatus={courseStatus}
-        metadataModel="coursewareMeta"
       >
         <Course
           courseId={courseId}

--- a/src/product-tours/ProductTours.test.jsx
+++ b/src/product-tours/ProductTours.test.jsx
@@ -65,7 +65,7 @@ describe('Course Home Tours', () => {
     await executeThunk(courseHomeThunks.fetchOutlineTab(courseId), store.dispatch);
     render(
       <TourProvider>
-        <LoadedTabPage metadataModel="courseHomeMeta" courseId={courseId} activeTabSlug="outline">
+        <LoadedTabPage courseId={courseId} activeTabSlug="outline">
           <OutlineTab />
         </LoadedTabPage>
       </TourProvider>,

--- a/src/product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton.jsx
+++ b/src/product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -15,9 +15,7 @@ import messages from '../messages';
 
 const LaunchCourseHomeTourButton = ({ srOnly }) => {
   const intl = useIntl();
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
 
   const {
     org,

--- a/src/shared/streak-celebration/StreakCelebrationModal.jsx
+++ b/src/shared/streak-celebration/StreakCelebrationModal.jsx
@@ -54,7 +54,7 @@ const CloseText = ({ intl }) => (
 );
 
 const StreakModal = ({
-  courseId, metadataModel, streakLengthToCelebrate, isStreakCelebrationOpen,
+  courseId, streakLengthToCelebrate, isStreakCelebrationOpen,
   closeStreakCelebration, streakDiscountCouponEnabled, verifiedMode, ...rest
 }) => {
   const intl = useIntl();
@@ -247,7 +247,6 @@ StreakModal.defaultProps = {
 
 StreakModal.propTypes = {
   courseId: PropTypes.string.isRequired,
-  metadataModel: PropTypes.string.isRequired,
   streakLengthToCelebrate: PropTypes.number,
   isStreakCelebrationOpen: PropTypes.bool,
   closeStreakCelebration: PropTypes.func.isRequired,

--- a/src/shared/streak-celebration/StreakCelebrationModal.test.jsx
+++ b/src/shared/streak-celebration/StreakCelebrationModal.test.jsx
@@ -61,7 +61,6 @@ describe('Loaded Tab Page', () => {
       closeStreakCelebration: jest.fn(),
       courseId: courseMetadata.id,
       isStreakCelebrationOpen: true,
-      metadataModel: 'coursewareMeta',
       streakLengthToCelebrate: 3,
       verifiedMode: camelCaseObject(courseHomeMetadata.verified_mode),
     };

--- a/src/tab-page/LoadedTabPage.test.jsx
+++ b/src/tab-page/LoadedTabPage.test.jsx
@@ -17,7 +17,7 @@ jest.mock('../product-tours/ProductTours', () => function () {
 });
 
 describe('Loaded Tab Page', () => {
-  const mockData = { activeTabSlug: 'courseware', metadataModel: 'coursewareMeta' };
+  const mockData = { activeTabSlug: 'courseware' };
 
   beforeAll(async () => {
     const store = await initializeTestStore({ excludeFetchSequence: true });

--- a/src/tab-page/LoadedTabPage.tsx
+++ b/src/tab-page/LoadedTabPage.tsx
@@ -19,7 +19,6 @@ interface LoadedTabPageProps {
   activeTabSlug: string;
   children?: React.ReactNode;
   courseId: string;
-  metadataModel: string;
   unitId?: string | null;
 }
 
@@ -27,7 +26,6 @@ const LoadedTabPage = ({
   activeTabSlug,
   children = null,
   courseId,
-  metadataModel,
   unitId = null,
 }: LoadedTabPageProps) => {
   const {
@@ -72,7 +70,6 @@ const LoadedTabPage = ({
       )}
       <StreakModal
         courseId={courseId}
-        metadataModel={metadataModel}
         streakLengthToCelebrate={streakLengthToCelebrate}
         isStreakCelebrationOpen={!!isStreakCelebrationOpen}
         closeStreakCelebration={closeStreakCelebration}

--- a/src/tab-page/TabContainer.jsx
+++ b/src/tab-page/TabContainer.jsx
@@ -39,7 +39,6 @@ const TabContainer = (props) => {
       activeTabSlug={tab}
       courseId={courseId}
       courseStatus={courseStatus}
-      metadataModel={`${slice}Meta`}
     >
       {children}
     </TabWithTimer>

--- a/src/tab-page/TabPage.test.jsx
+++ b/src/tab-page/TabPage.test.jsx
@@ -11,6 +11,10 @@ jest.mock('./LoadedTabPage', () => function () {
   return <div data-testid="LoadedTabPage" />;
 });
 
+jest.mock('../product-tours/newUserCourseHomeTour/LaunchCourseHomeTourButton', () => function () {
+  return <div data-testid="sr-tour-button" />;
+});
+
 jest.mock('../generic/ToastContext', () => ({
   ...jest.requireActual('../generic/ToastContext'),
   useToast: jest.fn(),
@@ -96,6 +100,16 @@ describe('Tab Page', () => {
   it('displays Loaded Tab Page', () => {
     render(<TabPage {...mockData} />, { wrapWithRouter: true });
     expect(screen.getByTestId('LoadedTabPage')).toBeInTheDocument();
+  });
+
+  it('renders the screen-reader tour button on the outline tab', () => {
+    render(<TabPage {...mockData} activeTabSlug="outline" />, { wrapWithRouter: true });
+    expect(screen.getByTestId('sr-tour-button')).toBeInTheDocument();
+  });
+
+  it('does not render the tour button on other tabs', () => {
+    render(<TabPage {...mockData} activeTabSlug="dates" />, { wrapWithRouter: true });
+    expect(screen.queryByTestId('sr-tour-button')).not.toBeInTheDocument();
   });
 
   describe('React Query courseStatus', () => {

--- a/src/tab-page/TabPage.tsx
+++ b/src/tab-page/TabPage.tsx
@@ -34,7 +34,6 @@ export interface TabPageProps {
   activeTabSlug: string;
   courseId?: string;
   courseStatus: CourseStatus;
-  metadataModel: string;
   unitId?: string;
   children?: ReactNode;
 }
@@ -71,7 +70,6 @@ const TabPage = ({
   activeTabSlug,
   courseId,
   courseStatus,
-  metadataModel,
   unitId,
   children,
 }: TabPageProps) => {
@@ -116,8 +114,12 @@ const TabPage = ({
     </Toast>
   );
 
-  const renderTourButton = () => {
-    if (metadataModel !== 'courseHomeMeta') { return null; }
+  // The outline page renders a visible "launch tour" button deep in the DOM; no other tab
+  // renders it. For screen-reader users we render a screen-reader-only copy above the header,
+  // where it won't be buried (a11y rationale:
+  // https://github.com/openedx/frontend-app-learning/pull/750#discussion_r755536879).
+  const renderSrOnlyTourButton = () => {
+    if (activeTabSlug !== 'outline') { return null; }
     return (<LaunchCourseHomeTourButton srOnly />);
   };
 
@@ -131,7 +133,6 @@ const TabPage = ({
       <LoadedTabPage
         activeTabSlug={activeTabSlug}
         courseId={courseId}
-        metadataModel={metadataModel}
         unitId={unitId}
       >
         {children}
@@ -148,7 +149,7 @@ const TabPage = ({
   return (
     <TourProvider>
       {shouldRenderContent && renderToast()}
-      {shouldRenderContent && renderTourButton()}
+      {shouldRenderContent && renderSrOnlyTourButton()}
       <HeaderSlot courseOrg={org} courseNumber={number} courseTitle={title} />
       {isLoading && renderLoading()}
       {shouldRenderContent && renderLoadedTabPage()}


### PR DESCRIPTION
## Summary

Simplify the course-home tour button on the shared `TabPage` by removing the vestigial `metadataModel` prop. Part of the Redux → React Query migration (#1946); a small, **behavior-preserving** refactor that lands **below the outline-tab conversion (#1991)** so outline builds on the cleaned-up `TabPage` and inherits the `courseId` fix. Closes #1992.

Investigation showed the screen-reader-only launch-tour button `TabPage` renders is **only ever real on the outline tab**: the tour data is fetched only on outline/courseware (long-standing — predates the React Query migration), and course tabs are full page loads, so nothing warms across tabs. `metadataModel` was a boolean-in-disguise ("is course-home") whose only live effect was gating that button, plus dead threading into `LoadedTabPage` → `StreakCelebrationModal`.

## What changed

- **`TabPage`:** gate the srOnly launch button on `activeTabSlug === 'outline'` — the tab identity `TabPage` already has (it uses it for the access-denied redirect) — instead of `metadataModel === 'courseHomeMeta'`. Rename `renderTourButton` → `renderSrOnlyTourButton`, and remove the `metadataModel` prop. The above-the-header placement (the a11y intent) is unchanged.
- **`metadataModel` removed end to end:** from `LoadedTabPage` and its dead pass-through to `StreakCelebrationModal` (declared required, never read), and from the `DatesTab` / `CoursewareContainer` / `TabContainer` call sites.
- **`LaunchCourseHomeTourButton`:** `courseId` moves from the `courseHome` Redux slice to `useParams`, so the visible outline button keeps a real `courseId` once a converted tab stops populating the slice.

## Behavior

No user-facing change. The srOnly button already only *materialized* on outline (full page loads keep it inert everywhere else), so gating the mount to outline matches reality, and it still renders above the header. The gate behaves identically whether outline is `TabContainer`-rendered or self-wrapped — both pass `activeTabSlug="outline"`.

## Testing

`npm run types`, `npm run lint`, and the full `npm test` suite (106 suites, 902 passing, 3 pre-existing skips) pass. `TabPage.test.jsx` gains two tests for the new gate (renders the srOnly button on outline, not on other tabs); the call-site test fixtures drop the removed `metadataModel` prop.

## Decisions

<details>
<summary>Full decision log</summary>

# Findings — what actually renders the course-home tour button

Decision doc for the tour-button cleanup PR — **#1993** (sub-issue #1992):
removes the vestigial `metadataModel` prop and moves the button's `courseId` off
the Redux slice. **Not checked in.** The behavior described below is `master` as
of the investigation; the "Agreed cleanup approach" section is what shipped.

## The two render sites of `LaunchCourseHomeTourButton`

1. **Visible** — `course-home/outline-tab/widgets/CourseTools.jsx` renders
   `<LaunchCourseHomeTourButton />`. `CourseTools` is rendered **only by the
   outline tab**, so the visible button is outline-only.
2. **Screen-reader-only** — `tab-page/TabPage.tsx` `renderTourButton()` renders
   `<LaunchCourseHomeTourButton srOnly />`, gated by
   `metadataModel === 'courseHomeMeta'` (i.e. all course-home tabs, not
   courseware) and `shouldRenderContent`. It's placed **above `<HeaderSlot>`**
   in the DOM — deliberate reading-order placement inherited from #775 (see
   History).

## What decides whether the button emits any DOM

`LaunchCourseHomeTourButton` wraps its entire output in `{toursEnabled && (…)}`
— when `toursEnabled` is falsy it mounts (its hooks run) but renders an **empty
fragment** (no DOM).

`toursEnabled` chain:
- `toursEnabled = tourData?.toursEnabled`, where `tourData` comes from
  `useTourData(username, false)` — **a disabled query**. The button never
  fetches; it only reads the shared cache entry (`tourQueryKeys.user(username)`).
- The only thing that *fetches* that entry is `ProductTours` via
  `useTourData(username, shouldFetchTourData())`.
- `shouldFetchTourData()` (in `ProductTours.jsx`) is true only when:
  authenticated **AND** the active tab is **outline or courseware** **AND**
  (on outline) `proctoringPanelStatus === 'loaded'`. Its own comment: *"Tours
  only exist on the Outline and Courseware tabs, so avoid calling the tour
  endpoint on any other tab."*
- `getTourData` (`/api/user_tours/v1/{username}`) → `{ toursEnabled: true, … }`
  on 200; `{ toursEnabled: false }` on 401/403/404 (403 = tour waffle flag off).

## The navigation model is the key fact

Course tabs are plain anchors: `course-tabs/CourseTabLink.tsx` renders
`<a href={url}>` where `url` is the backend-supplied `courseHomeMeta.tabs[].url`
(a full URL — tabs can span MFEs). So **switching tabs is a full page load**,
not client-side routing. React Router does not intercept a plain `<a href>`.

Consequences:
- Every tab load boots a **fresh Redux store** (`state.courseHome.courseId`
  starts at its initial `null`) **and** a fresh React Query cache.
- There is **no cross-tab carryover** in either store. Nothing a prior tab
  fetched or set survives the navigation.
- So the RQ cache is **never warm** across tabs, and Redux `courseId` is only
  ever whatever the *current* page populated.

## The button's data dependencies

- `courseId` ← `useSelector(state.courseHome)` (**Redux, transitional**). On a
  page that doesn't run a `fetchTab*` thunk, this is `null`.
- `org` ← `useModel('courseHomeMeta', courseId)`.
- `toursEnabled` ← the shared (cold-per-page) RQ cache described above.

## Net effective behavior (the shape)

| Tab | Visible btn (CourseTools) | srOnly btn (TabPage) | Tour data fetched on this page? | Redux `courseId` set on this page? | Button actually functional? |
|---|---|---|---|---|---|
| **outline** | yes | yes (`metadataModel` gate) | yes (once proctoring loaded) | yes today (`fetchOutlineTab`); **`null` after conversion** | **yes — the only place** |
| dates | no | mounts, empty DOM | no | no (converted) | no |
| live / discussion / progress | no | mounts, empty DOM | no | yes (still `fetchTab`) but no fetch/visible btn | no |
| courseware | no | no (`coursewareMeta`) | yes | — | n/a (no launch button rendered at all) |

**Conclusion: the launch-tour button is only ever "real" on the outline tab.**
On every other course-home tab the srOnly instance mounts but can never emit DOM
(full page load ⇒ no warmed cache ⇒ `toursEnabled` undefined). The
`metadataModel === 'courseHomeMeta'` gate thus mounts a dead button in four
places, and on outline the srOnly button is *redundant* with the visible
`CourseTools` one.

## History (why it looks like this)

- **#750** (`feat: new user course home tour`, 2020) — introduced the tour, the
  **visible** button in `CourseTools`, **and** the srOnly button. Per the
  author's **inline review comment** on `Header.jsx` (on the diff, not the PR
  conversation thread — easy to miss): *"This functions like a 'Skip to main
  content' link. Just prompts users to launch the tour if they'd like because
  the 'launch tour' button is pretty hidden in the DOM under 'Course Tools'.
  Might need to revisit this w/ Jeff Witt to take a second pass at the a11y here,
  but this is what we agreed on for now."* So the srOnly button was a
  **skip-link-style a11y aid**, added because the *visible* launch button is
  buried under `CourseTools` (an outline concern), and explicitly flagged as
  **provisional** pending an a11y review that (per the code) never happened. The
  tour-data fetch was **already gated to outline/courseware** here:
  `userIsAuthenticated && (isCoursewareTab || (isOutlineTab && proctoringPanelStatus === 'loaded'))`.
- **#775** (`fix: remove launch tour from header`, Dec 2021) — the local
  `Header` was being replaced by the shared `@edx/frontend-component-header`
  (no tour logic), so the srOnly button was lifted out of the header into
  `TabPage`, placed **above** it to preserve the top-of-DOM reading order. This
  commit added the `metadataModel === 'courseHomeMeta'` gate and hardcoded the
  button's `useModel(...)` to `'courseHomeMeta'` (before this, `metadataModel`
  actually selected the model — hence the prop's later vestigial drift).
- **#1968** (product-tours → React Query) — a **1:1 refactor** of the existing
  fetch gate: the pre-existing `dispatch(fetchTourData)` condition was moved
  verbatim into `shouldFetchTourData()` and passed as the RQ query's `enabled`
  flag. It did **not** change the gating or the behavior.

**Corrected conclusion (an earlier draft of this doc/analysis got this wrong):**
the srOnly button being effectively **outline-only** is **long-standing**, *not*
something the React Query migration caused — the outline/courseware fetch gate
predates #1968 (identical in the Redux version). And per the #750 rationale the
srOnly button was really an **outline** a11y aid all along (it substitutes for
the visible button that lives under outline's `CourseTools`). So the accurate
framing is **over-broad mounting**, not *inversion*: `metadataModel` mounts it on
all five course-home tabs, but it only ever materializes on outline (where it's
redundant with the visible one) and is harmlessly inert elsewhere.

**Empirical confirmation (courseware):** with the tour armed and the sequence-nav
slot filled, the courseware page shows the courseware **tour overlay**
(`#pgn__checkpoint`) but **no** srOnly launch button — the only
`sr-only sr-only-focusable` element is the shared header's `#main-content`
skip-nav link. Consistent with the `metadataModel` gate excluding courseware.

## The courseware tour is a separate mechanism (and also dead-by-default)

Distinct from the launch *button*. The **courseware tour** is a guided
`ProductTour` overlay, not button-launched:
- `ProductTours`: `if (coursewareTabActive && showCoursewareTour)
  setIsCoursewareTourEnabled(true)` → renders `coursewareTour(...)`.
- `showCoursewareTour` ← `TourContext` from the tour data's `showCoursewareTour`
  (camelCased from the API's `show_courseware_tour`).
- Dismissing it PATCHes `show_courseware_tour: false` (`useEndCoursewareTour`).
- `coursewareTour` has a **single checkpoint** targeting
  `#courseware-sequence-navigation` (`product-tours/CoursewareTour.jsx`).

**Why it doesn't show on a stock install:** `#courseware-sequence-navigation`
lives only in `SequenceNavigation.jsx`, which is rendered *nowhere directly* —
it's the would-be content of `SequenceNavigationSlot`
(`org.openedx.frontend.learning.sequence_navigation.v1`), a `PluginSlot` that is
**empty by default**. No slot fill ⇒ no nav element ⇒ the ProductTour has no
anchor ⇒ nothing renders, regardless of `show_courseware_tour`. (Confirmed: the
courseware tour appears once the slot is filled — see recipe below.)

### Re-arm + view recipe (local dev)

`UserTour` model (`lms/djangoapps/user_tours/models.py`): `show_courseware_tour`
(BooleanField, default `True`) and `course_home_tour_status` (choices:
`show-new-user-tour` / `show-existing-user-tour` / `no-tour`).

Re-arm in the LMS Django shell:
```python
from django.contrib.auth import get_user_model
from lms.djangoapps.user_tours.models import UserTour
tour = UserTour.objects.get(user=get_user_model().objects.get(username="USERNAME"))
tour.show_courseware_tour = True          # courseware tour
tour.course_home_tour_status = "show-new-user-tour"   # course-home tour
tour.save()
```

Fill the sequence-nav slot so the courseware tour has its anchor (untracked
`env.config.jsx`, requires a dev-server restart):
```jsx
import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
import { SequenceNavigation } from './src/courseware/course/sequence/sequence-navigation';
// pluginSlots['org.openedx.frontend.learning.sequence_navigation.v1'] =
//   { keepDefault: false, plugins: [{ op: Insert, widget: DIRECT_PLUGIN RenderWidget → <SequenceNavigation .../> }] }
```

## Implications for the cleanup

- `metadataModel` in `TabPage` is a boolean-in-disguise ("is course-home") whose
  *only* live effect is gating a button that's only real on outline — plus it's
  threaded dead into `LoadedTabPage` → `StreakCelebrationModal` (declared
  required, never used).
- The cleanup should decide **deliberately** whether the srOnly launch
  affordance needs to exist at all, and if so where — rather than leaving it
  mounted-but-dead on four tabs.
- Whatever renders it must stay **above `HeaderSlot`** for the a11y reading
  order (the #775 intent) — which argues against pushing it down into tab
  content.
- `LaunchCourseHomeTourButton`'s `courseId` must move from
  `useSelector(state.courseHome)` to `useParams` — but note it only *matters*
  on outline (the one tab where the button is real and, post-conversion, would
  otherwise read a `null` slice `courseId`).

## Agreed cleanup approach

Its own stack layer, **below the outline conversion** (so outline builds on the
cleaned `TabPage` and inherits the `courseId` fix). Keep the srOnly affordance —
no a11y removal (that would need a deliberate a11y-reviewed change, per the
never-done #750 "revisit w/ Jeff Witt" note); this cleanup only makes the code
say what's already true, with no user-facing behavior change.

1. **`TabPage.tsx`** — gate the srOnly button on `activeTabSlug === 'outline'`
   (not `metadataModel`, not a new boolean). `activeTabSlug` is already a prop;
   this directly encodes the headline finding ("only ever on outline") and is
   behavior-preserving (the button already only *materialized* on outline —
   full page loads keep it inert elsewhere). Comment it, citing the a11y
   rationale inline via the #750 review-comment link. Rename `renderTourButton` →
   `renderSrOnlyTourButton` to make the srOnly variant explicit. Keep it above
   `HeaderSlot`.
2. **Delete `metadataModel` end to end** — the prop on `TabPage` and
   `LoadedTabPage`, the dead threading into `StreakCelebrationModal` (destructure
   + required propType), and the `metadataModel=...` at every call site
   (`DatesTab`, `CoursewareContainer`, `TabContainer`'s `` `${slice}Meta` ``).
3. **`LaunchCourseHomeTourButton.jsx`** — `courseId`:
   `useSelector(state.courseHome)` → `useParams` (the de-Redux fix; matters for
   the visible outline `CourseTools` button).
4. **Tests** — add two `TabPage` tests for the new gate (srOnly button renders
   on outline, not on other tabs); drop the removed `metadataModel` prop from the
   call-site fixtures (`LoadedTabPage`, `StreakCelebrationModal`, `ProductTours`,
   `ProgressTab`, `OutlineTab`).

Works whether outline is still `TabContainer`-rendered or converted: both pass
`activeTabSlug="outline"` for the outline route, so the gate behaves identically.

</details>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
