### PR TITLE
refactor: convert the discussion tab from Redux to React Query

### DIFF
--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -84,10 +84,6 @@ export function fetchLiveTab(courseId) {
   return fetchTab(courseId, 'live', getLiveTabIframe);
 }
 
-export function fetchDiscussionTab(courseId) {
-  return fetchTab(courseId, 'discussion');
-}
-
 export async function deprecatedSaveCourseGoal(courseId, goalKey) {
   return deprecatedPostCourseGoals(courseId, goalKey);
 }

--- a/src/course-home/discussion-tab/DiscussionTab.jsx
+++ b/src/course-home/discussion-tab/DiscussionTab.jsx
@@ -1,12 +1,12 @@
 import { getConfig } from '@edx/frontend-platform';
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
 import { useParams, generatePath, useNavigate } from 'react-router-dom';
 import { useIFrameHeight, useIFramePluginEvents } from '../../generic/hooks';
+import { useCourseHomeMeta } from '../data/apiHooks';
+import { TabWithTimer } from '../../tab-page';
 
-const DiscussionTab = () => {
-  const { courseId } = useSelector(state => state.courseHome);
-  const { path } = useParams();
+const DiscussionTabContent = () => {
+  const { courseId, path } = useParams();
   const [originalPath] = useState(path);
   const navigate = useNavigate();
 
@@ -26,6 +26,22 @@ const DiscussionTab = () => {
       style={{ minHeight: '60rem' }}
       title="discussion"
     />
+  );
+};
+
+const DiscussionTab = () => {
+  const { courseId } = useParams();
+
+  const metadataQuery = useCourseHomeMeta(courseId);
+
+  return (
+    <TabWithTimer
+      activeTabSlug="discussion"
+      courseId={courseId}
+      courseStatus={{ metadataQuery }}
+    >
+      <DiscussionTabContent />
+    </TabWithTimer>
   );
 };
 

--- a/src/course-home/discussion-tab/DiscussionTab.test.jsx
+++ b/src/course-home/discussion-tab/DiscussionTab.test.jsx
@@ -13,9 +13,7 @@ import {
   createTestQueryClient, initializeMockApp, messageEvent, screen, waitFor,
 } from '../../setupTest';
 import initializeStore from '../../store';
-import { TabContainer } from '../../tab-page';
 import { appendBrowserTimezoneToUrl } from '../../utils';
-import { fetchDiscussionTab } from '../data/thunks';
 import DiscussionTab from './DiscussionTab';
 
 initializeMockApp();
@@ -31,17 +29,13 @@ describe('DiscussionTab', () => {
     store = initializeStore();
     component = (
       <AppProvider store={store}>
-        <QueryClientProvider client={createTestQueryClient()}>
+        <QueryClientProvider client={createTestQueryClient(store)}>
           <UserMessagesProvider>
             <ToastProvider>
               <Routes>
                 <Route
                   path="/course/:courseId/discussion"
-                  element={(
-                    <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
-                      <DiscussionTab />
-                    </TabContainer>
-                  )}
+                  element={<DiscussionTab />}
                 />
               </Routes>
             </ToastProvider>

--- a/src/generic/CourseAccessErrorPage.jsx
+++ b/src/generic/CourseAccessErrorPage.jsx
@@ -1,13 +1,11 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useParams, Navigate } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { FooterSlot } from '@edx/frontend-component-footer';
-import { LOADED, LOADING } from '@src/constants';
 import HeaderSlot from '../plugin-slots/HeaderSlot';
 import useActiveEnterpriseAlert from '../alerts/active-enteprise-alert';
 import { AlertList } from './user-messages';
-import { fetchDiscussionTab } from '../course-home/data/thunks';
+import { useCourseHomeMeta } from '../course-home/data/apiHooks';
 import PageLoading from './PageLoading';
 import messages from '../tab-page/messages';
 
@@ -15,18 +13,10 @@ const CourseAccessErrorPage = () => {
   const intl = useIntl();
   const { courseId } = useParams();
 
-  const dispatch = useDispatch();
   const activeEnterpriseAlert = useActiveEnterpriseAlert(courseId);
-  useEffect(() => {
-    dispatch(fetchDiscussionTab(courseId));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [courseId]);
+  const metadataQuery = useCourseHomeMeta(courseId);
 
-  const {
-    courseStatus,
-  } = useSelector(state => state.courseHome);
-
-  if (courseStatus === LOADING) {
+  if (metadataQuery.isPending) {
     return (
       <>
         <HeaderSlot />
@@ -37,7 +27,7 @@ const CourseAccessErrorPage = () => {
       </>
     );
   }
-  if (courseStatus === LOADED) {
+  if (metadataQuery.data?.courseAccess?.hasAccess) {
     return <Navigate to={`/redirect/home/${courseId}`} replace />;
   }
   return (

--- a/src/generic/CourseAccessErrorPage.test.jsx
+++ b/src/generic/CourseAccessErrorPage.test.jsx
@@ -4,22 +4,14 @@ import { Routes, Route } from 'react-router-dom';
 import { initializeTestStore, render, screen } from '../setupTest';
 import CourseAccessErrorPage from './CourseAccessErrorPage';
 
-const mockDispatch = jest.fn();
-const mockNavigate = jest.fn();
-let mockCourseStatus;
+let mockMetadataQuery;
 
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useDispatch: () => mockDispatch,
-  useSelector: () => ({ courseStatus: mockCourseStatus }),
+jest.mock('../course-home/data/apiHooks', () => ({
+  useCourseHomeMeta: () => mockMetadataQuery,
 }));
 jest.mock('./PageLoading', () => function () {
   return <div data-testid="page-loading" />;
 });
-jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom')),
-  useNavigate: () => mockNavigate,
-}));
 
 describe('CourseAccessErrorPage', () => {
   let courseId;
@@ -32,7 +24,7 @@ describe('CourseAccessErrorPage', () => {
   });
 
   it('Displays loading in start on page rendering', () => {
-    mockCourseStatus = 'loading';
+    mockMetadataQuery = { isPending: true, data: undefined };
     render(
       <Routes>
         <Route path="/course/:courseId/access-denied" element={<CourseAccessErrorPage />} />
@@ -44,7 +36,7 @@ describe('CourseAccessErrorPage', () => {
   });
 
   it('Redirect user to homepage if user has access', () => {
-    mockCourseStatus = 'loaded';
+    mockMetadataQuery = { isPending: false, data: { courseAccess: { hasAccess: true } } };
     render(
       <Routes>
         <Route path="/course/:courseId/access-denied" element={<CourseAccessErrorPage />} />
@@ -55,7 +47,20 @@ describe('CourseAccessErrorPage', () => {
   });
 
   it('For access denied it should render access denied page', () => {
-    mockCourseStatus = 'denied';
+    mockMetadataQuery = { isPending: false, data: { courseAccess: { hasAccess: false } } };
+
+    render(
+      <Routes>
+        <Route path="/course/:courseId/access-denied" element={<CourseAccessErrorPage />} />
+      </Routes>,
+      { wrapWithRouter: true },
+    );
+    expect(screen.getByTestId('access-denied-main')).toBeInTheDocument();
+    expect(window.location.pathname).toBe(accessDeniedUrl);
+  });
+
+  it('For a failed metadata query it should render access denied page', () => {
+    mockMetadataQuery = { isPending: false, isError: true, data: undefined };
 
     render(
       <Routes>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,7 @@ import { createRoot } from 'react-dom/client';
 import { Routes, Route } from 'react-router-dom';
 
 import { Helmet } from 'react-helmet';
-import { fetchDiscussionTab, fetchLiveTab } from './course-home/data/thunks';
+import { fetchLiveTab } from './course-home/data/thunks';
 import DiscussionTab from './course-home/discussion-tab/DiscussionTab';
 
 import messages from './i18n';
@@ -100,9 +100,7 @@ subscribe(APP_READY, () => {
                         path={DECODE_ROUTES.DISCUSSION}
                         element={(
                           <DecodePageRoute>
-                            <TabContainer tab="discussion" fetch={fetchDiscussionTab} slice="courseHome">
-                              <DiscussionTab />
-                            </TabContainer>
+                            <DiscussionTab />
                           </DecodePageRoute>
                       )}
                       />

--- a/src/tab-page/TabPage.tsx
+++ b/src/tab-page/TabPage.tsx
@@ -27,7 +27,7 @@ import { TourProvider } from '../product-tours/TourContext';
 // metadata query is typed to only the field this file reads, not the whole (untyped) shape.
 export type CourseStatus = StatusValue | {
   metadataQuery: UseQueryResult<{ courseAccess?: { hasAccess: boolean } }>;
-  tabDataQuery: UseQueryResult;
+  tabDataQuery?: UseQueryResult;
 };
 
 export interface TabPageProps {
@@ -60,9 +60,9 @@ const deriveView = (courseStatus: CourseStatus): TabView => {
   const { metadataQuery, tabDataQuery } = courseStatus;
   if (metadataQuery.isError) { return { ...view, isError: true }; }
   if (metadataQuery.isPending) { return { ...view, isLoading: true }; }
-  if (tabDataQuery.isPending) { return { ...view, isLoading: true }; }
+  if (tabDataQuery?.isPending) { return { ...view, isLoading: true }; }
   if (!metadataQuery.data?.courseAccess?.hasAccess) { return { ...view, isDenied: true }; }
-  if (tabDataQuery.isError) { return { ...view, isError: true }; }
+  if (tabDataQuery?.isError) { return { ...view, isError: true }; }
   return view;
 };
 


### PR DESCRIPTION
## Summary

Convert the course-home **discussion tab** from Redux to React Query. Part of the Redux → React Query migration (#1946), stacked on the progress-tab conversion (#2001), below the live-tab conversion (#2002). Closes #2003.

The discussion tab is **metadata-only** (no tab-data endpoint), so it self-wraps `<TabWithTimer>` with just `useCourseHomeMeta` and needs no model-store bridge. The other `fetchDiscussionTab` caller (`CourseAccessErrorPage`) is converted too, so the thunk is deleted outright.

## What changed

- **`tab-page/TabPage.tsx`** — `tabDataQuery` is now optional in `CourseStatus`; `deriveView` guards its two `tabDataQuery` checks. A metadata-only tab passes `courseStatus={{ metadataQuery }}`; the data-bearing tabs still pass both.
- **`course-home/discussion-tab/DiscussionTab.jsx`** — self-wrapping: a thin data-owning `DiscussionTab` (runs `useCourseHomeMeta`, renders `<TabWithTimer>`) + a `DiscussionTabContent` child holding the iframe and the `useIFrameHeight`/`useIFramePluginEvents('discussions.navigate')` wiring, so it mounts post-load. `courseId`/`path` from `useParams`.
- **`generic/CourseAccessErrorPage.jsx`** — the other `fetchDiscussionTab` caller (a metadata-only access probe) moves to `useCourseHomeMeta`; its four-state `courseStatus` branch maps 1:1 to the query states.
- **`index.jsx`** — discussion route → bare `<DiscussionTab />`; `fetchDiscussionTab` import/wiring dropped.
- **`course-home/data/thunks.js`** — `fetchDiscussionTab` deleted (both callers converted). The shared `fetchTab` helper and `fetchLiveTab` stay — the live tab consumes them until #2002, where `fetchTab` retires.

## Behavior

No user-facing change. No `discussion` model bridge is added: `fetchDiscussionTab` never wrote a `discussion` model, so `useModel('discussion')` was already empty and the access-expiration masquerade banner never rendered on this tab — preserved exactly. `TabWithTimer` is retained, so the outer exam timer still mounts as it did via `TabContainer`.

## Testing

`npm run types`, `npm run lint`, and the affected suites pass. `DiscussionTab.test.jsx` renders `<DiscussionTab />` through the bridged query client; `CourseAccessErrorPage.test.jsx` mocks `useCourseHomeMeta` (loading / has-access redirect / denied); `redux.test.js` is untouched (the shared `fetchTab` helper retires in the live layer, #2002). Manual browser verification and the manual-vs-automated split are documented in the decision log below.

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — Redux → React Query: the discussion tab (#1946)

Working notes for this PR (part of the wider Redux → React Query migration,
#1946). **Not checked in** — referenced when opening the PR. Part of #1975
(course-home tab data), stacked on the progress-tab conversion (#2001), **below**
the live-tab conversion (#2002). Closes #2003.

The discussion tab is the simplest course-home conversion: it's **metadata-only**
(no tab-data endpoint) and needs **no model-store bridge**. The only real work
beyond the self-wrap is a small shared-type change (a metadata-only tab is now a
first-class shape) and converting the *other* `fetchDiscussionTab` caller so the
thunk can be deleted outright.

## Scope: self-wrapping conversion

**Decision.** `DiscussionTab` becomes self-wrapping — it owns its access gating
via `useCourseHomeMeta` and renders `<TabWithTimer>` itself. The `index.jsx`
route drops `<TabContainer tab="discussion" fetch={fetchDiscussionTab}
slice="courseHome">` for a bare `<DiscussionTab />`.

## The discussion tab is metadata-only — `tabDataQuery` becomes optional

**Decision.** `fetchDiscussionTab` was `fetchTab(courseId, 'discussion')` with
**no `getTabData`** — it only fetched course metadata (for access gating); the tab
itself builds the discussions-MFE iframe URL from `courseId` + the route `path`,
reading no tab-data model. So the converted tab has a `metadataQuery` and no
tab-data query, and passes `courseStatus={{ metadataQuery }}`.

To make that a first-class shape, `TabPage`'s `CourseStatus` marks `tabDataQuery`
optional and `deriveView` guards its two checks (`tabDataQuery?.isError`
/ `?.isLoading`). The data-bearing tabs (dates/outline/progress/live) still pass
both — nothing changes for them.

**Rejected:** passing `metadataQuery` as a dummy `tabDataQuery` to avoid touching
`TabPage`. That double-reads the same query and reads confusingly at the call
site; "a tab may have only metadata" is the honest model.

## `DiscussionTab` splits into a thin wrapper + `DiscussionTabContent`

**Decision.** `DiscussionTab` runs the metadata query and renders
`<TabWithTimer courseStatus={{ metadataQuery }}><DiscussionTabContent /></TabWithTimer>`;
the iframe + its `useIFrameHeight`/`useIFramePluginEvents('discussions.navigate')`
wiring move to `DiscussionTabContent`. Same rationale as the outline/progress
splits: `TabPage` only renders children once loaded, so the plugin-event
registration and iframe mount happen post-load — matching today's timing, where
`DiscussionTab` is `TabContainer`'s already-loaded child.

## `TabWithTimer` is kept (the discussion tab always had the exam timer)

**Decision.** Keep `TabWithTimer`, not bare `TabPage`. The old Redux path wrapped
discussion in `TabContainer`, which renders `TabWithTimer` (→ `OuterExamTimer`).
So the discussion tab has always rendered the outer exam timer; keeping
`TabWithTimer` preserves that exactly.

## No transitional bridge

**Decision.** `useCourseHomeMeta` keeps its existing `courseHomeMeta` bridge (as
on every tab, for the shared `TabPage`/`LoadedTabPage` reads), but the discussion
tab adds **no `discussion` bridge**. `fetchDiscussionTab` never wrote a
`discussion` model (no `getTabData`), so `state.models.discussion` was always
empty — the masquerade banner's `useModel('discussion')` already resolves empty
and never rendered on this tab. Preserved exactly, no bridge needed.

## `courseId` from `useParams`

**Decision.** Both `DiscussionTab` and `DiscussionTabContent` read `courseId`
(and `path`) from `useParams`, replacing `useSelector(state.courseHome.courseId)`.
Required: with no fetch thunk, `state.courseHome.courseId` is never set for this
route.

## CourseAccessErrorPage converted too (the other `fetchDiscussionTab` caller)

**Decision.** `generic/CourseAccessErrorPage.jsx` dispatched `fetchDiscussionTab`
purely as a cheap **access probe** — metadata-only — then read
`state.courseHome.courseStatus` to decide: redirect home vs. show the denied
page. It's moved to `useCourseHomeMeta(courseId)`. It never needed anything
discussion-specific; converting it lets `fetchDiscussionTab` be deleted entirely.

The four-state `courseStatus` branch maps cleanly onto the query:

| Old (`courseStatus`) | New (`metadataQuery`) |
|---|---|
| `LOADING` (initial + fetching) → loading | `isLoading` → loading |
| `LOADED` (set only after a `hasAccess` success) → redirect | `data.courseAccess.hasAccess` → redirect |
| `DENIED` / `FAILED` → denied page | else (success-without-access **or** error) → denied page |

`useCourseHomeMeta` is always enabled, so it's `isLoading` on first mount (no
premature "denied" flash before data arrives).

## `fetchDiscussionTab` deleted; `fetchTab` kept for the live layer

**Decision.** Delete `fetchDiscussionTab` (both callers converted). Keep the
shared `fetchTab` helper and `fetchLiveTab` — the live tab still consumes them
until #2002.

## Ordering: below live, so `fetchTab` retires cleanly there

**Decision.** Sequence discussion **below** live. After this layer,
`fetchLiveTab` is `fetchTab`'s sole remaining consumer, so the live layer (#2002)
deletes `fetchLiveTab`, the now-orphaned `fetchTab`, and the `redux.test.js`
`Test fetchTab` block in one clean removal. The alternative order (live first)
would force retargeting that test block from `fetchLiveTab` → `fetchDiscussionTab`
and then deleting it a layer later — churn on `redux.test.js` for no benefit.
Consequently `redux.test.js` is **untouched** in this layer.

## Tests

- `DiscussionTab.test.jsx` renders `<DiscussionTab />` directly through the
  bridged query client (`createTestQueryClient(store)`), dropping the
  `TabContainer` + `fetchDiscussionTab` wrapper. The existing iframe-resize
  assertion is unchanged (it exercises `DiscussionTabContent`).
- `CourseAccessErrorPage.test.jsx` mocks `useCourseHomeMeta` instead of the
  Redux `useSelector`/`useDispatch`; the three cases (loading / has-access
  redirect / denied) map 1:1 to the query states above.
- `redux.test.js` — untouched (see Ordering).

## Manual testing (in-browser)

**Verified:**

- **`CourseAccessErrorPage`** (the real behavioral change) — all three states,
  confirmed on both this branch *and* the untouched Redux branch, so the
  `useCourseHomeMeta` swap is behavior-preserving: non-enrolled → renders the
  access-denied page (`access-denied-main` present, `has_access:false` in the
  metadata response, URL stays); enrolled → redirects to `/redirect/home/<courseId>`;
  brief loading spinner before metadata resolves.
- **Discussion embedded load** — the discussions MFE renders embedded in the tab's
  iframe on a cold, direct-URL load. The doubled header is expected for an embedded
  MFE and is unchanged from master.

**Not manually exercised (and why it's fine):**

- *Navigate into the tab from another tab* / *in-iframe topic-click navigation* —
  in this env the nav Discussion tab links to the **external** discussions MFE
  (per the metadata `tabs`), so the embedded route isn't entered organically. The
  `discussions.navigate` → `navigate` wiring is unchanged from the pre-conversion
  component.
- *Exam timer on discussion* — no active timed exam handy; preservation is assured
  structurally (`TabContainer` always wrapped discussion in `TabWithTimer`, and the
  converted tab keeps it).
- *Discussion route for a no-access course* — redirects to `/home` via
  `getAccessDeniedRedirectUrl('discussion')` (inline denied is outline-only);
  matches master.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
