### PR TITLE
refactor: convert progress tab from Redux to React Query

### DIFF
--- a/src/course-home/data/apiHooks.test.tsx
+++ b/src/course-home/data/apiHooks.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Factory } from 'rosie';
 import MockAdapter from 'axios-mock-adapter';
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
@@ -7,8 +8,8 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '../../setupTest';
 import { ToastProvider, useToast } from '../../generic/ToastContext';
 import {
-  useOutlineTabData, useResetDeadlines, usePostEvent, useRequestCert, useDismissWelcomeMessage,
-  useSaveWeeklyLearningGoal,
+  useOutlineTabData, useProgressTabData, useResetDeadlines, usePostEvent, useRequestCert,
+  useDismissWelcomeMessage, useSaveWeeklyLearningGoal,
 } from './apiHooks';
 
 const { loggingService } = initializeMockApp();
@@ -188,6 +189,68 @@ describe('course-home apiHooks', () => {
       axiosMock.onGet(outlineUrl).reply(500);
       const { wrapper } = buildWrapper();
       const { result } = renderHook(() => useOutlineTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+
+  describe('useProgressTabData', () => {
+    const progressUrl = `${getConfig().LMS_BASE_URL}/api/course_home/progress/course-1`;
+
+    it('transforms the server response', async () => {
+      axiosMock.onGet(progressUrl).reply(200, Factory.build('progressTabData'));
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useProgressTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data.studioUrl).toEqual('http://studio.edx.org/settings/grading/course-v1:edX+Test+run');
+      expect(result.current.data.gradesFeatureIsFullyLocked).toBe(false);
+    });
+
+    it('appends the targetUserId to the request URL', async () => {
+      axiosMock.onGet(`${progressUrl}/7/`).reply(200, Factory.build('progressTabData'));
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useProgressTabData('course-1', '7'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(axiosMock.history.get[0].url).toEqual(`${progressUrl}/7/`);
+    });
+
+    it.each([401, 403])(
+      'resolves to an empty object on a %s (access is handled via the metadata request)',
+      async (status) => {
+        axiosMock.onGet(progressUrl).reply(status, {});
+        const { wrapper } = buildWrapper();
+        const { result } = renderHook(() => useProgressTabData('course-1'), { wrapper });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toEqual({});
+      },
+    );
+
+    it('redirects to the legacy progress page and resolves to an empty object on a 404', async () => {
+      // jsdom's location.replace is non-configurable, so we swap the whole location for the
+      // duration of this test (restored in finally so it can never bleed into another test).
+      const originalLocation = window.location;
+      const replace = jest.fn();
+      Object.defineProperty(window, 'location', { configurable: true, value: { replace } });
+      try {
+        axiosMock.onGet(progressUrl).reply(404, {});
+        const { wrapper } = buildWrapper();
+        const { result } = renderHook(() => useProgressTabData('course-1'), { wrapper });
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(result.current.data).toEqual({});
+        expect(replace).toHaveBeenCalledWith(`${getConfig().LMS_BASE_URL}/courses/course-1/progress`);
+      } finally {
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+      }
+    });
+
+    it('surfaces the error on a non-handled failure', async () => {
+      axiosMock.onGet(progressUrl).reply(500);
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useProgressTabData('course-1'), { wrapper });
 
       await waitFor(() => expect(result.current.isError).toBe(true));
     });

--- a/src/course-home/data/apiHooks.ts
+++ b/src/course-home/data/apiHooks.ts
@@ -7,6 +7,7 @@ import {
   getCourseHomeCourseMetadata,
   getDatesTabData,
   getOutlineTabData,
+  getProgressTabData,
   postCourseDeadlines,
   postDismissWelcomeMessage,
   postRequestCert,
@@ -72,6 +73,12 @@ export const useOutlineTabData = (courseId: string) => useQuery({
   queryKey: courseHomeQueryKeys.outlineTab(courseId),
   queryFn: () => getOutlineTabData(courseId),
   meta: { modelType: 'outline', courseId },
+});
+
+export const useProgressTabData = (courseId: string, targetUserId?: string) => useQuery({
+  queryKey: courseHomeQueryKeys.progressTab(courseId, targetUserId),
+  queryFn: () => getProgressTabData(courseId, targetUserId),
+  meta: { modelType: 'progress', courseId },
 });
 
 export const useRequestCert = () => useMutation({

--- a/src/course-home/data/index.js
+++ b/src/course-home/data/index.js
@@ -1,6 +1,3 @@
-export {
-  fetchProgressTab,
-  deprecatedSaveCourseGoal,
-} from './thunks';
+export { deprecatedSaveCourseGoal } from './thunks';
 
 export { reducer } from './slice';

--- a/src/course-home/data/queryKeys.ts
+++ b/src/course-home/data/queryKeys.ts
@@ -5,4 +5,5 @@ export const courseHomeQueryKeys = {
   metadata: (courseId: string) => [...courseHomeQueryKeys.all, 'metadata', courseId] as const,
   datesTab: (courseId: string) => [...courseHomeQueryKeys.all, 'datesTab', courseId] as const,
   outlineTab: (courseId: string) => [...courseHomeQueryKeys.all, 'outlineTab', courseId] as const,
+  progressTab: (courseId: string, targetUserId?: string) => [...courseHomeQueryKeys.all, 'progressTab', courseId, targetUserId] as const,
 };

--- a/src/course-home/data/redux.test.js
+++ b/src/course-home/data/redux.test.js
@@ -42,61 +42,6 @@ describe('Data layer integration tests', () => {
     store = initializeStore();
   });
 
-  describe('Test fetchProgressTab', () => {
-    const progressBaseUrl = `${getConfig().LMS_BASE_URL}/api/course_home/progress`;
-
-    it('Should result in fetch failure if error occurs', async () => {
-      axiosMock.onGet(courseMetadataUrl).networkError();
-      axiosMock.onGet(`${progressBaseUrl}/${courseId}`).networkError();
-
-      await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-
-      expect(loggingService.logError).toHaveBeenCalled();
-      expect(store.getState().courseHome.courseStatus).toEqual('failed');
-    });
-
-    it('Should fetch, normalize, and save metadata', async () => {
-      const progressTabData = Factory.build('progressTabData', { courseId });
-
-      const progressUrl = `${progressBaseUrl}/${courseId}`;
-
-      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(progressUrl).reply(200, progressTabData);
-
-      await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-
-      const state = store.getState();
-      expect(state.courseHome.courseStatus).toEqual('loaded');
-    });
-
-    it('Should handle the url including a targetUserId', async () => {
-      const progressTabData = Factory.build('progressTabData', { courseId });
-      const targetUserId = 2;
-      const progressUrl = `${progressBaseUrl}/${courseId}/${targetUserId}/`;
-
-      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(progressUrl).reply(200, progressTabData);
-
-      await executeThunk(thunks.fetchProgressTab(courseId, 2), store.dispatch);
-
-      const state = store.getState();
-      expect(state.courseHome.targetUserId).toEqual(2);
-    });
-
-    it.each([401, 403, 404])(
-      'should result in fetch denied for expected errors and failed for all others',
-      async (errorStatus) => {
-        const progressUrl = `${progressBaseUrl}/${courseId}`;
-        axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeAccessDeniedMetadata);
-        axiosMock.onGet(progressUrl).reply(errorStatus, {});
-
-        await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-
-        expect(store.getState().courseHome.courseStatus).toEqual('denied');
-      },
-    );
-  });
-
   describe('Test saveCourseGoal', () => {
     it('Should save course goal', async () => {
       const goalUrl = `${getConfig().LMS_BASE_URL}/api/course_home/save_course_goal`;
@@ -280,6 +225,47 @@ describe('Data layer integration tests', () => {
 
       // Verify error was logged for the 500 error (may be called more than once due to multiple URL patterns)
       expect(loggingService.logError).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test fetchTab', () => {
+    const liveUrl = `${getConfig().LMS_BASE_URL}/api/course_live/iframe/${courseId}/`;
+
+    it('Should fetch metadata + tab data and mark the tab loaded', async () => {
+      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeMetadata);
+      axiosMock.onGet(liveUrl).reply(200, { iframe: 'https://example.com/live' });
+
+      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
+
+      expect(store.getState().courseHome.courseStatus).toEqual('loaded');
+    });
+
+    it('Should result in denied when the learner lacks course access', async () => {
+      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeAccessDeniedMetadata);
+      axiosMock.onGet(liveUrl).reply(200, {});
+
+      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
+
+      expect(store.getState().courseHome.courseStatus).toEqual('denied');
+    });
+
+    it('Should result in failure when the metadata request errors', async () => {
+      axiosMock.onGet(courseMetadataUrl).networkError();
+      axiosMock.onGet(liveUrl).reply(200, {});
+
+      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
+
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(store.getState().courseHome.courseStatus).toEqual('failed');
+    });
+
+    it('Should result in failure when the tab data request errors', async () => {
+      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeMetadata);
+      axiosMock.onGet(liveUrl).reply(500);
+
+      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
+
+      expect(store.getState().courseHome.courseStatus).toEqual('failed');
     });
   });
 });

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -2,7 +2,6 @@ import { logError } from '@edx/frontend-platform/logging';
 import {
   getCourseHomeCourseMetadata,
   getExamsData,
-  getProgressTabData,
   deprecatedPostCourseGoals,
   getLiveTabIframe,
 } from './api';
@@ -79,10 +78,6 @@ export function fetchTab(courseId, tab, getTabData, targetUserId) {
       logError(e);
     }
   };
-}
-
-export function fetchProgressTab(courseId, targetUserId) {
-  return fetchTab(courseId, 'progress', getProgressTabData, parseInt(targetUserId, 10) || targetUserId);
 }
 
 export function fetchLiveTab(courseId) {

--- a/src/course-home/progress-tab/ProgressHeader.jsx
+++ b/src/course-home/progress-tab/ProgressHeader.jsx
@@ -1,22 +1,19 @@
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
-import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
-import { useModel } from '../../generic/model-store';
-
+import { useProgressData } from './hooks';
 import messages from './messages';
 
 const ProgressHeader = () => {
   const intl = useIntl();
-  const {
-    courseId,
-    targetUserId,
-  } = useSelector(state => state.courseHome);
+  const { targetUserId: targetUserIdParam } = useParams();
+  const targetUserId = parseInt(targetUserIdParam, 10);
 
   const { administrator, userId } = getAuthenticatedUser();
 
-  const { studioUrl, username } = useModel('progress', courseId);
+  const { studioUrl, username } = useProgressData();
 
   const viewingOtherStudentsProgressPage = (targetUserId && targetUserId !== userId);
 

--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useWindowSize } from '@openedx/paragon';
-import { useContextId } from '../../data/hooks';
-import { useModel } from '../../generic/model-store';
+import { useParams } from 'react-router-dom';
+
 import ProgressTabCertificateStatusSidePanelSlot from '../../plugin-slots/ProgressTabCertificateStatusSidePanelSlot';
 
 import CourseCompletion from './course-completion/CourseCompletion';
@@ -11,11 +11,13 @@ import ProgressTabCertificateStatusMainBodySlot from '../../plugin-slots/Progres
 import ProgressTabCourseGradeSlot from '../../plugin-slots/ProgressTabCourseGradeSlot';
 import ProgressTabGradeBreakdownSlot from '../../plugin-slots/ProgressTabGradeBreakdownSlot';
 import ProgressTabRelatedLinksSlot from '../../plugin-slots/ProgressTabRelatedLinksSlot';
-import { useGetExamsData } from './hooks';
+import { useGetExamsData, useProgressData } from './hooks';
+import { useCourseHomeMeta, useProgressTabData } from '../data/apiHooks';
+import { TabWithTimer } from '../../tab-page';
 
-const ProgressTab = () => {
-  const courseId = useContextId();
-  const { disableProgressGraph, sectionScores } = useModel('progress', courseId);
+const ProgressTabContent = () => {
+  const { courseId } = useParams();
+  const { disableProgressGraph, sectionScores } = useProgressData();
 
   const sequenceIds = useMemo(() => (
     sectionScores.flatMap((section) => (section.subsections)).map((subsection) => subsection.blockKey)
@@ -50,6 +52,22 @@ const ProgressTab = () => {
         </div>
       </div>
     </>
+  );
+};
+
+const ProgressTab = () => {
+  const { courseId, targetUserId } = useParams();
+  const metadataQuery = useCourseHomeMeta(courseId);
+  const tabDataQuery = useProgressTabData(courseId, targetUserId);
+
+  return (
+    <TabWithTimer
+      activeTabSlug="progress"
+      courseId={courseId}
+      courseStatus={{ metadataQuery, tabDataQuery }}
+    >
+      <ProgressTabContent />
+    </TabWithTimer>
   );
 };
 

--- a/src/course-home/progress-tab/ProgressTab.test.jsx
+++ b/src/course-home/progress-tab/ProgressTab.test.jsx
@@ -1,20 +1,23 @@
 import React from 'react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { Factory } from 'rosie';
 import { getConfig, setConfig } from '@edx/frontend-platform';
+import { AppProvider } from '@edx/frontend-platform/react';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { breakpoints } from '@openedx/paragon';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 
 import {
-  fireEvent, initializeMockApp, logUnhandledRequests, render, screen, act, waitFor,
+  createTestQueryClient, fireEvent, initializeMockApp, logUnhandledRequests, screen, within, act, waitFor,
 } from '../../setupTest';
-import { appendBrowserTimezoneToUrl, executeThunk } from '../../utils';
-import * as thunks from '../data/thunks';
+import { appendBrowserTimezoneToUrl } from '../../utils';
 import initializeStore from '../../store';
 import ProgressTab from './ProgressTab';
-import LoadedTabPage from '../../tab-page/LoadedTabPage';
-import { TourProvider } from '../../product-tours/TourContext';
+import { UserMessagesProvider } from '../../generic/user-messages';
+import { ToastProvider } from '../../generic/ToastContext';
 import messages from './grades/messages';
 
 const mockCoursewareSearchParams = jest.fn();
@@ -64,9 +67,25 @@ describe('Progress Tab', () => {
     axiosMock.onGet(progressUrl).reply(200, progressTabData);
   }
 
-  async function fetchAndRender() {
-    await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-    await act(async () => render(<ProgressTab />, { store }));
+  async function fetchAndRender(initialEntry = `/course/${courseId}/progress`) {
+    const queryClient = createTestQueryClient(store);
+    await act(async () => render(
+      <AppProvider store={store} wrapWithRouter={false}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <QueryClientProvider client={queryClient}>
+            <UserMessagesProvider>
+              <ToastProvider>
+                <Routes>
+                  <Route path="/course/:courseId/progress/:targetUserId?" element={<ProgressTab />} />
+                </Routes>
+              </ToastProvider>
+            </UserMessagesProvider>
+          </QueryClientProvider>
+        </MemoryRouter>
+      </AppProvider>,
+    ));
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+    return queryClient;
   }
 
   beforeEach(async () => {
@@ -96,7 +115,8 @@ describe('Progress Tab', () => {
       await fetchAndRender();
       sendTrackEvent.mockClear();
 
-      const datesTabLink = screen.getByRole('link', { name: 'Dates' });
+      const relatedLinks = within(screen.getByRole('heading', { name: 'Related links' }).closest('section'));
+      const datesTabLink = relatedLinks.getByRole('link', { name: 'Dates' });
       fireEvent.click(datesTabLink);
 
       expect(sendTrackEvent).toHaveBeenCalledTimes(1);
@@ -320,7 +340,7 @@ describe('Progress Tab', () => {
       await fetchAndRender();
       expect(screen.getByText('locked feature')).toBeInTheDocument();
       expect(screen.getByText('Unlock to view grades and work towards a certificate.')).toBeInTheDocument();
-      expect(screen.getAllByRole('link', 'Unlock now')).toHaveLength(3);
+      expect(screen.getAllByRole('link', { name: 'Upgrade now' })).toHaveLength(1);
     });
 
     it('sends events on click of upgrade button in locked content header (CourseGradeHeader)', async () => {
@@ -364,7 +384,7 @@ describe('Progress Tab', () => {
       expect(screen.getByText('locked feature')).toBeInTheDocument();
       expect(screen.getByText('Unlock to view grades and work towards a certificate.')).toBeInTheDocument();
 
-      const upgradeButton = screen.getAllByRole('link', 'Unlock now')[0];
+      const upgradeButton = screen.getAllByRole('link', { name: 'Upgrade now' })[0];
       fireEvent.click(upgradeButton);
 
       expect(sendTrackEvent).toHaveBeenCalledTimes(2);
@@ -1435,8 +1455,7 @@ describe('Progress Tab', () => {
           masquerading_expired_course: true,
         },
       });
-      await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await fetchAndRender();
       expect(screen.getByTestId('instructor-toolbar')).toBeInTheDocument();
       expect(screen.getByText('This learner no longer has access to this course. Their access expired on', { exact: false })).toBeInTheDocument();
       expect(screen.getByText('1/1/2020', { exact: false })).toBeInTheDocument();
@@ -1449,8 +1468,7 @@ describe('Progress Tab', () => {
           masquerading_expired_course: false,
         },
       });
-      await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await fetchAndRender();
       expect(screen.queryByText('This learner no longer has access to this course. Their access expired on', { exact: false })).not.toBeInTheDocument();
       expect(screen.queryByText('1/1/2020', { exact: false })).not.toBeInTheDocument();
     });
@@ -1464,8 +1482,7 @@ describe('Progress Tab', () => {
         is_staff: false,
         start: '2999-01-01T00:00:00Z',
       });
-      await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await fetchAndRender();
       expect(screen.getByTestId('instructor-toolbar')).toBeInTheDocument();
       expect(screen.getByText('This learner does not yet have access to this course. The course starts on', { exact: false })).toBeInTheDocument();
       expect(screen.getByText('1/1/2999', { exact: false })).toBeInTheDocument();
@@ -1477,8 +1494,7 @@ describe('Progress Tab', () => {
         is_staff: true,
         start: '2999-01-01T00:00:00Z',
       });
-      await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
-      await act(async () => render(<TourProvider><LoadedTabPage courseId={courseId} activeTabSlug="progress">...</LoadedTabPage></TourProvider>, { store }));
+      await fetchAndRender();
       expect(screen.queryByText('This learner does not yet have access to this course. The course starts on', { exact: false })).not.toBeInTheDocument();
       expect(screen.queryByText('1/1/2999', { exact: false })).not.toBeInTheDocument();
     });
@@ -1489,8 +1505,7 @@ describe('Progress Tab', () => {
       setMetadata({ is_enrolled: true });
       setTabData({ username: 'otherstudent' });
 
-      await executeThunk(thunks.fetchProgressTab(courseId, 10), store.dispatch);
-      await act(async () => render(<ProgressTab />, { store }));
+      await fetchAndRender(`/course/${courseId}/progress/10/`);
 
       expect(screen.getByText('Course progress for otherstudent')).toBeInTheDocument();
     });
@@ -1631,7 +1646,7 @@ describe('Progress Tab', () => {
         section_scores: [mockSectionScores[0]], // Only first section
       });
 
-      await fetchAndRender();
+      const queryClient = await fetchAndRender();
 
       // Verify initial API calls (2 subsections in first section)
       expect(axiosMock.history.get.filter(req => req.url.includes('/api/v1/student/exam/attempt/'))).toHaveLength(2);
@@ -1639,12 +1654,14 @@ describe('Progress Tab', () => {
       // Clear axios history to track new calls
       axiosMock.resetHistory();
 
-      // Update with full section scores and re-render
+      // Update with full section scores and refetch the tab query
       setTabData({ section_scores: mockSectionScores });
-      await executeThunk(thunks.fetchProgressTab(courseId), store.dispatch);
+      await act(async () => { await queryClient.invalidateQueries(); });
 
       // Verify additional API calls for all subsections
-      expect(axiosMock.history.get.filter(req => req.url.includes('/api/v1/student/exam/attempt/'))).toHaveLength(3);
+      await waitFor(() => expect(
+        axiosMock.history.get.filter(req => req.url.includes('/api/v1/student/exam/attempt/')),
+      ).toHaveLength(3));
     });
 
     it('should handle exam API errors gracefully without breaking ProgressTab', async () => {

--- a/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
+++ b/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx
@@ -5,17 +5,18 @@ import { FormattedDate, FormattedMessage, useIntl } from '@edx/frontend-platform
 
 import { Button, Card } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
-import { useContextId } from '../../../data/hooks';
+import { useParams } from 'react-router-dom';
 import { useModel } from '../../../generic/model-store';
 import { COURSE_EXIT_MODES, getCourseExitMode } from '../../../courseware/course/course-exit/utils';
 import { DashboardLink, IdVerificationSupportLink, ProfileLink } from '../../../shared/links';
 import { useRequestCert } from '../../data/apiHooks';
+import { useProgressData } from '../hooks';
 import messages from './messages';
 import ProgressCertificateStatusSlot from '../../../plugin-slots/ProgressCertificateStatusSlot';
 
 const CertificateStatus = () => {
   const intl = useIntl();
-  const courseId = useContextId();
+  const { courseId } = useParams();
 
   const {
     entranceExamData,
@@ -39,7 +40,7 @@ const CertificateStatus = () => {
     userHasPassingGrade,
     verificationData,
     verifiedMode,
-  } = useModel('progress', courseId);
+  } = useProgressData();
   const {
     certificateAvailableDate,
   } = certificateData || {};

--- a/src/course-home/progress-tab/course-completion/CompletionDonutChart.jsx
+++ b/src/course-home/progress-tab/course-completion/CompletionDonutChart.jsx
@@ -1,6 +1,5 @@
 import { getLocale, isRtl, useIntl } from '@edx/frontend-platform/i18n';
-import { useContextId } from '../../../data/hooks';
-import { useModel } from '../../../generic/model-store';
+import { useProgressData } from '../hooks';
 
 import CompleteDonutSegment from './CompleteDonutSegment';
 import IncompleteDonutSegment from './IncompleteDonutSegment';
@@ -9,7 +8,6 @@ import messages from './messages';
 
 const CompletionDonutChart = () => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     completionSummary: {
@@ -17,7 +15,7 @@ const CompletionDonutChart = () => {
       incompleteCount,
       lockedCount,
     },
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const numTotalUnits = completeCount + incompleteCount + lockedCount;
   const completePercentage = completeCount ? Number(((completeCount / numTotalUnits) * 100).toFixed(0)) : 0;

--- a/src/course-home/progress-tab/credit-information/CreditInformation.jsx
+++ b/src/course-home/progress-tab/credit-information/CreditInformation.jsx
@@ -2,20 +2,18 @@ import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { CheckCircle, WarningFilled, WatchFilled } from '@openedx/paragon/icons';
 import { Hyperlink, Icon } from '@openedx/paragon';
-import { useContextId } from '../../../data/hooks';
 
-import { useModel } from '../../../generic/model-store';
+import { useProgressData } from '../hooks';
 import { DashboardLink } from '../../../shared/links';
 
 import messages from './messages';
 
 const CreditInformation = () => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     creditCourseRequirements,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   if (!creditCourseRequirements) { return null; }
 

--- a/src/course-home/progress-tab/grades/course-grade/CourseGrade.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CourseGrade.jsx
@@ -1,7 +1,6 @@
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { useContextId } from '../../../../data/hooks';
 
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 import CourseGradeFooter from './CourseGradeFooter';
 import CourseGradeHeader from './CourseGradeHeader';
@@ -12,7 +11,6 @@ import messages from '../messages';
 
 const CourseGrade = () => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     creditCourseRequirements,
@@ -21,7 +19,7 @@ const CourseGrade = () => {
     gradingPolicy: {
       gradeRange,
     },
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const passingGrade = Number((Math.min(...Object.values(gradeRange)) * 100).toFixed(0));
 

--- a/src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CourseGradeFooter.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { CheckCircle, WarningFilled } from '@openedx/paragon/icons';
 import { breakpoints, Icon, useWindowSize } from '@openedx/paragon';
-import { useContextId } from '../../../../data/hooks';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 import GradeRangeTooltip from './GradeRangeTooltip';
 import messages from '../messages';
@@ -45,13 +44,12 @@ const NoticeRow = ({
 
 const CourseGradeFooter = ({ passingGrade }) => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     assignmentTypeGradeSummary,
     courseGrade: { isPassing, letterGrade },
     gradingPolicy: { gradeRange },
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const latestDueDate = getLatestDueDateInFuture(assignmentTypeGradeSummary);
   const wideScreen = useWindowSize().width >= breakpoints.medium.minWidth;

--- a/src/course-home/progress-tab/grades/course-grade/CourseGradeHeader.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CourseGradeHeader.jsx
@@ -3,21 +3,22 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Locked } from '@openedx/paragon/icons';
 import { Button, Icon } from '@openedx/paragon';
-import { useContextId } from '../../../../data/hooks';
+import { useParams } from 'react-router-dom';
 
 import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 import messages from '../messages';
 
 const CourseGradeHeader = () => {
   const intl = useIntl();
-  const courseId = useContextId();
+  const { courseId } = useParams();
   const {
     org,
   } = useModel('courseHomeMeta', courseId);
   const {
     verifiedMode,
     gradesFeatureIsFullyLocked,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const eventProperties = {
     org_key: org,

--- a/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/CurrentGradeTooltip.jsx
@@ -2,15 +2,13 @@ import PropTypes from 'prop-types';
 
 import { getLocale, isRtl, useIntl } from '@edx/frontend-platform/i18n';
 import { OverlayTrigger, Popover } from '@openedx/paragon';
-import { useContextId } from '../../../../data/hooks';
 
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 import messages from '../messages';
 
 const CurrentGradeTooltip = ({ tooltipClassName }) => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     assignmentTypeGradeSummary,
@@ -18,7 +16,7 @@ const CurrentGradeTooltip = ({ tooltipClassName }) => {
       isPassing,
       percent,
     },
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const currentGrade = Number((percent * 100).toFixed(0));
 

--- a/src/course-home/progress-tab/grades/course-grade/GradeBar.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/GradeBar.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 
 import { getLocale, isRtl, useIntl } from '@edx/frontend-platform/i18n';
-import { useContextId } from '../../../../data/hooks';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 import CurrentGradeTooltip from './CurrentGradeTooltip';
 import PassingGradeTooltip from './PassingGradeTooltip';
 
@@ -10,7 +9,6 @@ import messages from '../messages';
 
 const GradeBar = ({ passingGrade }) => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     courseGrade: {
@@ -18,7 +16,7 @@ const GradeBar = ({ passingGrade }) => {
       percent,
     },
     gradesFeatureIsFullyLocked,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const currentGrade = Number((percent * 100).toFixed(0));
 

--- a/src/course-home/progress-tab/grades/course-grade/GradeRangeTooltip.jsx
+++ b/src/course-home/progress-tab/grades/course-grade/GradeRangeTooltip.jsx
@@ -6,21 +6,19 @@ import { InfoOutline } from '@openedx/paragon/icons';
 import {
   Icon, IconButton, OverlayTrigger, Popover,
 } from '@openedx/paragon';
-import { useContextId } from '../../../../data/hooks';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 import messages from '../messages';
 
 const GradeRangeTooltip = ({ iconButtonClassName, passingGrade }) => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     gradesFeatureIsFullyLocked,
     gradingPolicy: {
       gradeRange,
     },
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const [showTooltip, setShowTooltip] = useState(false);
 

--- a/src/course-home/progress-tab/grades/detailed-grades/DetailedGrades.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/DetailedGrades.jsx
@@ -3,8 +3,9 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Locked } from '@openedx/paragon/icons';
 import { Icon, Hyperlink } from '@openedx/paragon';
-import { useContextId } from '../../../../data/hooks';
+import { useParams } from 'react-router-dom';
 import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 import { showUngradedAssignments } from '../../utils';
 
 import DetailedGradesTable from './DetailedGradesTable';
@@ -14,7 +15,7 @@ import messages from '../messages';
 const DetailedGrades = () => {
   const intl = useIntl();
   const { administrator } = getAuthenticatedUser();
-  const courseId = useContextId();
+  const { courseId } = useParams();
   const {
     org,
     tabs,
@@ -23,7 +24,7 @@ const DetailedGrades = () => {
     gradesFeatureIsFullyLocked,
     gradesFeatureIsPartiallyLocked,
     sectionScores,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const hasSectionScores = sectionScores.length > 0;
   const emptyTableMsg = showUngradedAssignments()

--- a/src/course-home/progress-tab/grades/detailed-grades/DetailedGradesTable.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/DetailedGradesTable.jsx
@@ -1,19 +1,17 @@
 import { getLocale, isRtl, useIntl } from '@edx/frontend-platform/i18n';
 import { DataTable } from '@openedx/paragon';
-import { useContextId } from '../../../../data/hooks';
 
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 import messages from '../messages';
 import SubsectionTitleCell from './SubsectionTitleCell';
 import { showUngradedAssignments } from '../../utils';
 
 const DetailedGradesTable = () => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     sectionScores,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const isLocaleRtl = isRtl(getLocale());
   return (

--- a/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
+++ b/src/course-home/progress-tab/grades/detailed-grades/SubsectionTitleCell.jsx
@@ -10,21 +10,22 @@ import {
   Info,
   Locked,
 } from '@openedx/paragon/icons';
-import { useContextId } from '../../../../data/hooks';
+import { useParams } from 'react-router-dom';
 
 import messages from '../messages';
 import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 import ProblemScoreDrawer from './ProblemScoreDrawer';
 
 const SubsectionTitleCell = ({ subsection }) => {
   const intl = useIntl();
-  const courseId = useContextId();
+  const { courseId } = useParams();
   const {
     org,
   } = useModel('courseHomeMeta', courseId);
   const {
     gradesFeatureIsFullyLocked,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const {
     blockKey,

--- a/src/course-home/progress-tab/grades/grade-summary/AssignmentTypeCell.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/AssignmentTypeCell.jsx
@@ -2,19 +2,17 @@ import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Locked } from '@openedx/paragon/icons';
 import { Icon } from '@openedx/paragon';
-import { useContextId } from '../../../../data/hooks';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 import messages from '../messages';
 
 const AssignmentTypeCell = ({
   assignmentType, footnoteMarker, footnoteId, locked,
 }) => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     gradesFeatureIsFullyLocked,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const lockedIcon = locked ? <Icon id={`assignmentTypeBlockedIcon${assignmentType}`} aria-label={intl.formatMessage(messages.noAccessToAssignmentType, { assignmentType })} className="mr-1 mt-1 d-inline-flex" style={{ height: '1rem', width: '1rem' }} src={Locked} data-testid="locked-icon" /> : '';
 

--- a/src/course-home/progress-tab/grades/grade-summary/DroppableAssignmentFootnote.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/DroppableAssignmentFootnote.jsx
@@ -1,17 +1,15 @@
 import PropTypes from 'prop-types';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { useContextId } from '../../../../data/hooks';
 
 import messages from '../messages';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 const DroppableAssignmentFootnote = ({ footnotes }) => {
   const intl = useIntl();
-  const courseId = useContextId();
   const {
     gradesFeatureIsFullyLocked,
-  } = useModel('progress', courseId);
+  } = useProgressData();
   return (
     <>
       <span id="grade-summary-footnote-label" className="sr-only">{intl.formatMessage(messages.footnotesTitle)}</span>

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummary.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummary.jsx
@@ -1,17 +1,14 @@
 import React, { useState } from 'react';
 
-import { useContextId } from '../../../../data/hooks';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 import GradeSummaryHeader from './GradeSummaryHeader';
 import GradeSummaryTable from './GradeSummaryTable';
 
 const GradeSummary = () => {
-  const courseId = useContextId();
-
   const {
     assignmentTypeGradeSummary,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const [allOfSomeAssignmentTypeIsLocked, setAllOfSomeAssignmentTypeIsLocked] = useState(false);
 

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryHeader.jsx
@@ -8,18 +8,16 @@ import {
   Tooltip,
 } from '@openedx/paragon';
 import { InfoOutline, Locked } from '@openedx/paragon/icons';
-import { useContextId } from '../../../../data/hooks';
 
 import messages from '../messages';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 const GradeSummaryHeader = ({ allOfSomeAssignmentTypeIsLocked }) => {
   const intl = useIntl();
-  const courseId = useContextId();
   const {
     verifiedMode,
     gradesFeatureIsFullyLocked,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   return (
     <Stack gap={2} className="mb-3">

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryTable.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryTable.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { getLocale, isRtl, useIntl } from '@edx/frontend-platform/i18n';
 import { DataTable } from '@openedx/paragon';
 import { Lock } from '@openedx/paragon/icons';
-import { useContextId } from '../../../../data/hooks';
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 
 import AssignmentTypeCell from './AssignmentTypeCell';
 import DroppableAssignmentFootnote from './DroppableAssignmentFootnote';
@@ -14,13 +13,12 @@ import messages from '../messages';
 
 const GradeSummaryTable = ({ setAllOfSomeAssignmentTypeIsLocked }) => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     assignmentTypeGradeSummary,
     gradesFeatureIsFullyLocked,
     sectionScores,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const footnotes = [];
 

--- a/src/course-home/progress-tab/grades/grade-summary/GradeSummaryTableFooter.jsx
+++ b/src/course-home/progress-tab/grades/grade-summary/GradeSummaryTableFooter.jsx
@@ -7,14 +7,12 @@ import {
   Tooltip,
 } from '@openedx/paragon';
 import { InfoOutline } from '@openedx/paragon/icons';
-import { useContextId } from '../../../../data/hooks';
 
-import { useModel } from '../../../../generic/model-store';
+import { useProgressData } from '../../hooks';
 import messages from '../messages';
 
 const GradeSummaryTableFooter = () => {
   const intl = useIntl();
-  const courseId = useContextId();
 
   const {
     courseGrade: {
@@ -22,7 +20,7 @@ const GradeSummaryTableFooter = () => {
       percent,
     },
     finalGrades,
-  } = useModel('progress', courseId);
+  } = useProgressData();
 
   const getGradePercent = (grade) => {
     const percentage = grade * 100;

--- a/src/course-home/progress-tab/hooks.jsx
+++ b/src/course-home/progress-tab/hooks.jsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
 import { fetchExamAttemptsData } from '../data/thunks';
+import { useProgressTabData } from '../data/apiHooks';
 
 export function useGetExamsData(courseId, sequenceIds) {
   const dispatch = useDispatch();
@@ -9,4 +11,9 @@ export function useGetExamsData(courseId, sequenceIds) {
   useEffect(() => {
     dispatch(fetchExamAttemptsData(courseId, sequenceIds));
   }, [dispatch, courseId, sequenceIds]);
+}
+
+export function useProgressData() {
+  const { courseId, targetUserId } = useParams();
+  return useProgressTabData(courseId, targetUserId).data;
 }

--- a/src/course-home/progress-tab/related-links/RelatedLinks.jsx
+++ b/src/course-home/progress-tab/related-links/RelatedLinks.jsx
@@ -2,14 +2,14 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Hyperlink } from '@openedx/paragon';
-import { useContextId } from '../../../data/hooks';
+import { useParams } from 'react-router-dom';
 
 import messages from './messages';
 import { useModel } from '../../../generic/model-store';
 
 const RelatedLinks = () => {
   const intl = useIntl();
-  const courseId = useContextId();
+  const { courseId } = useParams();
   const {
     org,
     tabs,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,7 +26,6 @@ import GoalUnsubscribe from './course-home/goal-unsubscribe';
 import ProgressTab from './course-home/progress-tab/ProgressTab';
 import { TabContainer } from './tab-page';
 
-import { fetchProgressTab } from './course-home/data';
 import { fetchCourse } from './courseware/data';
 import { store } from './store';
 import { createQueryClient } from './queryClient';
@@ -113,14 +112,7 @@ subscribe(APP_READY, () => {
                           path={route}
                           element={(
                             <DecodePageRoute>
-                              <TabContainer
-                                tab="progress"
-                                fetch={fetchProgressTab}
-                                slice="courseHome"
-                                isProgressTab
-                              >
-                                <ProgressTab />
-                              </TabContainer>
+                              <ProgressTab />
                             </DecodePageRoute>
                         )}
                         />

--- a/src/plugin-slots/ProgressTabCertificateStatusMainBodySlot/README.md
+++ b/src/plugin-slots/ProgressTabCertificateStatusMainBodySlot/README.md
@@ -20,7 +20,7 @@ The following `env.config.jsx` will render the `course_id` of the course as a `<
 
 ```js
 import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
-import { useContextId } from './src/data/hooks';
+import { useParams } from 'react-router-dom';
 
 const config = {
   pluginSlots: {
@@ -33,7 +33,7 @@ const config = {
             id: 'custom_certificate_status_content',
             type: DIRECT_PLUGIN,
             RenderWidget: () => {
-              const courseId = useContextId();
+              const { courseId } = useParams();
               return (
                 <div>
                   <p>📚: {courseId}</p>

--- a/src/plugin-slots/ProgressTabCertificateStatusSidePanelSlot/README.md
+++ b/src/plugin-slots/ProgressTabCertificateStatusSidePanelSlot/README.md
@@ -20,7 +20,7 @@ The following `env.config.jsx` will render the `course_id` of the course as a `<
 
 ```js
 import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
-import { useContextId } from './src/data/hooks';
+import { useParams } from 'react-router-dom';
 
 const config = {
   pluginSlots: {
@@ -33,7 +33,7 @@ const config = {
             id: 'custom_certificate_status_content',
             type: DIRECT_PLUGIN,
             RenderWidget: () => {
-              const courseId = useContextId();
+              const { courseId } = useParams();
               return (
                 <div>
                   <p>📚: {courseId}</p>

--- a/src/plugin-slots/ProgressTabCourseGradeSlot/README.md
+++ b/src/plugin-slots/ProgressTabCourseGradeSlot/README.md
@@ -19,7 +19,7 @@ The following `env.config.jsx` will render the `course_id` of the course as a `<
 
 ```js
 import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
-import { useContextId } from './src/data/hooks';
+import { useParams } from 'react-router-dom';
 
 const config = {
   pluginSlots: {
@@ -32,7 +32,7 @@ const config = {
             id: 'custom_course_grade_content',
             type: DIRECT_PLUGIN,
             RenderWidget: () => {
-              const courseId = useContextId();
+              const { courseId } = useParams();
               return (
                 <div>
                   <p>📚: {courseId}</p>

--- a/src/plugin-slots/ProgressTabGradeBreakdownSlot/README.md
+++ b/src/plugin-slots/ProgressTabGradeBreakdownSlot/README.md
@@ -19,7 +19,7 @@ The following `env.config.jsx` will render the `course_id` of the course as a `<
 
 ```js
 import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
-import { useContextId } from './src/data/hooks';
+import { useParams } from 'react-router-dom';
 
 const config = {
   pluginSlots: {
@@ -32,7 +32,7 @@ const config = {
             id: 'custom_grade_summary_content',
             type: DIRECT_PLUGIN,
             RenderWidget: () => {
-              const courseId = useContextId();
+              const { courseId } = useParams();
               return (
                 <div>
                   <p>📚: {courseId}</p>

--- a/src/plugin-slots/ProgressTabGradeBreakdownSlot/index.jsx
+++ b/src/plugin-slots/ProgressTabGradeBreakdownSlot/index.jsx
@@ -1,13 +1,11 @@
-import { useModel } from '@src/generic/model-store';
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import React from 'react';
 import DetailedGrades from '../../course-home/progress-tab/grades/detailed-grades/DetailedGrades';
 import GradeSummary from '../../course-home/progress-tab/grades/grade-summary/GradeSummary';
-import { useContextId } from '../../data/hooks';
+import { useProgressData } from '../../course-home/progress-tab/hooks';
 
 const ProgressTabGradeBreakdownSlot = () => {
-  const courseId = useContextId();
-  const { gradesFeatureIsFullyLocked } = useModel('progress', courseId);
+  const { gradesFeatureIsFullyLocked } = useProgressData();
   const applyLockedOverlay = gradesFeatureIsFullyLocked ? 'locked-overlay' : '';
   return (
     <PluginSlot

--- a/src/plugin-slots/ProgressTabRelatedLinksSlot/README.md
+++ b/src/plugin-slots/ProgressTabRelatedLinksSlot/README.md
@@ -19,7 +19,7 @@ The following `env.config.jsx` will render the `course_id` of the course as a `<
 
 ```js
 import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
-import { useContextId } from './src/data/hooks';
+import { useParams } from 'react-router-dom';
 
 const config = {
   pluginSlots: {
@@ -32,7 +32,7 @@ const config = {
             id: 'custom_related_links_content',
             type: DIRECT_PLUGIN,
             RenderWidget: () => {
-              const courseId = useContextId();
+              const { courseId } = useParams();
               return (
                 <div>
                   <p>📚: {courseId}</p>

--- a/src/tab-page/TabContainer.jsx
+++ b/src/tab-page/TabContainer.jsx
@@ -11,21 +11,16 @@ const TabContainer = (props) => {
     fetch,
     slice,
     tab,
-    isProgressTab,
   } = props;
 
-  const { courseId: courseIdFromUrl, targetUserId } = useParams();
+  const { courseId: courseIdFromUrl } = useParams();
   const dispatch = useDispatch();
 
   useEffect(() => {
     // The courseId from the URL is the course we WANT to load.
-    if (isProgressTab) {
-      dispatch(fetch(courseIdFromUrl, targetUserId));
-    } else {
-      dispatch(fetch(courseIdFromUrl));
-    }
+    dispatch(fetch(courseIdFromUrl));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [courseIdFromUrl, targetUserId]);
+  }, [courseIdFromUrl]);
 
   // The courseId from the store is the course we HAVE loaded.  If the URL changes,
   // we don't want the application to adjust to it until it has actually loaded the new data.
@@ -50,11 +45,6 @@ TabContainer.propTypes = {
   fetch: PropTypes.func.isRequired,
   slice: PropTypes.string.isRequired,
   tab: PropTypes.string.isRequired,
-  isProgressTab: PropTypes.bool,
-};
-
-TabContainer.defaultProps = {
-  isProgressTab: false,
 };
 
 export default TabContainer;

--- a/src/tab-page/TabContainer.test.jsx
+++ b/src/tab-page/TabContainer.test.jsx
@@ -51,32 +51,4 @@ describe('Tab Container', () => {
     expect(mockDispatch).toHaveBeenCalledWith(courseId);
     expect(screen.getByTestId('TabPage')).toBeInTheDocument();
   });
-
-  it('Should handle passing in a targetUserId', () => {
-    const targetUserId = '1';
-
-    render(
-      <MemoryRouter initialEntries={[`/course/${courseId}/progress/${targetUserId}/`]}>
-        <Routes>
-          <Route
-            path="/course/:courseId/progress/:targetUserId/"
-            element={(
-              <TabContainer
-                fetch={mockFetch}
-                tab="dummy"
-                slice="courseHome"
-                isProgressTab
-              >
-                children={[]}
-              </TabContainer>
-            )}
-          />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledWith(courseId, targetUserId);
-    expect(screen.getByTestId('TabPage')).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
## Summary

Convert the course-home **progress tab** from Redux to React Query. Part of the Redux → React Query migration (#1946), stacked on the outline-tab conversion (#1997). Closes #1998.

`ProgressTab` becomes self-wrapping — it owns its data (`useCourseHomeMeta` + a new `useProgressTabData`) and renders `TabWithTimer` itself, so the `index.jsx` route drops its `<TabContainer tab="progress" fetch={fetchProgressTab} isProgressTab>` wrapper for a bare `<ProgressTab />` and `fetchProgressTab` is deleted.

## What changed

- **`apiHooks.ts` / `queryKeys.ts`** — add `useProgressTabData(courseId, targetUserId?)` and the `progressTab(courseId, targetUserId?)` key. It keeps a scoped `meta: { modelType: 'progress', courseId }` so the model-store bridge still feeds the one shared holdout reader (below).
- **`ProgressTab.jsx`** — split into a thin data-owning `ProgressTab` (runs the two queries, renders `<TabWithTimer courseStatus={{ metadataQuery, tabDataQuery }}><ProgressTabContent/></TabWithTimer>`) and a `ProgressTabContent` in the same file. The split keeps the query-data reads out of the loading phase, where the data is still empty.
- **`useProgressData()` hook** (`progress-tab/hooks.jsx`) — reads the tab data from `useProgressTabData(courseId, targetUserId)`; subtree readers call it instead of `useModel('progress')`, so they share one fetch (keyed by the same `targetUserId` — critical on the staff `/progress/:targetUserId/` route).
- **Subtree `courseId` → `useParams`** — the ~20 grade/certificate/related-links components + `ProgressTabGradeBreakdownSlot` move off `useContextId()`; most drop `courseId` entirely and read `useProgressData()`. Required: the route no longer runs a thunk to set `state.courseHome.courseId`.
- **`ProgressHeader.jsx`** — reads `targetUserId`/`username` from `useParams` + `useProgressData()` instead of the slice + `useModel('progress')`; the `targetUserId !== userId` int comparison is preserved.
- **Route + `TabContainer` cleanup** — `fetchProgressTab` deleted; the now-dead `isProgressTab` prop + its `targetUserId` fetch branch removed from `TabContainer` (progress was its only consumer). The shared `fetchTab` helper stays (live/discussion still use it).

## The one retained bridge

Every *progress-specific* reader is off the model store. `useProgressTabData` keeps its `meta` bridge for exactly one shared, tab-generic holdout: `useAccessExpirationMasqueradeBanner` (rendered by `InstructorToolbar`) does a dynamic `useModel(tab)` that resolves to `'progress'`. Migrating it cleanly needs every tab to be query-backed, so it's deferred to the model-store dissolution (#1977, tracked in #1999) — the `meta` line retires with the rest of the bridge then. Full rationale in the decision log.

## Behavior

No user-facing change. `examsData` (the exam-attempts Redux write that plugin slots read) stays as-is; only its `courseId` source moves to `useParams`.

Manual testing surfaced a **pre-existing** bug (present on `master`): masquerading as a specific learner via the masquerade bar shows "Your progress" instead of "Course progress for &lt;username&gt;", because that flow leaves the URL (and `:targetUserId`) unchanged. Filed as #2000 — out of scope here; this conversion preserves the behavior exactly.

## Testing

`npm run types`, `npm run lint`, and the full `npm test` suite pass (the one `Course.test.jsx` failure is a pre-existing parallel-run flake — green in isolation). `ProgressTab.test.jsx` now renders the real self-wrapping tab through the bridged query client; new `useProgressTabData` coverage (success/transform, `targetUserId` URL, 401/403/404, error) in `apiHooks.test.tsx`; `redux.test.js` drops the `fetchProgressTab` block (`fetchTab` stays covered by `DiscussionTab.test`). Manual browser verification and the test-coverage split are documented in the decision log below.

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — Redux → React Query: the progress tab (#1946)

Working notes for this PR (part of the wider Redux → React Query migration,
#1946). **Not checked in** — referenced when opening the PR. Part of #1975
(course-home tab data), stacked on the outline-tab conversion (#1997).

Unlike the dates/outline conversions, this one goes **bridge-free for every
progress-specific reader**: the whole grade/certificate subtree reads the tab
data straight from the React Query cache, not from the Redux model store. One
shared, tab-generic reader forces a single, narrowly-scoped exception (below).

## Scope: self-wrapping conversion

**Decision.** `ProgressTab` becomes self-wrapping — it owns its data via
`useCourseHomeMeta` + a new `useProgressTabData` hook and renders `<TabWithTimer>`
itself. The `index.jsx` route drops `<TabContainer tab="progress"
fetch={fetchProgressTab} isProgressTab>` for a bare `<ProgressTab />`, and
`fetchProgressTab` is deleted.

## `ProgressTab` splits into a thin wrapper + `ProgressTabContent`

**Decision.** `ProgressTab` runs the two queries and renders `<TabWithTimer
courseStatus={{ metadataQuery, tabDataQuery }}><ProgressTabContent /></TabWithTimer>`;
the body moves to `ProgressTabContent`. Same rationale as `OutlineTabContent`:
`TabPage` only renders children once the data has loaded, so the body reading the
query data (`useProgressData()`, and `sectionScores.flatMap(...)`) never runs
before the fetch resolves.

## Progress-specific readers read the query directly — no bridge for them

**Decision.** Every progress-subtree reader of the `progress` model — the ~20
grade/certificate/related-links components, the `ProgressTabGradeBreakdownSlot`
plugin slot, `ProgressHeader`, and `ProgressTabContent` — stops calling
`useModel('progress', courseId)` and reads the tab data from `useProgressTabData`
(via the `useProgressData` hook below). No model-store round-trip.

**Why.** The goal of the epic is to remove Redux, not to keep relocating reads
onto a transitional bridge. We're already editing every one of these files to
move `courseId` off `useContextId()` (required — see below), so converting the
read in the same pass costs almost nothing and actually retires the Redux
dependency instead of deferring it. React Query dedupes on the query key, so the
wrapper's `useProgressTabData` and every reader share one fetch.

## `useProgressData()` reader hook

**Decision.** Add `useProgressData()` (in `progress-tab/hooks.jsx`):
`const { courseId, targetUserId } = useParams(); return useProgressTabData(courseId,
targetUserId).data;`. Subtree readers call `useProgressData()` and destructure.

**Why.** React Query keys by every argument, so a reader must pass the *same*
`targetUserId` as the wrapper to hit the same cache entry — otherwise, on the
staff `/progress/:targetUserId/` route, it would key on `undefined`, fire a second
fetch, and show the requesting user's grades instead of the learner's. Threading
`targetUserId` through ~20 leaves is noise; the model store used to hide it (one
`progress` model keyed by `courseId`, the target user's data baked in). This hook
restores that ergonomic: callers name neither `targetUserId` nor (usually)
`courseId`. The wrapper still uses raw `useProgressTabData` because it needs the
full query object (`isLoading`/`isError`) for gating.

## The one shared reader keeps the `meta` bridge (its migration is deferred)

**Decision.** `useProgressTabData` keeps `meta: { modelType: 'progress', courseId }`,
so the model-store bridge still populates `useModel('progress', courseId)` — **for
exactly one reader**: `useAccessExpirationMasqueradeBanner(courseId, tab)` (rendered
by the shared `InstructorToolbar`) does `useModel(tab, courseId)` and reads
`accessExpiration.masqueradingExpiredCourse` for the "this learner's access expired"
masquerade banner. It's the only dynamic `useModel(<var>)` reader that resolves to
`'progress'` (the others are dates/outline/courseware); a literal `useModel('progress'`
grep misses it. Every *progress-specific* reader is already off the bridge (above) —
this is the lone shared, tab-generic holdout.

**Why keep it rather than migrate it here.** We tried migrating this banner first,
as a lower stack layer, so progress could be fully bridge-free — it doesn't work
cleanly. `accessExpiration` lives in per-tab data, the banner's consumer is the
shared, tab-generic `InstructorToolbar`, and only some tabs are query-backed, so
every mid-transition shape is bad: thread it down → the hook *takes its own data
in* (inverting the responsibility of a hook named for that data); have the hook
read the cache → a generic `alerts/` hook has to import `course-home` query keys
and special-case progress's `targetUserId`. Both still need a `useModel` fallback
for the unconverted tabs. It's only clean once every tab is query-backed. So the
banner migration is **deferred to the model-store dissolution (#1977)** and tracked
in **#1999**; the `meta` here retires with the rest of the bridge at that point.
The model store persists until #1977 regardless, so this one `meta` line is just
one more consumer of a bridge that's staying anyway — not worth holding up progress
or contorting the banner for.

## Subtree `courseId`: `useContextId()` → `useParams` (required)

**Decision.** The 20 progress-only subtree components + the
`ProgressTabGradeBreakdownSlot` move `courseId` from `useContextId()` to
`useParams` (most drop `courseId` entirely, reading `useProgressData()` instead;
the handful that use `courseId` elsewhere keep `const { courseId } = useParams()`).

**Why — required, not cosmetic.** `useContextId()` reads
`state.courseware.courseId ?? state.courseHome.courseId`; the `courseHome` one is
only set by the fetch thunk. Once the route stops running it, `useContextId()`
returns `undefined` and every reader misses. All 20 were verified progress-only.

## `targetUserId` from `useParams`, with the int comparison preserved

**Decision.** `ProgressHeader` reads `targetUserId` from `useParams` (a string)
and parses it for its one numeric use — the `targetUserId !== userId` title check
(`userId` is a number). The old thunk `parseInt`'d `targetUserId` into the slice,
so a faithful conversion keeps that an int comparison rather than switching to a
string compare.

## Masquerade heading is a pre-existing bug, left out of scope (#2000)

**Decision.** `ProgressHeader` keeps deriving "viewing another student" from the URL
`:targetUserId` segment (the faithful conversion above — `parseInt(useParams()
.targetUserId, 10)`). We do **not** extend it to also cover the masquerade bar.

**Why.** Manual testing surfaced that masquerading as a *specific student* via the
masquerade bar shows "Your progress" instead of "Course progress for &lt;username&gt;":
the bar sets a server-side session and leaves the URL (and `:targetUserId`) unchanged,
so the check is false. Confirmed **pre-existing on `master`** — the conversion preserves
the behavior exactly (old: slice `targetUserId` undefined → falsy; new:
`parseInt(undefined, 10)` → `NaN` → falsy). It's an independent bug whose real fix is
non-trivial (distinguishing specific-student masquerade from generic-role masquerade
needs a signal beyond the URL — the masquerade *target identity*), so bundling it would
break the faithful-conversion principle. Filed standalone as **#2000**. A `username`-based
proxy was considered and rejected as too indirect. (The deep-link `/progress/:targetUserId/`
path is unaffected and works.)

## `examsData` stays for now — a separate Redux write to retire later

**Decision.** Leave the exam-attempts path (`useGetExamsData` →
`fetchExamAttemptsData` → `state.courseHome.examsData`, via `getExamsData`) in
place; only its `courseId` source moves to `useParams`.

**Why (and not "it's a plugin contract").** It's a fire-and-forget Redux *write*
with no in-repo reader — it exists so plugin slots can read `examsData` from the
store (PR #1829). The Redux store isn't a supported plugin API, so that's not a
reason to preserve it; it's just another Redux surface to remove. But removing it
means giving plugins a query-based replacement, which is its own task — so it's
out of scope here, not something we protect. (An earlier note calling it a
"contract to keep" was wrong.)

## Route + `TabContainer` cleanups

**Decision.** Delete `fetchProgressTab` (only the route wrapper called it), and
remove the now-dead `isProgressTab` prop + its `targetUserId` fetch branch from
`TabContainer` (progress was its only consumer). The shared `fetchTab` helper
stays (live and discussion still use it).

## Coverage: preserve the shared `fetchTab` helper's coverage

**Decision.** When removing the `fetchProgressTab` redux test, keep the shared
`fetchTab` helper covered by a remaining tab test (live/discussion still use it),
adding one if needed. Give `useProgressTabData` its own `apiHooks.test` (success +
error). Same indirect-coverage trap the outline PR hit in `getOutlineTabData`.

## Test conversion

**`ProgressTab.test.jsx` renders the self-wrapping tab through the bridged query
client.** The `fetchAndRender` helper drops `executeThunk(fetchProgressTab)` +
bare `render(<ProgressTab />)` for the `OutlineTab.test` pattern: an `AppProvider`
+ `MemoryRouter` (route `/course/:courseId/progress/:targetUserId?`) +
`createTestQueryClient(store)` (the model-store bridge, so the one remaining
`useModel('progress')` reader still resolves) + `UserMessagesProvider`/`ToastProvider`,
then waits for the loading `status` role to clear. The masquerade / course-start
banner tests previously hand-rendered `<LoadedTabPage …>...</LoadedTabPage>`; they
now render the full `<ProgressTab />` and assert on the `instructor-toolbar` the
tab draws itself — same as the outline access-expiration tests.

**Two existing selectors had to disambiguate now that the full page (with tab
navigation) renders.** Rendering the whole tab, not just its content, adds the
header + `CourseTabsNavigationSlot` links to the DOM:
- The "Dates" related-link is scoped to the "Related links" `section` via
  `within(...)`, because the tab nav also has a "Dates" link.
- The two "locked feature" tests asserted on `getAllByRole('link', 'Unlock now')`
  — `'Unlock now'` is a positional string (an ignored options arg), so the query
  actually matched *every* link and only passed because the content-only render
  had exactly three. They now target the real button, `{ name: 'Upgrade now' }`
  (there is exactly one), keeping the existing `getAllByRole`/index/`fireEvent`
  style.

**The exam re-fetch test drives the data change through the query.** "Re-fetch
exam data when section scores change" used to re-run `fetchProgressTab`; it now
calls `queryClient.invalidateQueries()` (the helper returns the client) so the tab
query refetches the updated mock and `useGetExamsData` re-fires.

**`redux.test.js`** drops the whole `Test fetchProgressTab` block (thunk deleted).
`fetchTab` stays covered by `DiscussionTab.test` (its `TabContainer` mount dispatches
`fetchDiscussionTab` → `fetchTab`); `getProgressTabData`'s success/transform,
`targetUserId` URL, and 401/403/404/other-error branches move to the
`useProgressTabData` block in `apiHooks.test`. The 404 branch calls
`global.location.replace`, so that one case swaps `window.location` (non-configurable
`replace` can't be spied) inside a `try/finally` that always restores it.

**`TabContainer.test.jsx`** drops the `isProgressTab` `targetUserId` test — the prop
and its fetch branch are gone, and that behavior now lives in the progress query's
`useParams`/`useProgressTabData` path (covered by the `/progress/10/` route test).

## Manual testing (in-browser) vs. what we lean on the automated suite for

Tested in a real browser against a live backend (tutor local), scoped to what this
PR changes.

**Verified by hand:**
- Cold load + hard-reload directly on the progress URL (the `useProgressTabData`
  fetch path; nothing pre-fetched).
- The whole grade subtree renders off the `useParams` `courseId` — the highest-risk
  mechanical rewrite: course-grade header, grade summary, detailed grades + the
  per-problem drawer + subsection navigation, related-links + their analytics event,
  and the completion graph.
- Staff deep-link `/progress/<numericId>/`: heading shows "Course progress for
  &lt;username&gt;", the body shows *that* learner's grades/certificate, and the Studio
  link shows for admins.
- Access-expiration masquerade banner correctly **absent** for a masqueraded learner
  with active access.
- 404 on the progress data → redirect to the legacy `/courses/<id>/progress`.

**Left to the automated suite (not re-done by hand):**
- Both *positive* masquerade banners (access-expired shows; course-start shows) —
  `ProgressTab.test` renders them through the bridged query client, which exercises
  the retained one-reader `meta` bridge end-to-end in-test.
- Certificate states + "Request certificate" — `ProgressTab.test` Certificate Status suite.
- Locked/limited "Upgrade now" preview + its analytics — `ProgressTab.test` locked-feature tests.
- Exam-data integration (`examsData`) — `ProgressTab.test` exam-integration suite + `redux.test`'s `fetchExamAttemptsData`.
- Per-learner query keying (switching `targetUserId`) — the query key includes
  `targetUserId` (`queryKeys` + the `apiHooks` targetUserId-URL test); not re-checked in-browser.
- Denied / unenrolled path — shared `TabPage` denied handling.

The masquerade-bar heading is the known pre-existing bug (#2000 above), not covered here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
