### PR TITLE
style: Update course outline sidebar styling and use theme tokens

### DIFF
--- a/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss
+++ b/src/courseware/course/sidebar/sidebars/course-outline/CourseOutlineTray.scss
@@ -13,7 +13,7 @@
 }
 
 .outline-sidebar-heading-wrapper {
-    border: 1px solid #d7d3d1;
+    border: 1px solid var(--pgn-color-light-700);
 
     &.sticky {
         position: sticky;
@@ -29,7 +29,11 @@
 
 .course-sidebar-section {
     background: var(--pgn-color-white);
-    border: 1px solid #d7d3d1;
+    border: 1px solid var(--pgn-color-light-700);
+
+    &.active-section button {
+        background-color: var(--pgn-color-info-100);
+    }
 
     button {
         line-height: 1.75rem;

--- a/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarSection.jsx
+++ b/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarSection.jsx
@@ -48,13 +48,10 @@ const SidebarSection = ({ section, handleSelectSection }) => {
   );
 
   return (
-    <li className="mb-2 course-sidebar-section">
+    <li className={classNames('mb-2 course-sidebar-section', { 'active-section': isActiveSection })}>
       <Button
         variant="tertiary"
-        className={classNames(
-          'd-flex align-items-center w-100 px-4 py-3.5 rounded-0 justify-content-start',
-          { 'bg-info-100': isActiveSection },
-        )}
+        className="d-flex align-items-center w-100 px-4 py-3.5 rounded-0 justify-content-start"
         onClick={() => handleSelectSection(id)}
       >
         {sectionTitle}

--- a/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarUnit.tsx
+++ b/src/courseware/course/sidebar/sidebars/course-outline/components/SidebarUnit.tsx
@@ -45,7 +45,7 @@ const SidebarUnit = ({
   const unitIcon = <UnitIcon type={iconType} isCompleted={completeAndEnabled} />;
   return (
     <li className={classNames({
-      'bg-info-100': isActive,
+      'active-unit bg-info-100': isActive,
       'border-top border-light': !isFirst,
     })}
     >


### PR DESCRIPTION
- Replace hardcoded border color (#d7d3d1) with var(--pgn-color-light-700) in CourseOutlineTray.scss for theme compatibility.
- Move active-section highlight to a dedicated .active-section class on SidebarSection and add an .active-unit class on SidebarUnit.