### PR TITLE
refactor: convert the live tab from Redux to React Query

### DIFF
--- a/src/course-home/data/apiHooks.test.tsx
+++ b/src/course-home/data/apiHooks.test.tsx
@@ -8,7 +8,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '../../setupTest';
 import { ToastProvider, useToast } from '../../generic/ToastContext';
 import {
-  useOutlineTabData, useProgressTabData, useResetDeadlines, usePostEvent, useRequestCert,
+  useOutlineTabData, useLiveTabData, useProgressTabData, useResetDeadlines, usePostEvent, useRequestCert,
   useDismissWelcomeMessage, useSaveWeeklyLearningGoal,
 } from './apiHooks';
 
@@ -189,6 +189,46 @@ describe('course-home apiHooks', () => {
       axiosMock.onGet(outlineUrl).reply(500);
       const { wrapper } = buildWrapper();
       const { result } = renderHook(() => useOutlineTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+
+  describe('useLiveTabData', () => {
+    const liveUrl = `${getConfig().LMS_BASE_URL}/api/course_live/iframe/course-1/`;
+
+    it('resolves to the iframe payload', async () => {
+      axiosMock.onGet(liveUrl).reply(200, { iframe: 'https://example.com/live' });
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useLiveTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual({ iframe: 'https://example.com/live' });
+    });
+
+    it('resolves to an empty object on a 404', async () => {
+      axiosMock.onGet(liveUrl).reply(() => Promise.reject(
+        Object.assign(new Error('Request failed with status code 404'), {
+          response: { status: 404, data: {} },
+          customAttributes: { httpErrorStatus: 404 },
+        }),
+      ));
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useLiveTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual({});
+    });
+
+    it('surfaces the error on a non-404 failure', async () => {
+      axiosMock.onGet(liveUrl).reply(() => Promise.reject(
+        Object.assign(new Error('Request failed with status code 500'), {
+          response: { status: 500, data: {} },
+          customAttributes: { httpErrorStatus: 500 },
+        }),
+      ));
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useLiveTabData('course-1'), { wrapper });
 
       await waitFor(() => expect(result.current.isError).toBe(true));
     });

--- a/src/course-home/data/apiHooks.ts
+++ b/src/course-home/data/apiHooks.ts
@@ -6,6 +6,7 @@ import {
   executePostFromPostEvent,
   getCourseHomeCourseMetadata,
   getDatesTabData,
+  getLiveTabIframe,
   getOutlineTabData,
   getProgressTabData,
   postCourseDeadlines,
@@ -73,6 +74,12 @@ export const useOutlineTabData = (courseId: string) => useQuery({
   queryKey: courseHomeQueryKeys.outlineTab(courseId),
   queryFn: () => getOutlineTabData(courseId),
   meta: { modelType: 'outline', courseId },
+});
+
+export const useLiveTabData = (courseId: string) => useQuery({
+  queryKey: courseHomeQueryKeys.liveTab(courseId),
+  queryFn: () => getLiveTabIframe(courseId),
+  refetchOnWindowFocus: false,
 });
 
 export const useProgressTabData = (courseId: string, targetUserId?: string) => useQuery({

--- a/src/course-home/data/queryKeys.ts
+++ b/src/course-home/data/queryKeys.ts
@@ -5,5 +5,6 @@ export const courseHomeQueryKeys = {
   metadata: (courseId: string) => [...courseHomeQueryKeys.all, 'metadata', courseId] as const,
   datesTab: (courseId: string) => [...courseHomeQueryKeys.all, 'datesTab', courseId] as const,
   outlineTab: (courseId: string) => [...courseHomeQueryKeys.all, 'outlineTab', courseId] as const,
+  liveTab: (courseId: string) => [...courseHomeQueryKeys.all, 'liveTab', courseId] as const,
   progressTab: (courseId: string, targetUserId?: string) => [...courseHomeQueryKeys.all, 'progressTab', courseId, targetUserId] as const,
 };

--- a/src/course-home/data/redux.test.js
+++ b/src/course-home/data/redux.test.js
@@ -6,7 +6,7 @@ import { getConfig } from '@edx/frontend-platform';
 
 import * as thunks from './thunks';
 
-import { appendBrowserTimezoneToUrl, executeThunk } from '../../utils';
+import { executeThunk } from '../../utils';
 
 import { initializeMockApp } from '../../setupTest';
 import initializeStore from '../../store';
@@ -18,20 +18,6 @@ const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
 describe('Data layer integration tests', () => {
   const courseHomeMetadata = Factory.build('courseHomeMetadata');
   const { id: courseId } = courseHomeMetadata;
-  let courseMetadataUrl = `${getConfig().LMS_BASE_URL}/api/course_home/course_metadata/${courseId}`;
-  courseMetadataUrl = appendBrowserTimezoneToUrl(courseMetadataUrl);
-
-  const courseHomeAccessDeniedMetadata = Factory.build(
-    'courseHomeMetadata',
-    {
-      id: courseId,
-      course_access: {
-        has_access: false,
-        error_code: 'bad codes',
-        additional_context_user_message: 'your Codes Are BAD',
-      },
-    },
-  );
 
   let store;
 
@@ -225,47 +211,6 @@ describe('Data layer integration tests', () => {
 
       // Verify error was logged for the 500 error (may be called more than once due to multiple URL patterns)
       expect(loggingService.logError).toHaveBeenCalled();
-    });
-  });
-
-  describe('Test fetchTab', () => {
-    const liveUrl = `${getConfig().LMS_BASE_URL}/api/course_live/iframe/${courseId}/`;
-
-    it('Should fetch metadata + tab data and mark the tab loaded', async () => {
-      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(liveUrl).reply(200, { iframe: 'https://example.com/live' });
-
-      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
-
-      expect(store.getState().courseHome.courseStatus).toEqual('loaded');
-    });
-
-    it('Should result in denied when the learner lacks course access', async () => {
-      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeAccessDeniedMetadata);
-      axiosMock.onGet(liveUrl).reply(200, {});
-
-      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
-
-      expect(store.getState().courseHome.courseStatus).toEqual('denied');
-    });
-
-    it('Should result in failure when the metadata request errors', async () => {
-      axiosMock.onGet(courseMetadataUrl).networkError();
-      axiosMock.onGet(liveUrl).reply(200, {});
-
-      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
-
-      expect(loggingService.logError).toHaveBeenCalled();
-      expect(store.getState().courseHome.courseStatus).toEqual('failed');
-    });
-
-    it('Should result in failure when the tab data request errors', async () => {
-      axiosMock.onGet(courseMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(liveUrl).reply(500);
-
-      await executeThunk(thunks.fetchLiveTab(courseId), store.dispatch);
-
-      expect(store.getState().courseHome.courseStatus).toEqual('failed');
     });
   });
 });

--- a/src/course-home/data/slice.js
+++ b/src/course-home/data/slice.js
@@ -2,10 +2,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import {
-  LOADING,
   LOADED,
   FAILED,
-  DENIED,
 } from '@src/constants';
 
 const slice = createSlice({
@@ -22,26 +20,11 @@ const slice = createSlice({
     fetchProctoringInfoResolved: (state) => {
       state.proctoringPanelStatus = LOADED;
     },
-    fetchTabDenied: (state, { payload }) => {
-      state.courseId = payload.courseId;
-      state.courseStatus = DENIED;
-    },
     fetchTabFailure: (state, { payload }) => {
       state.courseId = payload.courseId;
       state.courseStatus = FAILED;
       state.errorMessage = payload.errorMessage || null;
       state.errorCode = payload.errorCode || null;
-    },
-    fetchTabRequest: (state, { payload }) => {
-      state.courseId = payload.courseId;
-      state.courseStatus = LOADING;
-      state.errorMessage = null;
-      state.errorCode = null;
-    },
-    fetchTabSuccess: (state, { payload }) => {
-      state.courseId = payload.courseId;
-      state.targetUserId = payload.targetUserId;
-      state.courseStatus = LOADED;
     },
     setExamsData: (state, { payload }) => {
       state.examsData = payload;
@@ -51,10 +34,7 @@ const slice = createSlice({
 
 export const {
   fetchProctoringInfoResolved,
-  fetchTabDenied,
   fetchTabFailure,
-  fetchTabRequest,
-  fetchTabSuccess,
   setExamsData,
 } = slice.actions;
 

--- a/src/course-home/data/thunks.js
+++ b/src/course-home/data/thunks.js
@@ -1,88 +1,16 @@
 import { logError } from '@edx/frontend-platform/logging';
 import {
-  getCourseHomeCourseMetadata,
   getExamsData,
   deprecatedPostCourseGoals,
-  getLiveTabIframe,
 } from './api';
 
 import {
-  addModel,
-} from '../../generic/model-store';
-
-import {
-  fetchTabDenied,
-  fetchTabFailure,
-  fetchTabRequest,
-  fetchTabSuccess,
   setExamsData,
 } from './slice';
 
 export const eventTypes = {
   POST_EVENT: 'post_event',
 };
-
-export function fetchTab(courseId, tab, getTabData, targetUserId) {
-  return async (dispatch) => {
-    dispatch(fetchTabRequest({ courseId }));
-    try {
-      const promisesToFulfill = [getCourseHomeCourseMetadata(courseId, 'outline')];
-      if (getTabData) {
-        promisesToFulfill.push(getTabData(courseId, targetUserId));
-      }
-      const [
-        courseHomeCourseMetadataResult,
-        tabDataResult,
-      ] = await Promise.allSettled(promisesToFulfill);
-      if (courseHomeCourseMetadataResult.status === 'fulfilled') {
-        dispatch(addModel({
-          modelType: 'courseHomeMeta',
-          model: {
-            id: courseId,
-            ...courseHomeCourseMetadataResult.value,
-          },
-        }));
-      }
-      if (tabDataResult?.status === 'fulfilled') {
-        dispatch(addModel({
-          modelType: tab,
-          model: {
-            id: courseId,
-            ...tabDataResult.value,
-          },
-        }));
-      }
-      if (courseHomeCourseMetadataResult.status === 'rejected') {
-        throw courseHomeCourseMetadataResult.reason;
-      } else if (!courseHomeCourseMetadataResult.value.courseAccess.hasAccess) {
-        // If the learner does not have access to the course, short cut to dispatch to a denied response regardless of
-        // the tabDataResult.
-        dispatch(fetchTabDenied({ courseId }));
-      } else if (tabDataResult?.status === 'rejected') {
-        throw tabDataResult.reason;
-      } else {
-        dispatch(fetchTabSuccess({
-          courseId,
-          targetUserId,
-        }));
-      }
-    } catch (e) {
-      // Extract error details from 403 responses
-      let errorMessage = null;
-      let errorCode = null;
-      if (e?.response?.status === 403 && e?.response?.data) {
-        errorMessage = e.response.data.detail || null;
-        errorCode = e.response.data.error_code || null;
-      }
-      dispatch(fetchTabFailure({ courseId, errorMessage, errorCode }));
-      logError(e);
-    }
-  };
-}
-
-export function fetchLiveTab(courseId) {
-  return fetchTab(courseId, 'live', getLiveTabIframe);
-}
 
 export async function deprecatedSaveCourseGoal(courseId, goalKey) {
   return deprecatedPostCourseGoals(courseId, goalKey);

--- a/src/course-home/live-tab/LiveTab.jsx
+++ b/src/course-home/live-tab/LiveTab.jsx
@@ -1,21 +1,48 @@
 import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
 
-const LiveTab = () => {
-  const { courseId } = useSelector(state => state.courseHome);
-  const liveModel = useSelector(state => state.models.live);
+import { useCourseHomeMeta, useLiveTabData } from '../data/apiHooks';
+import { TabWithTimer } from '../../tab-page';
+
+const LiveTabContent = ({ html }) => {
   useEffect(() => {
     const iframe = document.getElementById('lti-tab-embed');
     if (iframe) {
       iframe.className += ' vh-100 w-100 border-0';
     }
-  }, []);
+  }, [html]);
   return (
     <div
       id="live_tab"
       // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: liveModel[courseId]?.iframe }}
+      dangerouslySetInnerHTML={{ __html: html }}
     />
+  );
+};
+
+LiveTabContent.propTypes = {
+  html: PropTypes.string,
+};
+
+LiveTabContent.defaultProps = {
+  html: undefined,
+};
+
+const LiveTab = () => {
+  const { courseId } = useParams();
+
+  const metadataQuery = useCourseHomeMeta(courseId);
+  const tabDataQuery = useLiveTabData(courseId);
+
+  return (
+    <TabWithTimer
+      activeTabSlug="lti_live"
+      courseId={courseId}
+      courseStatus={{ metadataQuery, tabDataQuery }}
+    >
+      <LiveTabContent html={tabDataQuery.data?.iframe} />
+    </TabWithTimer>
   );
 };
 

--- a/src/course-home/live-tab/LiveTab.test.jsx
+++ b/src/course-home/live-tab/LiveTab.test.jsx
@@ -1,0 +1,106 @@
+import { getConfig, history } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { AppProvider } from '@edx/frontend-platform/react';
+import { QueryClientProvider, focusManager } from '@tanstack/react-query';
+import { act, render } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { Factory } from 'rosie';
+import { UserMessagesProvider } from '../../generic/user-messages';
+import { ToastProvider } from '../../generic/ToastContext';
+import {
+  createTestQueryClient, initializeMockApp, screen, waitFor,
+} from '../../setupTest';
+import initializeStore from '../../store';
+import { appendBrowserTimezoneToUrl } from '../../utils';
+import LiveTab from './LiveTab';
+
+initializeMockApp();
+jest.mock('@edx/frontend-platform/analytics');
+
+describe('LiveTab', () => {
+  let axiosMock;
+  let store;
+  let component;
+  let queryClient;
+
+  const courseMetadata = Factory.build('courseHomeMetadata', { user_timezone: 'America/New_York' });
+  const { id: courseId } = courseMetadata;
+
+  let courseMetadataUrl = `${getConfig().LMS_BASE_URL}/api/course_home/course_metadata/${courseId}`;
+  courseMetadataUrl = appendBrowserTimezoneToUrl(courseMetadataUrl);
+  const liveUrl = `${getConfig().LMS_BASE_URL}/api/course_live/iframe/${courseId}/`;
+
+  beforeEach(() => {
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    store = initializeStore();
+    queryClient = createTestQueryClient(store);
+    axiosMock.onGet(courseMetadataUrl).reply(200, courseMetadata);
+    component = (
+      <AppProvider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <UserMessagesProvider>
+            <ToastProvider>
+              <Routes>
+                <Route path="/course/:courseId/live" element={<LiveTab />} />
+              </Routes>
+            </ToastProvider>
+          </UserMessagesProvider>
+        </QueryClientProvider>
+      </AppProvider>
+    );
+    history.push(`/course/${courseId}/live`); // so tab can pull course id from url
+  });
+
+  afterEach(() => {
+    focusManager.setFocused(undefined);
+  });
+
+  it('renders the live iframe html from the query', async () => {
+    axiosMock.onGet(liveUrl).reply(200, {
+      iframe: '<iframe id="lti-tab-embed" title="live-embed" src="https://example.com/live"></iframe>',
+    });
+
+    render(component);
+
+    await waitFor(() => expect(screen.getByTitle('live-embed')).toBeInTheDocument());
+  });
+
+  it('does not refetch the live embed when the window regains focus', async () => {
+    axiosMock.onGet(liveUrl).reply(200, {
+      iframe: '<iframe id="lti-tab-embed" title="live-embed" src="https://example.com/live"></iframe>',
+    });
+
+    render(component);
+    await waitFor(() => expect(screen.getByTitle('live-embed')).toBeInTheDocument());
+
+    const liveCallCount = () => axiosMock.history.get.filter(req => req.url === liveUrl).length;
+    expect(liveCallCount()).toBe(1);
+
+    await act(async () => {
+      focusManager.setFocused(false);
+      focusManager.setFocused(true);
+    });
+
+    expect(liveCallCount()).toBe(1);
+  });
+
+  it('re-applies the sizing classes when the iframe html changes', async () => {
+    axiosMock.onGet(liveUrl).replyOnce(200, {
+      iframe: '<iframe id="lti-tab-embed" title="live-embed" src="https://example.com/live-a"></iframe>',
+    });
+    axiosMock.onGet(liveUrl).reply(200, {
+      iframe: '<iframe id="lti-tab-embed" title="live-embed" src="https://example.com/live-b"></iframe>',
+    });
+
+    render(component);
+    await waitFor(() => expect(screen.getByTitle('live-embed')).toHaveAttribute('src', 'https://example.com/live-a'));
+    expect(screen.getByTitle('live-embed')).toHaveClass('vh-100', 'w-100', 'border-0');
+
+    await act(async () => { await queryClient.invalidateQueries(); });
+
+    await waitFor(() => expect(screen.getByTitle('live-embed')).toHaveAttribute('src', 'https://example.com/live-b'));
+    expect(screen.getByTitle('live-embed')).toHaveClass('vh-100', 'w-100', 'border-0');
+  });
+});

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,7 +10,6 @@ import { createRoot } from 'react-dom/client';
 import { Routes, Route } from 'react-router-dom';
 
 import { Helmet } from 'react-helmet';
-import { fetchLiveTab } from './course-home/data/thunks';
 import DiscussionTab from './course-home/discussion-tab/DiscussionTab';
 
 import messages from './i18n';
@@ -82,9 +81,7 @@ subscribe(APP_READY, () => {
                         path={DECODE_ROUTES.LIVE}
                         element={(
                           <DecodePageRoute>
-                            <TabContainer tab="lti_live" fetch={fetchLiveTab} slice="courseHome">
-                              <LiveTab />
-                            </TabContainer>
+                            <LiveTab />
                           </DecodePageRoute>
                       )}
                       />


### PR DESCRIPTION
## Summary

Convert the course-home **live tab** from Redux to React Query. Part of the Redux → React Query migration (#1946), stacked on the discussion-tab conversion (#2005) as the **top** course-home tab layer. Closes #2002.

The live tab has real tab data (the LTI iframe HTML) but needs no model-store bridge — its only reader was the tab itself. It's the **last** course-home tab on the shared `fetchTab` helper, so this layer also retires `fetchTab`.

## What changed

- **`course-home/data/queryKeys.ts` / `apiHooks.ts`** — add `useLiveTabData(courseId)` (`getLiveTabIframe`, **no `meta`** tag) and the `liveTab(courseId)` key.
- **`course-home/live-tab/LiveTab.jsx`** — self-wrapping: a thin data-owning `LiveTab` (runs `useCourseHomeMeta` + `useLiveTabData`, renders `<TabWithTimer>`) + a `LiveTabContent` child holding the `dangerouslySetInnerHTML` div and the `getElementById('lti-tab-embed')` sizing `useEffect`, so it mounts post-load. `courseId` from `useParams`.
- **`index.jsx`** — live route → bare `<LiveTab />`; the `fetchLiveTab` import/wiring dropped.
- **`course-home/data/thunks.js`** — delete `fetchLiveTab` **and** the now-orphaned shared `fetchTab` helper (discussion, its other consumer, was converted in #2005), plus their now-unused imports. `eventTypes`, `deprecatedSaveCourseGoal`, and `fetchExamAttemptsData` remain.
- **`course-home/data/slice.js`** — remove the three now-dead reducers orphaned by the `fetchTab` deletion (`fetchTabRequest` / `fetchTabDenied` / `fetchTabSuccess`); `fetchTabFailure` stays (still dispatched by `TabPage.test.jsx` for the `errorMessage` display).

## Behavior

No user-facing change. No `live` model bridge: the masquerade banner reads `useModel('lti_live')`, but `fetchLiveTab` wrote model `live` (slug ≠ model), so that read was already empty and the banner never rendered here — preserved. `TabWithTimer` is retained, so the outer exam timer still mounts as it did via `TabContainer`. The three `fetchTab` request/denied/success reducers in `slice.js`, orphaned by the deletion, are removed; `fetchTabFailure` stays (still exercised by `TabPage.test.jsx`) and retires with the `courseHome` reducer in #1975.

## Testing

`npm run types`, `npm run lint`, and the affected suites pass. New `LiveTab.test.jsx` renders `<LiveTab />` through the bridged query client; `apiHooks.test.tsx` gains a `useLiveTabData` block (success / 404→`{}` / error); `redux.test.js` drops the `Test fetchTab` block wholesale (its subject `fetchTab` is deleted here). Manual browser verification (HAR-confirmed clean load) is documented in the decision log below.

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — Redux → React Query: the live tab (#1946)

Working notes for this PR (part of the wider Redux → React Query migration,
#1946). **Not checked in** — referenced when opening the PR. Part of #1975
(course-home tab data), stacked on the discussion-tab conversion (#2005) as the
**top** course-home tab layer. Closes #2002.

The live tab has real tab data (the LTI iframe HTML) but still needs **no
model-store bridge** — its only reader was the tab itself. It's the **last**
course-home tab on the shared `fetchTab` helper, so this layer also retires
`fetchTab`.

## Scope: self-wrapping conversion

**Decision.** `LiveTab` becomes self-wrapping — it owns its data via
`useCourseHomeMeta` + a new `useLiveTabData` hook and renders `<TabWithTimer>`
itself. The `index.jsx` route drops `<TabContainer tab="lti_live"
fetch={fetchLiveTab} slice="courseHome">` for a bare `<LiveTab />`.

## No transitional bridge (cleaner than progress)

**Decision.** `useLiveTabData` carries **no `meta` tag**:

- The only reader of `state.models.live` is `LiveTab` itself
  (`state.models.live[courseId]?.iframe`), which moves to the query.
- The shared masquerade banner reads `useModel(tab, courseId)` with
  `tab="lti_live"`, but `fetchLiveTab` wrote its data under model **`live`**, not
  `lti_live` — so `useModel('lti_live', …)` already resolved empty and the banner
  never rendered on this tab. `TabWithTimer activeTabSlug` stays `"lti_live"`, so
  that's preserved exactly. No `#1999`-style holdout.

## `LiveTab` splits into a thin wrapper + `LiveTabContent`

**Decision.** `LiveTab` runs the two queries and renders `<TabWithTimer
courseStatus={{ metadataQuery, tabDataQuery }}><LiveTabContent /></TabWithTimer>`;
the iframe `<div>` **and** its `getElementById('lti-tab-embed')` sizing `useEffect`
move to `LiveTabContent`. `TabPage` renders children only once loaded, so putting
the effect in the gated child preserves today's timing (where `LiveTab` was
`TabContainer`'s already-loaded child); in the self-wrapping shape the data-owning
component mounts *before* load.

## The iframe HTML is a prop named `html`, not `iframe`

**Decision.** `LiveTabContent` takes `html` (the iframe markup) and renders it via
`dangerouslySetInnerHTML`. It's named `html` rather than `iframe` so it doesn't
shadow the effect's `const iframe = document.getElementById('lti-tab-embed')`
DOM-node variable — which keeps that effect byte-identical to the original.

## `getLiveTabIframe` reused unchanged

**Decision.** `useLiveTabData`'s `queryFn` is the existing `getLiveTabIframe`
(`GET /api/course_live/iframe/<courseId>/`; 404 → `{}`, else throw), reused
as-is. Its name doesn't match the `get<Tab>TabData` siblings; a rename was
considered and **rejected** as out-of-scope churn for a conversion.

## `fetchTab` retires here (the last consumer)

**Decision.** Deleting `fetchLiveTab` leaves the shared `fetchTab` with no callers
(discussion, its other consumer, was converted in #2005). So `fetchTab` and its
now-unused imports (`getCourseHomeCourseMetadata`, `addModel`,
`fetchTab{Request,Denied,Failure,Success}`) are removed from `thunks.js`. What's
left there is `eventTypes`, `deprecatedSaveCourseGoal`, and `fetchExamAttemptsData`.

**Slice cleanup:** deleting `fetchTab` orphaned three of its reducers —
`fetchTabRequest`, `fetchTabDenied`, and `fetchTabSuccess` had no remaining
dispatcher, so they're removed from `slice.js` (along with the now-unused
`LOADING` / `DENIED` imports). `fetchTabFailure` **stays**: `TabPage.test.jsx`
still dispatches it to exercise `TabPage`'s `errorMessage` display. The residual
`courseStatus` / `errorMessage` fields retire with the `courseHome`-reducer
teardown (#1975), not this layer.

## `redux.test.js`: `Test fetchTab` block removed wholesale

**Decision.** With `fetchTab` gone, the `Test fetchTab` block (which drove it via
`fetchLiveTab`) is removed entirely, along with its now-orphaned `courseMetadataUrl`
/ `courseHomeAccessDeniedMetadata` declarations and the `appendBrowserTimezoneToUrl`
import. This is the clean, single deletion the below-live ordering was chosen to
enable — no retarget churn.

## Tests

- `LiveTab.test.jsx` (new) renders `<LiveTab />` through the bridged query client
  and asserts the iframe HTML from `useLiveTabData` renders — exercising `LiveTab`,
  `LiveTabContent`, and the sizing effect.
- `apiHooks.test.tsx` adds a `useLiveTabData` block: success (iframe payload),
  404 → `{}`, and non-404 → error. The 404/500 mocks attach `customAttributes`
  (via `Object.assign` on a real `Error`, so it's typed and lint-clean) because
  `getLiveTabIframe` reads `error.customAttributes.httpErrorStatus` — matching the
  approach in `api.test.js`.
- `redux.test.js` — `Test fetchTab` block removed (see above).

## Manual testing (in-browser)

**Verified** (no LTI live provider configured — the realistic demo case): a direct,
cold load of `/course/<id>/live` renders cleanly. The HAR shows
`GET /api/course_home/course_metadata/…` → 200 (`useCourseHomeMeta`) and
`GET /api/course_live/iframe/<id>/` → 200 (`useLiveTabData`), the latter with an
empty payload, so `#live_tab` renders empty — no crash, full page render. The
`OuterExamTimer` path fired (`…/proctored_exam/attempt/…` → 200), confirming
`TabWithTimer` is preserved. Zero 4xx/5xx, and nothing hit a `fetchTab` /
`courseStatus` / `courseware/sequence` path — i.e. deleting the shared `fetchTab`
helper broke nothing on this render.

**Not exercised:** a fully-configured LTI live provider (visible iframe content +
the `#lti-tab-embed` sizing effect) — none available locally. The automated
`LiveTab.test.jsx` covers the iframe-render + effect path with a mocked payload.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
