### PR TITLE
refactor: convert outline tab from Redux to React Query

### DIFF
--- a/src/course-home/data/apiHooks.test.tsx
+++ b/src/course-home/data/apiHooks.test.tsx
@@ -6,7 +6,10 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { initializeMockApp } from '../../setupTest';
 import { ToastProvider, useToast } from '../../generic/ToastContext';
-import { useResetDeadlines, usePostEvent, useRequestCert } from './apiHooks';
+import {
+  useOutlineTabData, useResetDeadlines, usePostEvent, useRequestCert, useDismissWelcomeMessage,
+  useSaveWeeklyLearningGoal,
+} from './apiHooks';
 
 const { loggingService } = initializeMockApp();
 
@@ -137,6 +140,83 @@ describe('course-home apiHooks', () => {
 
       await act(async () => {
         await result.current.mutateAsync({ courseId: 'course-1' }).catch(() => {});
+      });
+
+      await waitFor(() => expect(loggingService.logError).toHaveBeenCalled());
+    });
+  });
+
+  describe('useDismissWelcomeMessage', () => {
+    const dismissUrl = `${getConfig().LMS_BASE_URL}/api/course_home/dismiss_welcome_message`;
+
+    it('POSTs to the dismiss url', async () => {
+      axiosMock.onPost(dismissUrl).reply(201);
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useDismissWelcomeMessage(), { wrapper });
+
+      await act(async () => { await result.current.mutateAsync({ courseId: 'course-1' }); });
+
+      expect(axiosMock.history.post[0].url).toEqual(dismissUrl);
+    });
+
+    it('logs the error when the POST fails', async () => {
+      axiosMock.onPost(dismissUrl).reply(500);
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useDismissWelcomeMessage(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({ courseId: 'course-1' }).catch(() => {});
+      });
+
+      await waitFor(() => expect(loggingService.logError).toHaveBeenCalled());
+    });
+  });
+
+  describe('useOutlineTabData', () => {
+    const outlineUrl = `${getConfig().LMS_BASE_URL}/api/course_home/outline/course-1`;
+
+    it('resolves to an empty object on a 403 (access is handled via the metadata request)', async () => {
+      axiosMock.onGet(outlineUrl).reply(403, {});
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useOutlineTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual({});
+    });
+
+    it('surfaces the error on a non-403 failure', async () => {
+      axiosMock.onGet(outlineUrl).reply(500);
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useOutlineTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+
+  describe('useSaveWeeklyLearningGoal', () => {
+    const goalUrl = `${getConfig().LMS_BASE_URL}/api/course_home/save_course_goal`;
+
+    it('POSTs the weekly learning goal', async () => {
+      axiosMock.onPost(goalUrl).reply(200, {});
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useSaveWeeklyLearningGoal(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync({ courseId: 'course-1', daysPerWeek: 3, subscribedToReminders: true });
+      });
+
+      expect(axiosMock.history.post[0].url).toEqual(goalUrl);
+    });
+
+    it('logs the error when the POST fails', async () => {
+      axiosMock.onPost(goalUrl).reply(500);
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useSaveWeeklyLearningGoal(), { wrapper });
+
+      await act(async () => {
+        await result.current.mutateAsync(
+          { courseId: 'course-1', daysPerWeek: 3, subscribedToReminders: true },
+        ).catch(() => {});
       });
 
       await waitFor(() => expect(loggingService.logError).toHaveBeenCalled());

--- a/src/course-home/data/apiHooks.ts
+++ b/src/course-home/data/apiHooks.ts
@@ -3,7 +3,14 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { useToast, ToastContent } from '@src/generic/ToastContext';
 import {
-  executePostFromPostEvent, getCourseHomeCourseMetadata, getDatesTabData, postCourseDeadlines, postRequestCert,
+  executePostFromPostEvent,
+  getCourseHomeCourseMetadata,
+  getDatesTabData,
+  getOutlineTabData,
+  postCourseDeadlines,
+  postDismissWelcomeMessage,
+  postRequestCert,
+  postWeeklyLearningGoal,
 } from './api';
 import { courseHomeQueryKeys } from './queryKeys';
 
@@ -61,7 +68,25 @@ export const useDatesTabData = (courseId: string) => useQuery({
   meta: { modelType: 'dates', courseId },
 });
 
+export const useOutlineTabData = (courseId: string) => useQuery({
+  queryKey: courseHomeQueryKeys.outlineTab(courseId),
+  queryFn: () => getOutlineTabData(courseId),
+  meta: { modelType: 'outline', courseId },
+});
+
 export const useRequestCert = () => useMutation({
   mutationFn: ({ courseId }: { courseId: string }) => postRequestCert(courseId),
+  onError: (error) => logError(error),
+});
+
+export const useDismissWelcomeMessage = () => useMutation({
+  mutationFn: ({ courseId }: { courseId: string }) => postDismissWelcomeMessage(courseId),
+  onError: (error) => logError(error),
+});
+
+export const useSaveWeeklyLearningGoal = () => useMutation({
+  mutationFn: ({ courseId, daysPerWeek, subscribedToReminders }: {
+    courseId: string; daysPerWeek: number; subscribedToReminders: boolean;
+  }) => postWeeklyLearningGoal(courseId, daysPerWeek, subscribedToReminders),
   onError: (error) => logError(error),
 });

--- a/src/course-home/data/index.js
+++ b/src/course-home/data/index.js
@@ -1,8 +1,6 @@
 export {
-  fetchOutlineTab,
   fetchProgressTab,
   deprecatedSaveCourseGoal,
-  saveWeeklyLearningGoal,
 } from './thunks';
 
 export { reducer } from './slice';

--- a/src/course-home/data/queryKeys.ts
+++ b/src/course-home/data/queryKeys.ts
@@ -4,4 +4,5 @@ export const courseHomeQueryKeys = {
   all: [appId, 'courseHome'] as const,
   metadata: (courseId: string) => [...courseHomeQueryKeys.all, 'metadata', courseId] as const,
   datesTab: (courseId: string) => [...courseHomeQueryKeys.all, 'datesTab', courseId] as const,
+  outlineTab: (courseId: string) => [...courseHomeQueryKeys.all, 'outlineTab', courseId] as const,
 };

--- a/src/course-home/data/redux.test.js
+++ b/src/course-home/data/redux.test.js
@@ -42,45 +42,6 @@ describe('Data layer integration tests', () => {
     store = initializeStore();
   });
 
-  describe('Test fetchOutlineTab', () => {
-    const outlineBaseUrl = `${getConfig().LMS_BASE_URL}/api/course_home/outline`;
-    const outlineUrl = `${outlineBaseUrl}/${courseId}`;
-
-    it('Should result in fetch failure if error occurs', async () => {
-      axiosMock.onGet(courseMetadataUrl).networkError();
-      axiosMock.onGet(outlineUrl).networkError();
-
-      await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
-
-      expect(loggingService.logError).toHaveBeenCalled();
-      expect(store.getState().courseHome.courseStatus).toEqual('failed');
-    });
-
-    it('Should fetch, normalize, and save metadata', async () => {
-      const outlineTabData = Factory.build('outlineTabData', { courseId });
-
-      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(outlineUrl).reply(200, outlineTabData);
-
-      await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
-
-      const state = store.getState();
-      expect(state.courseHome.courseStatus).toEqual('loaded');
-    });
-
-    it.each([401, 403, 404])(
-      'should result in fetch denied if course access is denied, regardless of outline API status',
-      async (errorStatus) => {
-        axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeAccessDeniedMetadata);
-        axiosMock.onGet(outlineUrl).reply(errorStatus, {});
-
-        await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
-
-        expect(store.getState().courseHome.courseStatus).toEqual('denied');
-      },
-    );
-  });
-
   describe('Test fetchProgressTab', () => {
     const progressBaseUrl = `${getConfig().LMS_BASE_URL}/api/course_home/progress`;
 
@@ -145,18 +106,6 @@ describe('Data layer integration tests', () => {
 
       expect(axiosMock.history.post[0].url).toEqual(goalUrl);
       expect(axiosMock.history.post[0].data).toEqual(`{"course_id":"${courseId}","goal_key":"unsure"}`);
-    });
-  });
-
-  describe('Test dismissWelcomeMessage', () => {
-    it('Should dismiss welcome message', async () => {
-      const dismissUrl = `${getConfig().LMS_BASE_URL}/api/course_home/dismiss_welcome_message`;
-      axiosMock.onPost(dismissUrl).reply(201);
-
-      await executeThunk(thunks.dismissWelcomeMessage(courseId), store.dispatch);
-
-      expect(axiosMock.history.post[0].url).toEqual(dismissUrl);
-      expect(axiosMock.history.post[0].data).toEqual(`{"course_id":"${courseId}"}`);
     });
   });
 

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -2,11 +2,8 @@ import { logError } from '@edx/frontend-platform/logging';
 import {
   getCourseHomeCourseMetadata,
   getExamsData,
-  getOutlineTabData,
   getProgressTabData,
   deprecatedPostCourseGoals,
-  postWeeklyLearningGoal,
-  postDismissWelcomeMessage,
   getLiveTabIframe,
 } from './api';
 
@@ -88,10 +85,6 @@ export function fetchProgressTab(courseId, targetUserId) {
   return fetchTab(courseId, 'progress', getProgressTabData, parseInt(targetUserId, 10) || targetUserId);
 }
 
-export function fetchOutlineTab(courseId) {
-  return fetchTab(courseId, 'outline', getOutlineTabData);
-}
-
 export function fetchLiveTab(courseId) {
   return fetchTab(courseId, 'live', getLiveTabIframe);
 }
@@ -100,16 +93,8 @@ export function fetchDiscussionTab(courseId) {
   return fetchTab(courseId, 'discussion');
 }
 
-export function dismissWelcomeMessage(courseId) {
-  return async () => postDismissWelcomeMessage(courseId);
-}
-
 export async function deprecatedSaveCourseGoal(courseId, goalKey) {
   return deprecatedPostCourseGoals(courseId, goalKey);
-}
-
-export async function saveWeeklyLearningGoal(courseId, daysPerWeek, subscribedToReminders) {
-  return postWeeklyLearningGoal(courseId, daysPerWeek, subscribedToReminders);
 }
 
 export function fetchExamAttemptsData(courseId, sequenceIds) {

--- a/src/course-home/outline-tab/DateSummary.jsx
+++ b/src/course-home/outline-tab/DateSummary.jsx
@@ -3,7 +3,7 @@ import { faCalendarAlt } from '@fortawesome/free-regular-svg-icons';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { FormattedDate } from '@edx/frontend-platform/i18n';
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { useModel } from '../../generic/model-store';
 import { isLearnerAssignment } from '../dates-tab/utils';
@@ -13,9 +13,7 @@ const DateSummary = ({
   dateBlock,
   userTimezone,
 }) => {
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
   const {
     org,
   } = useModel('courseHomeMeta', courseId);

--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -13,7 +13,7 @@ import CourseHandouts from './widgets/CourseHandouts';
 import StartOrResumeCourseCard from './widgets/StartOrResumeCourseCard';
 import WeeklyLearningGoalCard from './widgets/WeeklyLearningGoalCard';
 import CourseTools from './widgets/CourseTools';
-import { fetchOutlineTab } from '../data';
+import { useCourseHomeMeta, useOutlineTabData } from '../data/apiHooks';
 import messages from './messages';
 import ShiftDatesAlert from '../suggested-schedule-messaging/ShiftDatesAlert';
 import UpgradeToShiftDatesAlert from '../suggested-schedule-messaging/UpgradeToShiftDatesAlert';
@@ -27,13 +27,12 @@ import WelcomeMessage from './widgets/WelcomeMessage';
 import ProctoringInfoPanel from './widgets/ProctoringInfoPanel';
 import AccountActivationAlert from '../../alerts/logistration-alert/AccountActivationAlert';
 import CourseHomeSectionOutlineSlot from '../../plugin-slots/CourseHomeSectionOutlineSlot';
+import { TabWithTimer } from '../../tab-page';
 
-const OutlineTab = () => {
+const OutlineTabContent = () => {
   const intl = useIntl();
-  const {
-    courseId,
-    proctoringPanelStatus,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
+  const { proctoringPanelStatus } = useSelector(state => state.courseHome);
 
   const {
     isSelfPaced,
@@ -146,7 +145,7 @@ const OutlineTab = () => {
           />
           {isSelfPaced && hasDeadlines && (
             <>
-              <ShiftDatesAlert model="outline" fetch={fetchOutlineTab} />
+              <ShiftDatesAlert model="outline" />
               <UpgradeToShiftDatesAlert model="outline" logUpgradeLinkClick={logUpgradeToShiftDatesLinkClick} />
             </>
           )}
@@ -188,6 +187,22 @@ const OutlineTab = () => {
         )}
       </div>
     </>
+  );
+};
+
+const OutlineTab = () => {
+  const { courseId } = useParams();
+  const metadataQuery = useCourseHomeMeta(courseId);
+  const tabDataQuery = useOutlineTabData(courseId);
+
+  return (
+    <TabWithTimer
+      activeTabSlug="outline"
+      courseId={courseId}
+      courseStatus={{ metadataQuery, tabDataQuery }}
+    >
+      <OutlineTabContent />
+    </TabWithTimer>
   );
 };
 

--- a/src/course-home/outline-tab/OutlineTab.test.jsx
+++ b/src/course-home/outline-tab/OutlineTab.test.jsx
@@ -5,24 +5,26 @@ import React from 'react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { Factory } from 'rosie';
 import { getConfig } from '@edx/frontend-platform';
+import { AppProvider } from '@edx/frontend-platform/react';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { QueryClientProvider } from '@tanstack/react-query';
 import MockAdapter from 'axios-mock-adapter';
 import Cookies from 'js-cookie';
 import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import messages from './messages';
 
 import { buildMinimalCourseBlocks } from '../../shared/data/__factories__/courseBlocks.factory';
 import {
-  fireEvent, initializeMockApp, logUnhandledRequests, render, screen, waitFor, act,
+  createTestQueryClient, fireEvent, initializeMockApp, logUnhandledRequests, screen, waitFor, act,
 } from '../../setupTest';
-import { appendBrowserTimezoneToUrl, executeThunk } from '../../utils';
-import * as thunks from '../data/thunks';
+import { appendBrowserTimezoneToUrl } from '../../utils';
 import initializeStore from '../../store';
 import { CERT_STATUS_TYPE } from './alerts/certificate-status-alert/CertificateStatusAlert';
 import OutlineTab from './OutlineTab';
-import LoadedTabPage from '../../tab-page/LoadedTabPage';
-import { TourProvider } from '../../product-tours/TourContext';
+import { UserMessagesProvider } from '../../generic/user-messages';
+import { ToastProvider } from '../../generic/ToastContext';
 
 const mockCoursewareSearchParams = jest.fn();
 
@@ -71,19 +73,26 @@ describe('Outline Tab', () => {
     axiosMock.onGet(outlineUrl).reply(200, outlineTabData);
   }
 
-  async function fetchAndRender(path = '') {
-    await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
+  async function fetchAndRender(path = '', { renderStore = store, waitForLoaded = true } = {}) {
     const search = path.includes('?') ? path.slice(path.indexOf('?')) : '';
     await act(async () => render(
-      <MemoryRouter initialEntries={[`/course/${courseId}/home${search}`]}>
-        <TourProvider>
-          <Routes>
-            <Route path="/course/:courseId/home" element={<OutlineTab />} />
-          </Routes>
-        </TourProvider>
-      </MemoryRouter>,
-      { store },
+      <AppProvider store={renderStore} wrapWithRouter={false}>
+        <MemoryRouter initialEntries={[`/course/${courseId}/home${search}`]}>
+          <QueryClientProvider client={createTestQueryClient(renderStore)}>
+            <UserMessagesProvider>
+              <ToastProvider>
+                <Routes>
+                  <Route path="/course/:courseId/home" element={<OutlineTab />} />
+                </Routes>
+              </ToastProvider>
+            </UserMessagesProvider>
+          </QueryClientProvider>
+        </MemoryRouter>
+      </AppProvider>,
     ));
+    if (waitForLoaded) {
+      await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    }
   }
 
   beforeEach(async () => {
@@ -109,6 +118,23 @@ describe('Outline Tab', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('Access denied', () => {
+    it('waits for the outline data before rendering for a denied learner (no crash)', async () => {
+      const testStore = initializeStore();
+      setMetadata({ course_access: { has_access: false, error_code: 'authentication_required' }, is_enrolled: false });
+      let resolveOutline;
+      axiosMock.onGet(outlineUrl).reply(() => new Promise((resolve) => { resolveOutline = resolve; }));
+
+      await fetchAndRender('', { renderStore: testStore, waitForLoaded: false });
+
+      await waitFor(() => expect(testStore.getState().models.courseHomeMeta?.[courseId]).toBeDefined());
+      expect(screen.getByRole('status')).toBeInTheDocument();
+
+      await act(async () => { resolveOutline([200, Factory.build('outlineTabData')]); });
+      expect(await screen.findByTestId('private-course-alert')).toBeInTheDocument();
+    });
   });
 
   describe('Course Outline', () => {
@@ -429,12 +455,10 @@ describe('Outline Tab', () => {
           weekly_learning_goal_enabled: true,
         },
       });
-      const spy = jest.spyOn(thunks, 'saveWeeklyLearningGoal');
-
       await fetchAndRender();
-      const button = await screen.getByTestId('weekly-learning-goal-input-Regular');
+      const button = screen.getByTestId('weekly-learning-goal-input-Regular');
       fireEvent.click(button);
-      expect(spy).toHaveBeenCalledTimes(0);
+      expect(axiosMock.history.post.some(req => req.url.includes('save_course_goal'))).toBe(false);
     });
 
     it('post goal via query param', async () => {
@@ -443,11 +467,12 @@ describe('Outline Tab', () => {
           weekly_learning_goal_enabled: true,
         },
       });
-      const spy = jest.spyOn(thunks, 'saveWeeklyLearningGoal');
       sendTrackEvent.mockClear();
 
       await fetchAndRender('http://localhost/?weekly_goal=3');
-      expect(spy).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(
+        axiosMock.history.post.filter(req => req.url.includes('save_course_goal')),
+      ).toHaveLength(1));
       expect(sendTrackEvent).toHaveBeenCalledWith('enrollment.email.clicked.setgoal', {});
     });
 
@@ -665,9 +690,8 @@ describe('Outline Tab', () => {
             masquerading_expired_course: true,
           },
         });
-        await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
-        await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="outline">...</LoadedTabPage></TourProvider>, { store }));
-        const instructorToolbar = await screen.getByTestId('instructor-toolbar');
+        await fetchAndRender();
+        const instructorToolbar = screen.getByTestId('instructor-toolbar');
         expect(instructorToolbar).toBeInTheDocument();
         expect(screen.getByText('This learner no longer has access to this course. Their access expired on', { exact: false })).toBeInTheDocument();
         expect(screen.getByText('1/1/2020', { exact: false })).toBeInTheDocument();
@@ -681,9 +705,8 @@ describe('Outline Tab', () => {
             masquerading_expired_course: false,
           },
         });
-        await executeThunk(thunks.fetchOutlineTab(courseId), store.dispatch);
-        await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="outline">...</LoadedTabPage></TourProvider>, { store }));
-        const instructorToolbar = await screen.getByTestId('instructor-toolbar');
+        await fetchAndRender();
+        const instructorToolbar = screen.getByTestId('instructor-toolbar');
         expect(instructorToolbar).toBeInTheDocument();
         expect(screen.queryByText('This learner no longer has access to this course. Their access expired on', { exact: false })).not.toBeInTheDocument();
       });

--- a/src/course-home/outline-tab/section-outline/Section.tsx
+++ b/src/course-home/outline-tab/section-outline/Section.tsx
@@ -3,9 +3,9 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { Collapsible, IconButton } from '@openedx/paragon';
 import { Minus, Plus } from '@openedx/paragon/icons';
 
+import { useParams } from 'react-router-dom';
 import { useModel } from '../../../generic/model-store';
 import genericMessages from '../../../generic/messages';
-import { useContextId } from '../../../data/hooks';
 import messages from '../messages';
 import SectionTitle from './SectionTitle';
 import SequenceLink from './SequenceLink';
@@ -27,7 +27,7 @@ const Section: React.FC<Props> = ({
   section,
 }) => {
   const intl = useIntl();
-  const courseId = useContextId();
+  const { courseId } = useParams();
   const {
     complete,
     sequenceIds,

--- a/src/course-home/outline-tab/section-outline/SequenceDueDate.tsx
+++ b/src/course-home/outline-tab/section-outline/SequenceDueDate.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { FormattedTime, useIntl } from '@edx/frontend-platform/i18n';
+import { useParams } from 'react-router-dom';
 import { useModel } from '../../../generic/model-store';
 
-import { useContextId } from '../../../data/hooks';
 import messages from '../messages';
 
 interface Props {
@@ -17,7 +17,7 @@ const SequenceDueDate: React.FC<Props> = ({
   description,
 }) => {
   const intl = useIntl();
-  const courseId = useContextId();
+  const { courseId } = useParams();
   let dueDateMessage: string | React.ReactNode = intl.formatMessage(
     messages.sequenceNoDueDate,
     { description: description || '' },

--- a/src/course-home/outline-tab/section-outline/SequenceTitle.tsx
+++ b/src/course-home/outline-tab/section-outline/SequenceTitle.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { Icon } from '@openedx/paragon';
 import { CheckCircleOutline, CheckCircle } from '@openedx/paragon/icons';
 
 import EffortEstimate from '../../../shared/effort-estimate';
 import messages from '../messages';
-import { useContextId } from '../../../data/hooks';
 
 interface Props {
   complete: boolean;
@@ -24,7 +23,7 @@ const SequenceTitle: React.FC<Props> = ({
   id,
 }) => {
   const intl = useIntl();
-  const courseId = useContextId();
+  const { courseId } = useParams();
   const coursewareUrl = <Link to={`/course/${courseId}/${id}`}>{title}</Link>;
   const displayTitle = showLink ? coursewareUrl : title;
 

--- a/src/course-home/outline-tab/widgets/CourseDates.jsx
+++ b/src/course-home/outline-tab/widgets/CourseDates.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 
@@ -9,9 +9,7 @@ import { useModel } from '../../../generic/model-store';
 
 const CourseDates = () => {
   const intl = useIntl();
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
   const {
     userTimezone,
   } = useModel('courseHomeMeta', courseId);

--- a/src/course-home/outline-tab/widgets/CourseHandouts.jsx
+++ b/src/course-home/outline-tab/widgets/CourseHandouts.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 
@@ -9,9 +9,7 @@ import { useModel } from '../../../generic/model-store';
 
 const CourseHandouts = () => {
   const intl = useIntl();
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
   const {
     handoutsHtml,
   } = useModel('outline', courseId);

--- a/src/course-home/outline-tab/widgets/CourseTools.jsx
+++ b/src/course-home/outline-tab/widgets/CourseTools.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -16,9 +16,7 @@ import LaunchCourseHomeTourButton from '../../../product-tours/newUserCourseHome
 
 const CourseTools = () => {
   const intl = useIntl();
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
   const { org } = useModel('courseHomeMeta', courseId);
   const {
     courseTools,

--- a/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
+++ b/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import camelCase from 'lodash.camelcase';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -13,9 +14,7 @@ import { useModel } from '../../../generic/model-store';
 
 const ProctoringInfoPanel = () => {
   const intl = useIntl();
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
   const {
     username,
   } = useModel('courseHomeMeta', courseId);

--- a/src/course-home/outline-tab/widgets/StartOrResumeCourseCard.jsx
+++ b/src/course-home/outline-tab/widgets/StartOrResumeCourseCard.jsx
@@ -2,16 +2,14 @@ import React from 'react';
 import { Button, Card } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import { sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import messages from '../messages';
 import { useModel } from '../../../generic/model-store';
 
 const StartOrResumeCourseCard = () => {
   const intl = useIntl();
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
 
   const {
     org,

--- a/src/course-home/outline-tab/widgets/WeeklyLearningGoalCard.jsx
+++ b/src/course-home/outline-tab/widgets/WeeklyLearningGoalCard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import { Form, Card, Icon } from '@openedx/paragon';
@@ -8,10 +8,9 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Email } from '@openedx/paragon/icons';
-import { useSelector } from 'react-redux';
 import messages from '../messages';
 import LearningGoalButton from './LearningGoalButton';
-import { saveWeeklyLearningGoal } from '../../data';
+import { useSaveWeeklyLearningGoal } from '../../data/apiHooks';
 import { useModel } from '../../../generic/model-store';
 import './FlagButton.scss';
 
@@ -20,9 +19,7 @@ const WeeklyLearningGoalCard = ({
   subscribedToReminders,
 }) => {
   const intl = useIntl();
-  const {
-    courseId,
-  } = useSelector(state => state.courseHome);
+  const { courseId } = useParams();
 
   const {
     isMasquerading,
@@ -30,6 +27,7 @@ const WeeklyLearningGoalCard = ({
   } = useModel('courseHomeMeta', courseId);
 
   const { administrator } = getAuthenticatedUser();
+  const saveWeeklyLearningGoal = useSaveWeeklyLearningGoal();
 
   const [daysPerWeekGoal, setDaysPerWeekGoal] = useState(daysPerWeek);
   // eslint-disable-next-line react/prop-types
@@ -42,7 +40,7 @@ const WeeklyLearningGoalCard = ({
     setGetReminderSelected(selectReminders);
     setDaysPerWeekGoal(days);
     if (!isMasquerading) { // don't save goal updates while masquerading
-      saveWeeklyLearningGoal(courseId, days, selectReminders);
+      saveWeeklyLearningGoal.mutate({ courseId, daysPerWeek: days, subscribedToReminders: selectReminders });
       sendTrackEvent('edx.ui.lms.goal.days-per-week.changed', {
         org_key: org,
         courserun_key: courseId,
@@ -60,7 +58,9 @@ const WeeklyLearningGoalCard = ({
     const isGetReminderChecked = event.target.checked;
     setGetReminderSelected(isGetReminderChecked);
     if (!isMasquerading) { // don't save goal updates while masquerading
-      saveWeeklyLearningGoal(courseId, daysPerWeekGoal, isGetReminderChecked);
+      saveWeeklyLearningGoal.mutate({
+        courseId, daysPerWeek: daysPerWeekGoal, subscribedToReminders: isGetReminderChecked,
+      });
       sendTrackEvent('edx.ui.lms.goal.reminder-selected.changed', {
         org_key: org,
         courserun_key: courseId,

--- a/src/course-home/outline-tab/widgets/WelcomeMessage.jsx
+++ b/src/course-home/outline-tab/widgets/WelcomeMessage.jsx
@@ -5,11 +5,10 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { Alert, Button, TransitionReplace } from '@openedx/paragon';
 import truncate from 'truncate-html';
 
-import { useDispatch } from 'react-redux';
 import LmsHtmlFragment from '../LmsHtmlFragment';
 import messages from '../messages';
 import { useModel } from '../../../generic/model-store';
-import { dismissWelcomeMessage } from '../../data/thunks';
+import { useDismissWelcomeMessage } from '../../data/apiHooks';
 
 const WelcomeMessage = ({ courseId, nextElementRef }) => {
   const intl = useIntl();
@@ -37,7 +36,7 @@ const WelcomeMessage = ({ courseId, nextElementRef }) => {
   );
 
   const [showShortMessage, setShowShortMessage] = useState(messageCanBeShortened);
-  const dispatch = useDispatch();
+  const dismissWelcomeMessage = useDismissWelcomeMessage();
 
   if (!welcomeMessageHtml) {
     return null;
@@ -53,7 +52,7 @@ const WelcomeMessage = ({ courseId, nextElementRef }) => {
       onClose={() => {
         nextElementRef.current?.focus();
         setDisplay(false);
-        dispatch(dismissWelcomeMessage(courseId));
+        dismissWelcomeMessage.mutate({ courseId });
       }}
       className="raised-card"
       actions={messageCanBeShortened ? [

--- a/src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx
+++ b/src/course-home/suggested-schedule-messaging/ShiftDatesAlert.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import PropTypes from 'prop-types';
@@ -17,11 +16,10 @@ import { courseHomeQueryKeys } from '../data/queryKeys';
 import { useModel } from '../../generic/model-store';
 import messages from './messages';
 
-const ShiftDatesAlert = ({ fetch, model }) => {
+const ShiftDatesAlert = ({ model }) => {
   const intl = useIntl();
   const { courseId } = useParams();
   const queryClient = useQueryClient();
-  const dispatch = useDispatch();
 
   const {
     datesBannerInfo,
@@ -41,9 +39,7 @@ const ShiftDatesAlert = ({ fetch, model }) => {
 
   const refreshTabData = () => {
     queryClient.invalidateQueries({ queryKey: courseHomeQueryKeys.datesTab(courseId) });
-    if (fetch) {
-      dispatch(fetch(courseId));
-    }
+    queryClient.invalidateQueries({ queryKey: courseHomeQueryKeys.outlineTab(courseId) });
   };
 
   return (
@@ -72,12 +68,7 @@ const ShiftDatesAlert = ({ fetch, model }) => {
 };
 
 ShiftDatesAlert.propTypes = {
-  fetch: PropTypes.func,
   model: PropTypes.string.isRequired,
-};
-
-ShiftDatesAlert.defaultProps = {
-  fetch: undefined,
 };
 
 export default ShiftDatesAlert;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,7 +26,7 @@ import GoalUnsubscribe from './course-home/goal-unsubscribe';
 import ProgressTab from './course-home/progress-tab/ProgressTab';
 import { TabContainer } from './tab-page';
 
-import { fetchOutlineTab, fetchProgressTab } from './course-home/data';
+import { fetchProgressTab } from './course-home/data';
 import { fetchCourse } from './courseware/data';
 import { store } from './store';
 import { createQueryClient } from './queryClient';
@@ -75,9 +75,7 @@ subscribe(APP_READY, () => {
                         path={DECODE_ROUTES.HOME}
                         element={(
                           <DecodePageRoute>
-                            <TabContainer tab="outline" fetch={fetchOutlineTab} slice="courseHome">
-                              <OutlineTab />
-                            </TabContainer>
+                            <OutlineTab />
                           </DecodePageRoute>
                       )}
                       />

--- a/src/product-tours/ProductTours.test.jsx
+++ b/src/product-tours/ProductTours.test.jsx
@@ -3,29 +3,28 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { Factory } from 'rosie';
 import { getConfig, history } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { AppProvider } from '@edx/frontend-platform/react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import MockAdapter from 'axios-mock-adapter';
 import { waitForElementToBeRemoved } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import * as popper from '@popperjs/core';
 
 import {
-  fireEvent, initializeMockApp, logUnhandledRequests, render, screen,
+  act, createTestQueryClient, fireEvent, initializeMockApp, logUnhandledRequests, render, screen, waitFor,
 } from '../setupTest';
 import initializeStore from '../store';
-import { appendBrowserTimezoneToUrl, executeThunk } from '../utils';
+import { appendBrowserTimezoneToUrl } from '../utils';
 
 import CoursewareContainer from '../courseware/CoursewareContainer';
-import LoadedTabPage from '../tab-page/LoadedTabPage';
 import { TourProvider } from './TourContext';
 import ProductTours from './ProductTours';
 import OutlineTab from '../course-home/outline-tab/OutlineTab';
-import * as courseHomeThunks from '../course-home/data/thunks';
 import { buildSimpleCourseBlocks } from '../shared/data/__factories__/courseBlocks.factory';
 import { buildOutlineFromBlocks } from '../courseware/data/__factories__/learningSequencesOutline.factory';
 
@@ -62,15 +61,17 @@ describe('Course Home Tours', () => {
   }
 
   async function fetchAndRender() {
-    await executeThunk(courseHomeThunks.fetchOutlineTab(courseId), store.dispatch);
-    render(
-      <TourProvider>
-        <LoadedTabPage courseId={courseId} activeTabSlug="outline">
-          <OutlineTab />
-        </LoadedTabPage>
-      </TourProvider>,
-      { store, wrapWithRouter: true },
-    );
+    await act(async () => render(
+      <MemoryRouter initialEntries={[`/course/${courseId}/home`]}>
+        <QueryClientProvider client={createTestQueryClient(store)}>
+          <Routes>
+            <Route path="/course/:courseId/home" element={<OutlineTab />} />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+      { store },
+    ));
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
   }
 
   beforeEach(async () => {
@@ -193,7 +194,8 @@ describe('Course Home Tours', () => {
     });
 
     it('launches tour on button click', async () => {
-      const launchTourButton = await screen.findByRole('button', { name: 'Launch tour' });
+      const buttons = await screen.findAllByRole('button', { name: 'Launch tour' });
+      const launchTourButton = buttons.find((button) => !button.classList.contains('sr-only'));
       expect(launchTourButton).toBeInTheDocument();
 
       fireEvent.click(launchTourButton);

--- a/src/tab-page/TabPage.test.jsx
+++ b/src/tab-page/TabPage.test.jsx
@@ -167,6 +167,22 @@ describe('Tab Page', () => {
       expect(screen.queryByTestId('LoadedTabPage')).not.toBeInTheDocument();
     });
 
+    it('shows loading when access is denied but the tab-data query is still pending', () => {
+      render(
+        <TabPage
+          {...mockData}
+          activeTabSlug="outline"
+          courseStatus={{
+            metadataQuery: { data: { courseAccess: { hasAccess: false } } },
+            tabDataQuery: { isPending: true },
+          }}
+        />,
+        { wrapWithRouter: true },
+      );
+      expect(screen.getByText('Loading course page…')).toBeInTheDocument();
+      expect(screen.queryByTestId('LoadedTabPage')).not.toBeInTheDocument();
+    });
+
     it('does not render tab content when access is denied', async () => {
       const testStore = await initializeTestStore({ excludeFetchCourse: true, excludeFetchSequence: true }, false);
       testStore.dispatch(addModel({

--- a/src/tab-page/TabPage.tsx
+++ b/src/tab-page/TabPage.tsx
@@ -60,9 +60,9 @@ const deriveView = (courseStatus: CourseStatus): TabView => {
   const { metadataQuery, tabDataQuery } = courseStatus;
   if (metadataQuery.isError) { return { ...view, isError: true }; }
   if (metadataQuery.isPending) { return { ...view, isLoading: true }; }
+  if (tabDataQuery.isPending) { return { ...view, isLoading: true }; }
   if (!metadataQuery.data?.courseAccess?.hasAccess) { return { ...view, isDenied: true }; }
   if (tabDataQuery.isError) { return { ...view, isError: true }; }
-  if (tabDataQuery.isPending) { return { ...view, isLoading: true }; }
   return view;
 };
 


### PR DESCRIPTION
## Summary

Convert the course-home **outline tab** from Redux to React Query. Part of the Redux → React Query migration (#1946), and the next course-home tab through the door the dates-tab conversion opened. Closes #1991.

`OutlineTab` becomes self-wrapping — it owns its data (`useCourseHomeMeta` + a new `useOutlineTabData`) and renders `TabWithTimer` itself, so the `index.jsx` route drops its `<TabContainer tab="outline" fetch={fetchOutlineTab}>` wrapper for a bare `<OutlineTab />` and `fetchOutlineTab` is deleted.

## What changed

- **`apiHooks.ts` / `queryKeys.ts`** — add `useOutlineTabData` (tagged `meta: { modelType: 'outline', courseId }` so the model-store bridge still populates the subtree's `useModel('outline')` reads) and the `outlineTab(courseId)` key.
- **`OutlineTab.jsx`** — split into a thin data-owning `OutlineTab` (runs the two queries, renders `<TabWithTimer courseStatus={{ metadataQuery, tabDataQuery }}><OutlineTabContent/></TabWithTimer>`) and an `OutlineTabContent` in the same file. The split keeps the `useModel('outline')` destructure out of the loading phase, where the model is still `{}`. `courseId` from `useParams`; `proctoringPanelStatus` stays on `useSelector`.
- **Subtree `courseId` → `useParams`** — the seven slice-reading widgets (`DateSummary`, `CourseDates`, `CourseHandouts`, `CourseTools`, `StartOrResumeCourseCard`, `WeeklyLearningGoalCard`, `ProctoringInfoPanel`) and the three `section-outline` components that reached the slice via `useContextId` (`Section`, `SequenceDueDate`, `SequenceTitle`). Required: the route no longer runs a thunk to set `state.courseHome.courseId`.
- **`ShiftDatesAlert.jsx`** — `refreshTabData` now invalidates **both** `datesTab` and `outlineTab`; drops its `fetch`/`useDispatch` (outline was the last `fetch=` caller).
- **Outline-only POST writers → mutations** — `dismissWelcomeMessage` → `useDismissWelcomeMessage` (thunk deleted) and `saveWeeklyLearningGoal` → `useSaveWeeklyLearningGoal` (moved out of `thunks.js`, where it was a loose non-thunk helper).

## Behavior

No user-facing change. `proctoringPanelStatus` deliberately stays in Redux (client UI state, out of scope for a data-layer conversion). The mutations add `onError: logError`, which the thunks lacked — a strict improvement.

## Testing

`npm run types`, `npm run lint`, and the full `npm test` suite (106 suites, 3 pre-existing skips) pass. `OutlineTab.test.jsx` and `ProductTours.test.jsx` now render the real self-wrapping tab through the bridged query client; new mutation coverage (`useOutlineTabData`, `useDismissWelcomeMessage`, `useSaveWeeklyLearningGoal`) in `apiHooks.test.tsx`. Manual browser verification and the test-coverage split are documented in the decision log below.

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — Redux → React Query: the outline tab (#1991)

Working notes for this PR (part of the wider Redux → React Query migration,
#1946). **Not checked in** — referenced when opening the PR. Part of #1975
(course-home tab data), stacked on the dates-tab conversion (#1984), which set
the self-wrapping pattern.

## Scope: same self-wrapping conversion the dates tab established

**Decision.** `OutlineTab` becomes self-wrapping — it renders `<TabWithTimer>`
itself and owns its data via `useCourseHomeMeta` + a new `useOutlineTabData`
hook. `courseId` comes from `useParams`. The `index.jsx` route drops its
`<TabContainer tab="outline" fetch={fetchOutlineTab}>` wrapper for a bare
`<OutlineTab />`, and `fetchOutlineTab` is deleted.

**Why.** This is the pattern the dates tab set (#1984), which itself converges
on the shape `CoursewareContainer` already uses. Nothing tab-specific here —
the outline tab is just the next tab through the same door.

## `OutlineTab` splits into a thin wrapper + `OutlineTabContent`

**Decision.** `OutlineTab` is now just the data-owning wrapper: it runs the two
queries and renders `<TabWithTimer courseStatus={{ metadataQuery, tabDataQuery }}>
<OutlineTabContent /></TabWithTimer>`. The heavy body — everything that reads
`useModel('outline', courseId)` — moves into an `OutlineTabContent` component in
the same file.

**Why.** Self-wrapping means `OutlineTab` renders *before* its data resolves (the
spinner phase lives inside `TabWithTimer`). The body destructures the `outline`
model (`const { courseBlocks, … } = useModel('outline', courseId)`), and
`useModel` returns `{}` for a missing model, so that destructure ran against `{}`
during loading and crashed. `TabPage` only renders its children once the data has
loaded, so moving the body into a child (`OutlineTabContent`) means the
destructure never runs empty — no defensive defaults, no guard, and the wrapper
stays a thin data-owner. Same file, so it reads as one unit.

## The `outline` model stays on the transitional bridge — it isn't outline-only

**Decision.** Keep every `useModel('outline'|'courseHomeMeta', …)` read in the
subtree exactly as-is, populated by the model-store bridge (the `meta:
{ modelType, courseId }` tag on the query drives `addModel` on success). Do
**not** convert any of these reads to consume `useOutlineTabData`'s data
directly in this PR. Dissolving the model store is its own coordinated epic
step (#1977).

**Why — the mechanism.** We looked into who actually reads these models, to see
if any were outline-tab-only and could be pulled forward:
- `courseHomeMeta` is read all over the app (courseware, every tab, dozens of
  shared alerts, `TabPage`) — plainly shared.
- `outline` looked outline-scoped — every reader is under `outline-tab/`
  **except two**: `useEnrollmentAlert` and `useLogistrationAlert`. Those run
  inside `LoadedTabPage`, which renders on **every** tab and courseware, and
  they read `useModel('outline', courseId)` **passively and defensively**
  (`outline && outline.courseBlocks && …`) — on non-outline pages the model is
  empty and the alert stays hidden.

The distinction that matters: **`useModel` is a passive read** (returns whatever
is cached, fetches nothing); **`useOutlineTabData(courseId)` is an active query**
(calling it *triggers* the outline fetch). Swapping those shared alert hooks to
the query would fire the outline API on the dates tab, the progress tab, and
courseware — a real regression. The passive-read-plus-bridge is exactly what
makes the shared read safe today, which is why untangling it is a coordinated
store dissolution (#1977), not per-tab work.

**Alternative rejected.** *Convert just the outline-tab-only readers to
`useOutlineTabData` (child calls dedupe against `OutlineTab`'s query, so no
extra fetch), leaving the bridge for the two shared alerts.* It can't remove the
bridge or the `meta` tag (the shared alerts still need the model store
populated), and it leaves the `outline` model read two different ways for #1977
to reconcile anyway — churn without retiring the transitional mechanism.

## `proctoringPanelStatus` stays in Redux

**Decision.** `OutlineTab` keeps reading `proctoringPanelStatus` from
`useSelector(state.courseHome)`; only `courseId` moves to `useParams`.
`ProctoringInfoPanel` keeps its `useDispatch(fetchProctoringInfoResolved())`.

**Why.** It's client UI state (a reducer flips it to `loaded` when the panel
resolves, gating when the goal widget appears), not server data — out of scope
for a data-layer conversion. It's retired when the store is reduced to the
external specialExams reducer (#1978).

## Subtree `courseId`: slice / `useContextId` reads → `useParams`

**Decision.** Every subtree component that derived `courseId` from the slice
moves to `useParams`:
- direct `useSelector(state.courseHome)` readers — `DateSummary`, `CourseDates`,
  `CourseHandouts`, `CourseTools`, `StartOrResumeCourseCard`,
  `WeeklyLearningGoalCard`, `ProctoringInfoPanel` (keeps its `useDispatch`).
- the `section-outline` readers — `Section`, `SequenceDueDate`, `SequenceTitle`
  — which reached the slice *indirectly* through `useContextId()`
  (`state.courseware.courseId ?? state.courseHome.courseId`). Only these three
  outline-only callers move; the shared `useContextId` itself is left alone
  (~30 progress/course-exit components rely on it).

**Why — required, not cosmetic.** `state.courseHome.courseId` is only ever set
by a tab's fetch thunk (`fetchTabRequest`). Once the outline route stops running
one, any descendant still reading it — directly or via `useContextId()` — gets
`undefined`, so its `useModel(…, courseId)` misses or its `sequences[id]` lookup
crashes: the same breakage class as the `UpgradeToCompleteAlert` slot child in
the dates PR.

## `ShiftDatesAlert`: invalidate all date-bearing caches, and finish its bridge

**Decision.** `refreshTabData` invalidates **both** `datesTab(courseId)` and
`outlineTab(courseId)`, independent of which tab the alert is on. The `model`
prop stays only for the `useModel(model)` visibility gate and the
`resetDeadlines.mutate({ courseId, model })` call. Outline is the last
`fetch={fetchOutlineTab}` caller, so the `fetch` prop and `useDispatch` are
removed entirely.

**Why.** The alert is about *dates*; shifting them changes date info wherever
it's cached — the `dates` model (`datesTab` query) **and** the outline model's
`datesWidget`/`SequenceDueDate` (`outlineTab` query). So invalidation is
model-independent: both keys, always.

**Not a fix to the dates PR.** The dates PR invalidating only `datesTab` was
correct for its moment — outline was still Redux/thunk-fetched then, so no
`outlineTab` query existed to invalidate; its on-mount `fetchOutlineTab` handled
staleness. This PR is where the outline cache first exists, so it's where it
joins the alert's invalidation set.

## Bucket 3: outline-only POST writers become mutations

**Decision.** Convert the outline tab's fire-and-forget POST writers to React
Query mutations, removing `useDispatch` from their components:
- `dismissWelcomeMessage` (`WelcomeMessage`) → `useDismissWelcomeMessage`; the
  thunk is deleted.
- `saveWeeklyLearningGoal` (`WeeklyLearningGoalCard`) →
  `useSaveWeeklyLearningGoal`. This one wasn't even a thunk — it was a plain
  `postWeeklyLearningGoal` wrapper sitting in `thunks.js`. Since we're converting
  the outline writers anyway, it moves out of `thunks.js` and becomes a mutation
  like the others rather than a loose helper.

**Why.** They only POST, dispatch no action, and touch no state — the same *kind*
of writer the CTA-toast PR (#1982) converted (`resetDeadlines`/`processEvent` →
mutations). Converting them here gets the outline tab's genuine remaining Redux
off the store rather than leaving it for a later sweep (#1973).

**`requestCert` was peeled into a prerequisite PR (#1995), not converted here.**
It looked like a third outline writer (`CertificateStatusAlert`), but it's shared
— `CourseCelebration` (course-exit) and `CertificateStatus` (progress) dispatch
it too. Converting a shared thunk mid-outline-PR would drag two unrelated
subtrees into this diff, so it became its own lower stack layer (`useRequestCert`,
all three callers converted); this PR builds on top of it.

**Minor behavior note.** The mutations use `onError: logError` to match the
sibling mutations in `apiHooks.ts`; the original thunks logged nothing (a failed
POST was an unhandled rejection), so this is a small improvement, not a
regression.

## Verification: what was checked in a browser vs. left to the tests

The risky part of this PR is mechanical — the query conversion plus the
`courseId` rewrites, where a wrong `courseId` makes a `useModel` read miss
silently or crashes a `sequences[id]` lookup. So the manual pass targeted the
paths where that failure mode is *only* visible at runtime, and leaned on the
automated suite for the rest.

**Manually verified in a browser:**
- Core load — spinner → content with no mid-load crash (the `OutlineTabContent`
  split), including a hard-reload directly on the outline URL.
- The course outline structure — the `section-outline` `useContextId` →
  `useParams` move: sections expand/collapse, sequence titles link into
  courseware, due dates and completion state render.
- The `useParams`-fed sidebar widgets that a normal course surfaces — dates
  widget, course handouts, course tools, Start/Resume card.
- Smoke: launch tour from outline, outline ↔ dates full-page navigation,
  masquerade-as-learner, and a no-access course.

**Left to the automated tests** (each renders the real tab through the bridged
query path — the same code path production uses — so they exercise the actual
`useParams`/query wiring, not a mock of it):
- Shift due dates from outline — `OutlineTab.test` "handles shift due dates
  click" seeds `missed_deadlines: true`, swaps the refetch to `false`, clicks,
  and asserts the button disappears; it only can if `refreshTabData` invalidated
  `outlineTab` and refetched. This is the one genuinely new behavior in the PR,
  and it's directly asserted.
- Welcome message render + dismiss — `OutlineTab.test` "Welcome Message" block
  plus `apiHooks.test` `useDismissWelcomeMessage` (POST + error logging).
- Weekly learning goal — `OutlineTab.test` "Weekly Learning Goal" block (with the
  proctoring endpoint mocked, so the proctoring-gated render is exercised) plus
  `apiHooks.test` `useSaveWeeklyLearningGoal`.
- Proctoring info panel — its `courseId` is the same `useParams` value proven
  good by the widgets verified above; the proctoring GET is mocked in the tab
  tests.

**Why that split is safe.** What a browser pass would add beyond the tests is
narrow: whether the *live* backend persists a dismiss / goal / shift across a
real reload. But those three endpoints (`dismiss_welcome_message`,
`save_course_goal`, `reset_course_deadlines`) are unchanged by this PR — the same
`api.js` functions, now called from a mutation instead of a thunk — so that path
is the platform's behavior, not this diff's. Standing up the fixtures they need
(a set welcome message, a self-paced course with a past-due deadline, proctored
exams) buys little signal for this change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
