### PR TITLE
refactor: convert the courseware metadata fetch to React Query

### DIFF
--- a/src/course-home/courseware-search/data/apiHooks.ts
+++ b/src/course-home/courseware-search/data/apiHooks.ts
@@ -7,7 +7,6 @@ import { coursewareSearchQueryKeys } from './queryKeys';
 export const useCoursewareSearchEnabled = (courseId: string) => useQuery({
   queryKey: coursewareSearchQueryKeys.enabled(courseId),
   queryFn: () => getCoursewareSearchEnabled(courseId),
-  retry: false,
 });
 
 export const useCoursewareSearchResults = (courseId: string, keyword: string) => useQuery({

--- a/src/course-home/courseware-search/map-search-response.js
+++ b/src/course-home/courseware-search/map-search-response.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const { NonRetryableError } = require('../../data/http-error');
 
 const endpointSchema = Joi.object({
   took: Joi.number().required(),
@@ -24,7 +25,7 @@ export default function mapSearchResponse(response, searchKeywords = '') {
   const { error, value: data } = endpointSchema.validate(response);
 
   if (error) {
-    throw new Error('Error in server response:', error);
+    throw new NonRetryableError('Error in server response:', { cause: error });
   }
 
   const keywords = searchKeywords ? searchKeywords.toLowerCase().split(' ') : [];

--- a/src/course-home/data/apiHooks.test.tsx
+++ b/src/course-home/data/apiHooks.test.tsx
@@ -8,6 +8,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '../../setupTest';
 import { ToastProvider, useToast } from '../../generic/ToastContext';
 import {
+  useCourseHomeMeta,
   useOutlineTabData, useLiveTabData, useProgressTabData, useResetDeadlines, usePostEvent, useRequestCert,
   useDismissWelcomeMessage, useSaveWeeklyLearningGoal,
 } from './apiHooks';
@@ -323,6 +324,48 @@ describe('course-home apiHooks', () => {
       });
 
       await waitFor(() => expect(loggingService.logError).toHaveBeenCalled());
+    });
+  });
+
+  describe('useCourseHomeMeta', () => {
+    const courseId = 'course-1';
+    const metadataUrl = new RegExp(`${getConfig().LMS_BASE_URL}/api/course_home/course_metadata/`);
+    const tabSlugs = (data: unknown) => (data as { tabs: Array<{ slug: string }> }).tabs.map(tab => tab.slug);
+
+    beforeEach(() => {
+      axiosMock.onGet(metadataUrl).reply(200, Factory.build('courseHomeMetadata'));
+    });
+
+    it('labels the shared courseware/outline tab "courseware" (the rootSlug CoursewareContainer + CourseExit pass)', async () => {
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useCourseHomeMeta(courseId, 'courseware'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(tabSlugs(result.current.data)).toContain('courseware');
+      expect(tabSlugs(result.current.data)).not.toContain('outline');
+    });
+
+    it('labels the shared courseware/outline tab "outline" (the rootSlug the course-home tabs pass)', async () => {
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useCourseHomeMeta(courseId, 'outline'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(tabSlugs(result.current.data)).toContain('outline');
+      expect(tabSlugs(result.current.data)).not.toContain('courseware');
+    });
+
+    it('keys the query by rootSlug so the two contexts do not share a cache entry', async () => {
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => ({
+        courseware: useCourseHomeMeta(courseId, 'courseware'),
+        outline: useCourseHomeMeta(courseId, 'outline'),
+      }), { wrapper });
+
+      await waitFor(() => expect(
+        result.current.courseware.isSuccess && result.current.outline.isSuccess,
+      ).toBe(true));
+      expect(tabSlugs(result.current.courseware.data)).toContain('courseware');
+      expect(tabSlugs(result.current.outline.data)).toContain('outline');
     });
   });
 });

--- a/src/course-home/data/apiHooks.ts
+++ b/src/course-home/data/apiHooks.ts
@@ -1,6 +1,7 @@
 import { logError } from '@edx/frontend-platform/logging';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
+import type { RequestError } from '@src/data/http-error';
 import { useToast, ToastContent } from '@src/generic/ToastContext';
 import {
   executePostFromPostEvent,
@@ -58,9 +59,15 @@ export const usePostEvent = () => {
   });
 };
 
-export const useCourseHomeMeta = (courseId: string) => useQuery({
-  queryKey: courseHomeQueryKeys.metadata(courseId),
-  queryFn: () => getCourseHomeCourseMetadata(courseId, 'outline'),
+// Typed to only what we read off this query, not the whole (untyped) endpoint shape;
+// other course-home fields are read via `useModel`/the bridge (until #1977).
+export const useCourseHomeMeta = (courseId: string | undefined, rootSlug: string) => useQuery<
+{ courseAccess?: { hasAccess: boolean } },
+RequestError
+>({
+  queryKey: courseHomeQueryKeys.metadata(courseId!, rootSlug),
+  queryFn: () => getCourseHomeCourseMetadata(courseId, rootSlug),
+  enabled: !!courseId,
   meta: { modelType: 'courseHomeMeta', courseId },
 });
 
@@ -79,7 +86,6 @@ export const useOutlineTabData = (courseId: string) => useQuery({
 export const useLiveTabData = (courseId: string) => useQuery({
   queryKey: courseHomeQueryKeys.liveTab(courseId),
   queryFn: () => getLiveTabIframe(courseId),
-  refetchOnWindowFocus: false,
 });
 
 export const useProgressTabData = (courseId: string, targetUserId?: string) => useQuery({

--- a/src/course-home/data/modelStoreBridge.test.ts
+++ b/src/course-home/data/modelStoreBridge.test.ts
@@ -1,0 +1,102 @@
+import { QueryCache, QueryClient } from '@tanstack/react-query';
+
+import { addModelsMap } from '@src/generic/model-store';
+import initializeStore from '@src/store';
+import { bridgeToModelStore } from './modelStoreBridge';
+
+type Store = ReturnType<typeof initializeStore>;
+
+const modelsOf = (store: Store) => store.getState().models as Record<string, Record<string, unknown>>;
+
+const runQuery = (queryClient: QueryClient, queryFn: () => unknown, meta: Record<string, unknown>) => (
+  queryClient.fetchQuery({ queryKey: [Math.random().toString()], queryFn, meta })
+);
+
+describe('modelStoreBridge', () => {
+  let store: Store;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    store = initializeStore();
+    queryClient = new QueryClient({
+      queryCache: new QueryCache({ onSuccess: (data, query) => bridgeToModelStore(store, data, query) }),
+    });
+  });
+
+  it('single form: mirrors the whole result as one model keyed by courseId', async () => {
+    await runQuery(queryClient, () => ({ foo: 'bar' }), { modelType: 'dates', courseId: 'course-1' });
+
+    expect(modelsOf(store).dates['course-1']).toEqual({ id: 'course-1', foo: 'bar' });
+  });
+
+  it('list form addModel: mirrors the whole result as one model (using its own id)', async () => {
+    await runQuery(
+      queryClient,
+      () => ({ id: 'course-1', title: 'Demo' }),
+      { models: [{ modelType: 'coursewareMeta', strategy: 'addModel' }] },
+    );
+
+    expect(modelsOf(store).coursewareMeta['course-1']).toEqual({ id: 'course-1', title: 'Demo' });
+  });
+
+  it('list form: fans one result out to several collection mirrors via source keys', async () => {
+    await runQuery(
+      queryClient,
+      () => ({
+        courses: { c1: { id: 'c1', sectionIds: ['s1'] } },
+        sections: { s1: { id: 's1', title: 'Section' } },
+        sequences: { q1: { id: 'q1', title: 'Sequence' } },
+      }),
+      {
+        models: [
+          { modelType: 'coursewareMeta', strategy: 'updateModelsMap', source: 'courses' },
+          { modelType: 'sections', strategy: 'addModelsMap', source: 'sections' },
+          { modelType: 'sequences', strategy: 'updateModelsMap', source: 'sequences' },
+        ],
+      },
+    );
+
+    const models = modelsOf(store);
+    expect(models.coursewareMeta.c1).toEqual({ id: 'c1', sectionIds: ['s1'] });
+    expect(models.sections.s1).toEqual({ id: 's1', title: 'Section' });
+    expect(models.sequences.q1).toEqual({ id: 'q1', title: 'Sequence' });
+  });
+
+  it('updateModelsMap merges into an existing model rather than replacing it', async () => {
+    store.dispatch(addModelsMap({
+      modelType: 'sequences',
+      modelsMap: { q1: { id: 'q1', unitIds: ['u1', 'u2'], activeUnitIndex: 0 } },
+    }));
+
+    await runQuery(
+      queryClient,
+      () => ({ sequences: { q1: { id: 'q1', title: 'Sequence' } } }),
+      { models: [{ modelType: 'sequences', strategy: 'updateModelsMap', source: 'sequences' }] },
+    );
+
+    expect(modelsOf(store).sequences.q1).toEqual({
+      id: 'q1',
+      title: 'Sequence',
+      unitIds: ['u1', 'u2'],
+      activeUnitIndex: 0,
+    });
+  });
+
+  it('updateModels merges an array of models', async () => {
+    await runQuery(
+      queryClient,
+      () => ({ units: [{ id: 'u1', complete: true }, { id: 'u2', complete: false }] }),
+      { models: [{ modelType: 'units', strategy: 'updateModels', source: 'units' }] },
+    );
+
+    const { units } = modelsOf(store);
+    expect(units.u1).toEqual({ id: 'u1', complete: true });
+    expect(units.u2).toEqual({ id: 'u2', complete: false });
+  });
+
+  it('does nothing when a query has no model-store meta', async () => {
+    await runQuery(queryClient, () => ({ foo: 'bar' }), {});
+
+    expect(store.getState().models).toEqual({});
+  });
+});

--- a/src/course-home/data/queryKeys.ts
+++ b/src/course-home/data/queryKeys.ts
@@ -2,7 +2,7 @@ import { appId } from '@src/constants';
 
 export const courseHomeQueryKeys = {
   all: [appId, 'courseHome'] as const,
-  metadata: (courseId: string) => [...courseHomeQueryKeys.all, 'metadata', courseId] as const,
+  metadata: (courseId: string, rootSlug: string) => [...courseHomeQueryKeys.all, 'metadata', courseId, rootSlug] as const,
   datesTab: (courseId: string) => [...courseHomeQueryKeys.all, 'datesTab', courseId] as const,
   outlineTab: (courseId: string) => [...courseHomeQueryKeys.all, 'outlineTab', courseId] as const,
   liveTab: (courseId: string) => [...courseHomeQueryKeys.all, 'liveTab', courseId] as const,

--- a/src/course-home/dates-tab/DatesTab.jsx
+++ b/src/course-home/dates-tab/DatesTab.jsx
@@ -19,7 +19,7 @@ const DatesTab = () => {
   const intl = useIntl();
   const { courseId } = useParams();
 
-  const metadataQuery = useCourseHomeMeta(courseId);
+  const metadataQuery = useCourseHomeMeta(courseId, 'outline');
   const tabDataQuery = useDatesTabData(courseId);
 
   const {

--- a/src/course-home/discussion-tab/DiscussionTab.jsx
+++ b/src/course-home/discussion-tab/DiscussionTab.jsx
@@ -32,7 +32,7 @@ const DiscussionTabContent = () => {
 const DiscussionTab = () => {
   const { courseId } = useParams();
 
-  const metadataQuery = useCourseHomeMeta(courseId);
+  const metadataQuery = useCourseHomeMeta(courseId, 'outline');
 
   return (
     <TabWithTimer

--- a/src/course-home/live-tab/LiveTab.jsx
+++ b/src/course-home/live-tab/LiveTab.jsx
@@ -32,7 +32,7 @@ LiveTabContent.defaultProps = {
 const LiveTab = () => {
   const { courseId } = useParams();
 
-  const metadataQuery = useCourseHomeMeta(courseId);
+  const metadataQuery = useCourseHomeMeta(courseId, 'outline');
   const tabDataQuery = useLiveTabData(courseId);
 
   return (

--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -192,7 +192,7 @@ const OutlineTabContent = () => {
 
 const OutlineTab = () => {
   const { courseId } = useParams();
-  const metadataQuery = useCourseHomeMeta(courseId);
+  const metadataQuery = useCourseHomeMeta(courseId, 'outline');
   const tabDataQuery = useOutlineTabData(courseId);
 
   return (

--- a/src/course-home/progress-tab/ProgressTab.jsx
+++ b/src/course-home/progress-tab/ProgressTab.jsx
@@ -57,7 +57,7 @@ const ProgressTabContent = () => {
 
 const ProgressTab = () => {
   const { courseId, targetUserId } = useParams();
-  const metadataQuery = useCourseHomeMeta(courseId);
+  const metadataQuery = useCourseHomeMeta(courseId, 'outline');
   const tabDataQuery = useProgressTabData(courseId, targetUserId);
 
   return (

--- a/src/courseware/CoursewareContainer.test.jsx
+++ b/src/courseware/CoursewareContainer.test.jsx
@@ -101,7 +101,7 @@ describe('CoursewareContainer', () => {
 
     component = (
       <AppProvider store={store} wrapWithRouter={false}>
-        <QueryClientProvider client={createTestQueryClient()}>
+        <QueryClientProvider client={createTestQueryClient(store)}>
           <UserMessagesProvider>
             <ToastProvider>
               <Routes>

--- a/src/courseware/CoursewareContainer.tsx
+++ b/src/courseware/CoursewareContainer.tsx
@@ -12,6 +12,7 @@ import {
   getSequenceForUnitDeprecated,
   saveSequencePosition,
 } from './data';
+import { useCourseStatusBridge } from './data/statusBridge';
 import { TabPage } from '../tab-page';
 import type { CourseStatus } from '../tab-page/TabPage';
 import type { RootState } from '../store';
@@ -233,6 +234,8 @@ const CoursewareContainer = () => {
   const nextSequence = useSelector(nextSequenceSelector);
   const firstSequenceId = useSelector(firstSequenceIdSelector);
   const sectionViaSequenceId = useSelector(sectionViaSequenceIdSelector);
+
+  useCourseStatusBridge(routeCourseId);
 
   const latest = useRef<any>();
 

--- a/src/courseware/course/course-exit/CourseExit.jsx
+++ b/src/courseware/course/course-exit/CourseExit.jsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
-import { useSelector } from 'react-redux';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 
 import CourseCelebration from './CourseCelebration';
 import CourseInProgress from './CourseInProgress';
@@ -11,9 +10,13 @@ import { postUnsubscribeFromGoalReminders } from './data/api';
 import { CourseExitViewCoursesPluginSlot } from '../../../plugin-slots/CourseExitPluginSlots';
 
 import { useModel } from '../../../generic/model-store';
+import { TabWithTimer } from '../../../tab-page';
+import { useCoursewareMetadata, useCoursewareOutline } from '../../data/apiHooks';
+import { useCourseExitStatusBridge } from '../../data/statusBridge';
+import { useCourseHomeMeta } from '../../../course-home/data/apiHooks';
 
-const CourseExit = () => {
-  const { courseId } = useSelector(state => state.courseware);
+const CourseExitContent = () => {
+  const { courseId } = useParams();
   const {
     certificateData,
     courseExitPageIsActive,
@@ -63,6 +66,24 @@ const CourseExit = () => {
       <CourseExitViewCoursesPluginSlot />
       {body}
     </>
+  );
+};
+
+const CourseExit = () => {
+  const { courseId } = useParams();
+  const metadataQuery = useCoursewareMetadata(courseId);
+  const courseHomeMetaQuery = useCourseHomeMeta(courseId, 'courseware');
+  useCoursewareOutline(courseId);
+  useCourseExitStatusBridge(courseId, metadataQuery, courseHomeMetaQuery);
+
+  return (
+    <TabWithTimer
+      activeTabSlug="courseware"
+      courseId={courseId}
+      courseStatus={{ metadataQuery: courseHomeMetaQuery, tabDataQuery: metadataQuery }}
+    >
+      <CourseExitContent />
+    </TabWithTimer>
   );
 };
 

--- a/src/courseware/course/course-exit/CourseExit.test.jsx
+++ b/src/courseware/course/course-exit/CourseExit.test.jsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import MockAdapter from 'axios-mock-adapter';
 import { Factory } from 'rosie';
-import { getConfig } from '@edx/frontend-platform';
+import { getConfig, history } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { waitFor } from '@testing-library/react';
+import { waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { QueryClientProvider } from '@tanstack/react-query';
 
-import { fetchCourse } from '../../data';
+import { getCourseMetadata } from '../../data/api';
+import { getCourseHomeCourseMetadata } from '../../../course-home/data/api';
+import { fetchCourseSuccess } from '../../data/slice';
+import { addModel } from '../../../generic/model-store';
 import { buildSimpleCourseBlocks } from '../../../shared/data/__factories__/courseBlocks.factory';
 import { buildOutlineFromBlocks } from '../../data/__factories__/learningSequencesOutline.factory';
 import {
-  initializeMockApp, logUnhandledRequests, render, screen,
+  createTestQueryClient, initializeMockApp, logUnhandledRequests, render, screen,
 } from '../../../setupTest';
 import initializeStore from '../../../store';
-import { appendBrowserTimezoneToUrl, executeThunk } from '../../../utils';
+import { appendBrowserTimezoneToUrl } from '../../../utils';
 import CourseCelebration from './CourseCelebration';
 import CourseExit from './CourseExit';
 import CourseInProgress from './CourseInProgress';
@@ -51,8 +56,27 @@ describe('Course Exit Pages', () => {
   }
 
   async function fetchAndRender(component) {
-    await executeThunk(fetchCourse(courseId), store.dispatch);
-    render(component, { store, wrapWithRouter: true });
+    const [metadata, homeMetadata] = await Promise.all([
+      getCourseMetadata(courseId),
+      getCourseHomeCourseMetadata(courseId, 'courseware'),
+    ]);
+    store.dispatch(addModel({ modelType: 'coursewareMeta', model: metadata }));
+    store.dispatch(addModel({ modelType: 'courseHomeMeta', model: { id: courseId, ...homeMetadata } }));
+    store.dispatch(fetchCourseSuccess({ courseId }));
+    history.push(`/course/${courseId}`);
+    render(
+      <QueryClientProvider client={createTestQueryClient(store)}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/course/:courseId" element={component} />
+          </Routes>
+        </BrowserRouter>
+      </QueryClientProvider>,
+      { store, wrapWithRouter: false },
+    );
+    if (screen.queryByRole('status')) {
+      await waitForElementToBeRemoved(() => screen.queryByRole('status'));
+    }
   }
 
   beforeEach(() => {
@@ -99,6 +123,24 @@ describe('Course Exit Pages', () => {
       expect(screen.getByText('You’ve reached the end of the course!')).toBeInTheDocument();
     });
 
+    it('Routes to in-progress experience when the course has scheduled content', async () => {
+      setMetadata({
+        enrollment: { is_active: true },
+        user_has_passing_grade: false,
+      });
+      const { courseBlocks } = buildSimpleCourseBlocks(courseId, courseHomeMetadata.title);
+      // buildOutlineFromBlocks releases every sequence; mark one unreleased so the normalized
+      // outline reports hasScheduledContent (see isReleased in ../../data/utils.js).
+      const outline = buildOutlineFromBlocks(courseBlocks);
+      const [scheduledSequenceId] = Object.keys(outline.outline.sequences);
+      outline.outline.sequences[scheduledSequenceId].accessible = false;
+      outline.outline.sequences[scheduledSequenceId].effective_start = tomorrow.toISOString();
+      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, outline);
+
+      await fetchAndRender(<CourseExit />);
+      expect(await screen.findByText('More content is coming soon!')).toBeInTheDocument();
+    });
+
     it('Redirects if it does not match any statuses', async () => {
       setMetadata({
         certificate_data: {
@@ -107,6 +149,24 @@ describe('Course Exit Pages', () => {
       });
       await fetchAndRender(<CourseExit />);
       expect(global.location.href).toEqual(`http://localhost/course/${courseId}`);
+    });
+  });
+
+  describe('Course Exit access error', () => {
+    it('surfaces the 403 access detail instead of the generic error', async () => {
+      axiosMock.onGet(courseHomeMetadataUrl).reply(403, { detail: 'You are not enrolled', error_code: 'not_enrolled' });
+      history.push(`/course/${courseId}`);
+      render(
+        <QueryClientProvider client={createTestQueryClient(store)}>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/course/:courseId" element={<CourseExit />} />
+            </Routes>
+          </BrowserRouter>
+        </QueryClientProvider>,
+        { store, wrapWithRouter: false },
+      );
+      expect(await screen.findByText('You are not enrolled')).toBeInTheDocument();
     });
   });
 

--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.test.js
@@ -1,11 +1,11 @@
-import { useDispatch } from 'react-redux';
 import { renderHook } from '@testing-library/react';
 
 import { logError } from '@edx/frontend-platform/logging';
 
 import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { fetchCourse } from '@src/courseware/data';
+import { coursewareQueryKeys } from '@src/courseware/data/queryKeys';
+import { courseHomeQueryKeys } from '@src/course-home/data/queryKeys';
 import { useEventListener } from '@src/generic/hooks';
 import { useSequenceNavigationMetadata } from '@src/courseware/course/sequence/sequence-navigation/hooks';
 
@@ -15,6 +15,7 @@ import useIFrameBehavior, { iframeBehaviorState } from './useIFrameBehavior';
 
 const mockNavigate = jest.fn();
 const mockMutate = jest.fn();
+const mockInvalidateQueries = jest.fn();
 
 jest.mock('@edx/frontend-platform', () => ({
   ...jest.requireActual('@edx/frontend-platform'),
@@ -29,7 +30,6 @@ jest.mock('react', () => ({
 }));
 
 jest.mock('react-redux', () => ({
-  useDispatch: jest.fn(),
   useSelector: jest.fn(),
 }));
 
@@ -37,8 +37,9 @@ jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));
 
-jest.mock('@src/courseware/data', () => ({
-  fetchCourse: jest.fn(),
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
 }));
 jest.mock('@src/course-home/data/thunks', () => ({
   eventTypes: { POST_EVENT: 'post_event' },
@@ -71,9 +72,6 @@ const testIFrameHeight = 42;
 
 const config = { LMS_BASE_URL: 'test-base-url' };
 getConfig.mockReturnValue(config);
-
-const dispatch = jest.fn();
-useDispatch.mockReturnValue(dispatch);
 
 const postMessage = jest.fn();
 const frame = {
@@ -351,9 +349,8 @@ describe('useIFrameBehavior hook', () => {
         result.current.handleIFrameLoad();
         expect(sendTrackEvent).not.toHaveBeenCalled();
       });
-      it('registers an event handler to process fetchCourse events.', () => {
+      it('invalidates the courseware queries on a post event.', () => {
         mockState(defaultStateVals);
-        fetchCourse.mockReturnValue('fetch-course-action');
         const { result } = renderHook(() => useIFrameBehavior(props));
         result.current.handleIFrameLoad();
         const event = {
@@ -375,8 +372,9 @@ describe('useIFrameBehavior hook', () => {
 
         const { onSuccess } = mockMutate.mock.calls[0][1];
         onSuccess();
-        expect(fetchCourse).toHaveBeenCalledWith('course-1');
-        expect(dispatch).toHaveBeenCalledWith('fetch-course-action');
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: coursewareQueryKeys.metadata('course-1') });
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: coursewareQueryKeys.outline('course-1') });
+        expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: courseHomeQueryKeys.metadata('course-1', 'courseware') });
       });
       it('updates initial iframe visibility on load', () => {
         const { result } = renderHook(() => useIFrameBehavior(props));

--- a/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts
+++ b/src/courseware/course/sequence/Unit/hooks/useIFrameBehavior.ts
@@ -1,14 +1,16 @@
 import React, { useState } from 'react';
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { throttle } from 'lodash';
 
 import { logError } from '@edx/frontend-platform/logging';
 
-import { fetchCourse } from '@src/courseware/data';
 import { usePostEvent } from '@src/course-home/data/apiHooks';
+import { courseHomeQueryKeys } from '@src/course-home/data/queryKeys';
+import { coursewareQueryKeys } from '@src/courseware/data/queryKeys';
 import { eventTypes } from '@src/course-home/data/thunks';
 import { useEventListener } from '@src/generic/hooks';
 import { getSequenceId } from '@src/courseware/data/selectors';
@@ -34,7 +36,7 @@ const useIFrameBehavior = ({
   // Do not remove this hook.  See function description.
   useLoadBearingHook(id);
 
-  const dispatch = useDispatch();
+  const queryClient = useQueryClient();
   const postEvent = usePostEvent();
   const activeSequenceId = useSelector(getSequenceId);
   const navigate = useNavigate();
@@ -164,7 +166,14 @@ const useIFrameBehavior = ({
     }
     postEvent.mutate(
       { postData: event.postData, researchEventData },
-      { onSuccess: () => dispatch(fetchCourse(event.postData.bodyParams.courseId)) },
+      {
+        onSuccess: () => {
+          const eventCourseId = event.postData.bodyParams.courseId;
+          queryClient.invalidateQueries({ queryKey: coursewareQueryKeys.metadata(eventCourseId) });
+          queryClient.invalidateQueries({ queryKey: coursewareQueryKeys.outline(eventCourseId) });
+          queryClient.invalidateQueries({ queryKey: courseHomeQueryKeys.metadata(eventCourseId, 'courseware') });
+        },
+      },
     );
   };
 

--- a/src/courseware/data/apiHooks.test.tsx
+++ b/src/courseware/data/apiHooks.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { Factory } from 'rosie';
+import MockAdapter from 'axios-mock-adapter';
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { appendBrowserTimezoneToUrl } from '../../utils';
+import { buildSimpleCourseBlocks } from '../../shared/data/__factories__/courseBlocks.factory';
+import { buildOutlineFromBlocks } from './__factories__/learningSequencesOutline.factory';
+import { createTestQueryClient, initializeMockApp } from '../../setupTest';
+import initializeStore from '../../store';
+import { normalizeLearningSequencesData } from './utils';
+import { fetchCourseSuccess } from './slice';
+import { sequenceIdsSelector } from './selectors';
+import { useCoursewareMetadata, useCoursewareOutline } from './apiHooks';
+
+initializeMockApp();
+
+describe('courseware apiHooks — coursewareMeta bridge', () => {
+  const courseMetadata = Factory.build('courseMetadata');
+  const courseId = courseMetadata.id;
+  const { courseBlocks } = buildSimpleCourseBlocks(courseId);
+  const outlineResponse = buildOutlineFromBlocks(courseBlocks);
+  const normalizedOutline = normalizeLearningSequencesData(outlineResponse);
+  const expectedSectionIds = normalizedOutline.courses[courseId].sectionIds;
+  const expectedSequenceIds = expectedSectionIds.flatMap(
+    (id: string) => normalizedOutline.sections[id].sequenceIds,
+  );
+
+  let axiosMock: MockAdapter;
+  let store: ReturnType<typeof initializeStore>;
+  const outlineUrl = `${getConfig().LMS_BASE_URL}/api/learning_sequences/v1/course_outline/${courseId}`;
+  const metadataUrl = appendBrowserTimezoneToUrl(`${getConfig().LMS_BASE_URL}/api/courseware/course/${courseId}`);
+
+  const coursewareMetaFor = (id: string) => (
+    store.getState().models as { coursewareMeta?: Record<string, { sectionIds?: string[]; title?: string }> }
+  ).coursewareMeta?.[id];
+
+  beforeEach(() => {
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    store = initializeStore();
+  });
+
+  it('keeps coursewareMeta.sectionIds (and the sequence order nav needs) when metadata resolves after the outline', async () => {
+    let resolveMetadata: () => void = () => {};
+    axiosMock.onGet(outlineUrl).reply(200, outlineResponse);
+    axiosMock.onGet(metadataUrl).reply(() => new Promise((resolve) => {
+      resolveMetadata = () => resolve([200, courseMetadata]);
+    }));
+
+    const queryClient = createTestQueryClient(store);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    renderHook(
+      () => ({ meta: useCoursewareMetadata(courseId), outline: useCoursewareOutline(courseId) }),
+      { wrapper },
+    );
+
+    // The outline resolves first and populates sectionIds.
+    await waitFor(() => expect(coursewareMetaFor(courseId)?.sectionIds).toEqual(expectedSectionIds));
+    store.dispatch(fetchCourseSuccess({ courseId }));
+    expect(sequenceIdsSelector(store.getState())).toEqual(expectedSequenceIds);
+
+    // Now let the metadata mirror land last.
+    resolveMetadata();
+    await waitFor(() => expect(coursewareMetaFor(courseId)?.title).toBe(courseMetadata.name));
+
+    // sectionIds must survive.
+    expect(coursewareMetaFor(courseId)?.sectionIds).toEqual(expectedSectionIds);
+    expect(sequenceIdsSelector(store.getState())).toEqual(expectedSequenceIds);
+  });
+});

--- a/src/courseware/data/apiHooks.ts
+++ b/src/courseware/data/apiHooks.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCourseMetadata, getLearningSequencesOutline } from './api';
+import { coursewareQueryKeys } from './queryKeys';
+
+export const useCoursewareMetadata = (courseId: string | undefined) => useQuery({
+  queryKey: coursewareQueryKeys.metadata(courseId!),
+  queryFn: () => getCourseMetadata(courseId),
+  enabled: !!courseId,
+  meta: { models: [{ modelType: 'coursewareMeta', strategy: 'updateModel' }] },
+});
+
+export const useCoursewareOutline = (courseId: string | undefined) => useQuery({
+  queryKey: coursewareQueryKeys.outline(courseId!),
+  queryFn: () => getLearningSequencesOutline(courseId),
+  enabled: !!courseId,
+  meta: {
+    logStatusAs: { 403: 'info' },
+    models: [
+      { modelType: 'coursewareMeta', strategy: 'updateModelsMap', source: 'courses' },
+      { modelType: 'sections', strategy: 'addModelsMap', source: 'sections' },
+      { modelType: 'sequences', strategy: 'updateModelsMap', source: 'sequences' },
+    ],
+  },
+});

--- a/src/courseware/data/queryKeys.ts
+++ b/src/courseware/data/queryKeys.ts
@@ -1,0 +1,7 @@
+import { appId } from '@src/constants';
+
+export const coursewareQueryKeys = {
+  all: [appId, 'courseware'] as const,
+  metadata: (courseId: string) => [...coursewareQueryKeys.all, 'metadata', courseId] as const,
+  outline: (courseId: string) => [...coursewareQueryKeys.all, 'outline', courseId] as const,
+};

--- a/src/courseware/data/redux.test.js
+++ b/src/courseware/data/redux.test.js
@@ -4,14 +4,15 @@ import MockAdapter from 'axios-mock-adapter';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform';
 
-import { FAILED, LOADING } from '@src/constants';
 import * as thunks from './thunks';
 
 import { appendBrowserTimezoneToUrl, executeThunk } from '../../utils';
 
 import { buildSimpleCourseBlocks } from '../../shared/data/__factories__/courseBlocks.factory';
 import { buildOutlineFromBlocks } from './__factories__/learningSequencesOutline.factory';
-import { initializeMockApp } from '../../setupTest';
+import { initializeMockApp, seedCoursewareModels } from '../../setupTest';
+import { getCourseMetadata } from './api';
+import { addModel } from '../../generic/model-store';
 import initializeStore from '../../store';
 
 const { loggingService } = initializeMockApp();
@@ -33,7 +34,6 @@ describe('Data layer integration tests', () => {
     {},
     { courseId, unitBlocks, sequenceBlock: sequenceBlocks[0] },
   );
-  const simpleOutline = buildOutlineFromBlocks(courseBlocks);
 
   let courseUrl = `${courseBaseUrl}/${courseId}`;
   courseUrl = appendBrowserTimezoneToUrl(courseUrl);
@@ -44,7 +44,6 @@ describe('Data layer integration tests', () => {
   const sequenceUrl = `${sequenceBaseUrl}/${sequenceMetadata.item_id}`;
   const sequenceId = sequenceBlocks[0].id;
   const unitId = unitBlocks[0].id;
-  const coursewareSidebarSettingsUrl = `${getConfig().LMS_BASE_URL}/courses/${courseId}/courseware-navigation-sidebar/toggles/`;
 
   let store;
 
@@ -56,165 +55,25 @@ describe('Data layer integration tests', () => {
   });
 
   describe('Test fetchCourse', () => {
-    it('Should fail to fetch course and blocks if request error happens', async () => {
-      axiosMock.onGet(courseUrl).networkError();
-      axiosMock.onGet(learningSequencesUrlRegExp).networkError();
-      axiosMock.onGet(coursewareSidebarSettingsUrl).networkError();
+    const sidebarTogglesUrl = `${getConfig().LMS_BASE_URL}/courses/${courseId}/courseware-navigation-sidebar/toggles/`;
+
+    it('Should store the sidebar toggles on success', async () => {
+      axiosMock.onGet(sidebarTogglesUrl).reply(200, { enable_completion_tracking: true });
+
+      await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
+
+      expect(store.getState().courseware.coursewareOutlineSidebarSettings).toEqual({
+        enableCompletionTracking: true,
+      });
+    });
+
+    it('Should log an error and leave the toggles unset on failure', async () => {
+      axiosMock.onGet(sidebarTogglesUrl).networkError();
 
       await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
 
       expect(loggingService.logError).toHaveBeenCalled();
-      expect(store.getState().courseware).toEqual(expect.objectContaining({
-        courseId,
-        courseOutline: {},
-        courseStatus: FAILED,
-        coursewareOutlineSidebarSettings: {},
-        courseOutlineStatus: LOADING,
-        sequenceId: null,
-        sequenceMightBeUnit: false,
-        sequenceStatus: LOADING,
-      }));
-    });
-
-    it('should store errorMessage and errorCode when course_home metadata returns 403', async () => {
-      const errorDetail = 'This course is not currently accessible. The course team has restricted access to this content.';
-      const errorCode = 'not_visible_in_catalog';
-
-      axiosMock.onGet(courseUrl).reply(200, courseMetadata);
-      axiosMock.onGet(courseHomeMetadataUrl).reply(403, { detail: errorDetail, error_code: errorCode });
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(courseBlocks));
-      axiosMock.onGet(coursewareSidebarSettingsUrl).reply(200, { enable_completion_tracking: true });
-
-      await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
-
-      const { courseware } = store.getState();
-      expect(courseware.courseStatus).toEqual(FAILED);
-      expect(courseware.errorMessage).toEqual(errorDetail);
-      expect(courseware.errorCode).toEqual(errorCode);
-    });
-
-    it('should not store errorMessage for non-403 network errors', async () => {
-      axiosMock.onGet(courseUrl).networkError();
-      axiosMock.onGet(courseHomeMetadataUrl).networkError();
-      axiosMock.onGet(learningSequencesUrlRegExp).networkError();
-      axiosMock.onGet(coursewareSidebarSettingsUrl).networkError();
-
-      await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
-
-      const { courseware } = store.getState();
-      expect(courseware.courseStatus).toEqual(FAILED);
-      expect(courseware.errorMessage).toBeNull();
-      expect(courseware.errorCode).toBeNull();
-    });
-
-    it('Should fetch, normalize, and save metadata, but with denied status', async () => {
-      const forbiddenCourseMetadata = Factory.build('courseMetadata');
-      const forbiddenCourseHomeMetadata = Factory.build('courseHomeMetadata', {
-        course_access: {
-          has_access: false,
-        },
-      });
-      const forbiddenCourseHomeUrl = appendBrowserTimezoneToUrl(
-        `${getConfig().LMS_BASE_URL}/api/course_home/course_metadata/${courseId}`,
-      );
-      const forbiddenCourseBlocks = Factory.build('courseBlocks', {
-        courseId: forbiddenCourseMetadata.id,
-      });
-      let forbiddenCourseUrl = `${courseBaseUrl}/${forbiddenCourseMetadata.id}`;
-      forbiddenCourseUrl = appendBrowserTimezoneToUrl(forbiddenCourseUrl);
-
-      axiosMock.onGet(forbiddenCourseHomeUrl).reply(200, forbiddenCourseHomeMetadata);
-      axiosMock.onGet(forbiddenCourseUrl).reply(200, forbiddenCourseMetadata);
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(forbiddenCourseBlocks));
-
-      await executeThunk(thunks.fetchCourse(forbiddenCourseMetadata.id), store.dispatch);
-
-      const state = store.getState();
-
-      expect(state.courseware.courseStatus).toEqual('denied');
-
-      // check that at least one key camel cased, thus course data normalized
-      expect(state.models.courseHomeMeta[forbiddenCourseMetadata.id].courseAccess).not.toBeUndefined();
-    });
-
-    it('Should fetch, normalize, and save metadata', async () => {
-      axiosMock.onGet(courseHomeMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(courseUrl).reply(200, courseMetadata);
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(courseBlocks));
-      axiosMock.onGet(coursewareSidebarSettingsUrl).reply(200, {
-        enable_completion_tracking: true,
-      });
-
-      await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
-
-      const state = store.getState();
-
-      expect(state.courseware.courseStatus).toEqual('loaded');
-      expect(state.courseware.courseId).toEqual(courseId);
-      expect(state.courseware.sequenceStatus).toEqual('loading');
-      expect(state.courseware.sequenceId).toEqual(null);
-      expect(state.courseware.coursewareOutlineSidebarSettings).toEqual({
-        enableCompletionTracking: true,
-      });
-
-      // check that at least one key camel cased, thus course data normalized
-      expect(state.models.coursewareMeta[courseId].marketingUrl).not.toBeUndefined();
-    });
-
-    it('Should fetch, normalize, and save metadata; filtering has no effect', async () => {
-      // Very similar to previous test, but pass back an outline for filtering
-      // (even though it won't actually filter down in this case).
-      axiosMock.onGet(courseHomeMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(courseUrl).reply(200, courseMetadata);
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, simpleOutline);
-      axiosMock.onGet(coursewareSidebarSettingsUrl).reply(200, {
-        enable_completion_tracking: false,
-      });
-
-      await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
-
-      const state = store.getState();
-
-      expect(state.courseware.courseStatus).toEqual('loaded');
-      expect(state.courseware.courseId).toEqual(courseId);
-      expect(state.courseware.sequenceStatus).toEqual('loading');
-      expect(state.courseware.sequenceId).toEqual(null);
-      expect(state.courseware.coursewareOutlineSidebarSettings).toEqual({
-        enableCompletionTracking: false,
-      });
-
-      // check that at least one key camel cased, thus course data normalized
-      expect(state.models.coursewareMeta[courseId].marketingUrl).not.toBeUndefined();
-      expect(state.models.sequences.length === 1);
-
-      Object.values(state.models.sections).forEach(section => expect(section.sequenceIds.length === 1));
-    });
-
-    it('Should fetch, normalize, and save metadata; filtering removes sequence', async () => {
-      // Very similar to previous test, but pass back an outline for filtering
-      // (even though it won't actually filter down in this case).
-      axiosMock.onGet(courseHomeMetadataUrl).reply(200, courseHomeMetadata);
-      axiosMock.onGet(courseUrl).reply(200, courseMetadata);
-
-      // Create an outline with basic matching metadata, but then empty it out...
-      const emptyOutline = buildOutlineFromBlocks(courseBlocks);
-      emptyOutline.sequences = {};
-      emptyOutline.sections = [];
-      axiosMock.onGet(learningSequencesUrlRegExp).reply(200, emptyOutline);
-      await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
-
-      const state = store.getState();
-
-      expect(state.courseware.courseStatus).toEqual('loaded');
-      expect(state.courseware.courseId).toEqual(courseId);
-      expect(state.courseware.sequenceStatus).toEqual('loading');
-      expect(state.courseware.sequenceId).toEqual(null);
-
-      // check that at least one key camel cased, thus course data normalized
-      expect(state.models.coursewareMeta[courseId].marketingUrl).not.toBeUndefined();
-      expect(state.models.sequences === null);
-
-      Object.values(state.models.sections).forEach(section => expect(section.sequenceIds.length === 0));
+      expect(store.getState().courseware.coursewareOutlineSidebarSettings).toEqual({});
     });
   });
 
@@ -252,7 +111,7 @@ describe('Data layer integration tests', () => {
 
       // setting course with blocks before sequence to check that blocks receive
       // additional information after fetchSequence call.
-      await executeThunk(thunks.fetchCourse(courseId), store.dispatch);
+      await seedCoursewareModels(store, courseId);
 
       // ensure that initial state has no additional sequence info
       let state = store.getState();
@@ -425,7 +284,10 @@ describe('Data layer integration tests', () => {
 
       axiosMock.onGet(courseUrlNeedSignature).reply(200, courseMetadataNeedSignature);
 
-      await executeThunk(thunks.fetchCourse(courseMetadataNeedSignature.id), store.dispatch);
+      store.dispatch(addModel({
+        modelType: 'coursewareMeta',
+        model: await getCourseMetadata(courseMetadataNeedSignature.id),
+      }));
       expect(
         store.getState().models.coursewareMeta[courseMetadataNeedSignature.id].userNeedsIntegritySignature,
       ).toEqual(true);

--- a/src/courseware/data/statusBridge.test.ts
+++ b/src/courseware/data/statusBridge.test.ts
@@ -1,0 +1,160 @@
+import { renderHook } from '@testing-library/react';
+
+import { useCourseHomeMeta } from '@src/course-home/data/apiHooks';
+import { useCoursewareMetadata, useCoursewareOutline } from './apiHooks';
+import {
+  fetchCourseDenied,
+  fetchCourseFailure,
+  fetchCourseRequest,
+  fetchCourseSuccess,
+} from './slice';
+import { useCourseExitStatusBridge, useCourseStatusBridge } from './statusBridge';
+
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+jest.mock('./apiHooks');
+jest.mock('@src/course-home/data/apiHooks');
+
+const courseId = 'course-v1:edX+Demo+2020';
+
+type MetaQuery = ReturnType<typeof useCoursewareMetadata>;
+type OutlineQuery = ReturnType<typeof useCoursewareOutline>;
+type HomeMetaQuery = ReturnType<typeof useCourseHomeMeta>;
+
+const pending = { isPending: true, isSuccess: false, isError: false };
+const success = (data?: unknown) => ({
+  isPending: false, isSuccess: true, isError: false, data,
+});
+const errored = (error?: unknown) => ({
+  isPending: false, isSuccess: false, isError: true, error,
+});
+const access = success({ courseAccess: { hasAccess: true } });
+const noAccess = success({ courseAccess: { hasAccess: false } });
+
+describe('useCourseStatusBridge', () => {
+  const render = (metadata: object, outline: object, courseHomeMeta: object, id: string | undefined = courseId) => {
+    jest.mocked(useCoursewareMetadata).mockReturnValue(metadata as MetaQuery);
+    jest.mocked(useCoursewareOutline).mockReturnValue(outline as OutlineQuery);
+    jest.mocked(useCourseHomeMeta).mockReturnValue(courseHomeMeta as HomeMetaQuery);
+    renderHook(() => useCourseStatusBridge(id));
+  };
+
+  beforeEach(() => { mockDispatch.mockClear(); });
+
+  it('dispatches nothing without a courseId', () => {
+    render(success(), success(), access, '');
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('requests while any query is pending', () => {
+    render(pending, success(), access);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseRequest({ courseId }));
+  });
+
+  it('succeeds when the learner has access and the outline loaded', () => {
+    render(success(), success(), access);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseSuccess({ courseId }));
+  });
+
+  it('denies when the learner lacks access', () => {
+    render(success(), success(), noAccess);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseDenied({ courseId }));
+  });
+
+  it('fails with the 403 detail/code when a query errors', () => {
+    const error = { response: { status: 403, data: { detail: 'No access', error_code: 'course_access_redirect' } } };
+    render(success(), success(), errored(error));
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseFailure({
+      courseId,
+      errorMessage: 'No access',
+      errorCode: 'course_access_redirect',
+    }));
+  });
+
+  it('fails without detail/code for a non-403 error', () => {
+    render(errored({ response: { status: 500 } }), success(), access);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseFailure({ courseId }));
+  });
+
+  it('fails without detail/code for a 403 with no body', () => {
+    render(success(), success(), errored({ response: { status: 403 } }));
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseFailure({ courseId }));
+  });
+
+  it('does not re-dispatch on re-render when the query state is unchanged', () => {
+    jest.mocked(useCoursewareMetadata).mockImplementation(() => success() as MetaQuery);
+    jest.mocked(useCoursewareOutline).mockImplementation(() => success() as OutlineQuery);
+    jest.mocked(useCourseHomeMeta).mockImplementation(() => access as HomeMetaQuery);
+
+    const { rerender } = renderHook(() => useCourseStatusBridge(courseId));
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+
+    mockDispatch.mockClear();
+    rerender();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCourseExitStatusBridge', () => {
+  const render = (metadata: object, courseHomeMeta: object, id: string | undefined = courseId) => {
+    renderHook(() => useCourseExitStatusBridge(id, metadata as MetaQuery, courseHomeMeta as HomeMetaQuery));
+  };
+
+  beforeEach(() => { mockDispatch.mockClear(); });
+
+  it('dispatches nothing without a courseId', () => {
+    render(success(), access, '');
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('requests while a query is pending', () => {
+    render(pending, access);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseRequest({ courseId }));
+  });
+
+  it('succeeds when the learner has access', () => {
+    render(success(), access);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseSuccess({ courseId }));
+  });
+
+  it('denies when the learner lacks access', () => {
+    render(success(), noAccess);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseDenied({ courseId }));
+  });
+
+  it('fails with the 403 detail/code when a query errors', () => {
+    const error = { response: { status: 403, data: { detail: 'No access', error_code: 'course_access_redirect' } } };
+    render(success(), errored(error));
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseFailure({
+      courseId,
+      errorMessage: 'No access',
+      errorCode: 'course_access_redirect',
+    }));
+  });
+
+  it('fails without detail/code for a non-403 error', () => {
+    render(errored({ response: { status: 500 } }), access);
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseFailure({ courseId }));
+  });
+
+  it('fails without detail/code for a 403 with no body', () => {
+    render(success(), errored({ response: { status: 403 } }));
+    expect(mockDispatch).toHaveBeenCalledWith(fetchCourseFailure({ courseId }));
+  });
+
+  it('does not re-dispatch on re-render when the query state is unchanged', () => {
+    const { rerender } = renderHook(() => useCourseExitStatusBridge(
+      courseId,
+      success() as MetaQuery,
+      success({ courseAccess: { hasAccess: true } }) as HomeMetaQuery,
+    ));
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+
+    mockDispatch.mockClear();
+    rerender();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/courseware/data/statusBridge.ts
+++ b/src/courseware/data/statusBridge.ts
@@ -1,0 +1,91 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { useCourseHomeMeta } from '@src/course-home/data/apiHooks';
+import { useCoursewareMetadata, useCoursewareOutline } from './apiHooks';
+import {
+  fetchCourseDenied,
+  fetchCourseFailure,
+  fetchCourseRequest,
+  fetchCourseSuccess,
+} from './slice';
+
+// Transitional: bridges the courseware query state into the Redux `courseStatus` field so
+// the still-Redux readers (the container's redirect helpers/selectors and TabPage's string
+// status) keep working; removed when those readers move to React Query.
+export const useCourseStatusBridge = (courseId: string | undefined) => {
+  const dispatch = useDispatch();
+  const metadataQuery = useCoursewareMetadata(courseId);
+  const outlineQuery = useCoursewareOutline(courseId);
+  const courseHomeMetaQuery = useCourseHomeMeta(courseId, 'courseware');
+
+  const { isPending: metadataPending, isSuccess: metadataSuccess } = metadataQuery;
+  const { isPending: outlinePending, isSuccess: outlineSuccess } = outlineQuery;
+  const { isPending: courseHomePending, isSuccess: courseHomeSuccess, error: courseHomeError } = courseHomeMetaQuery;
+  const hasAccess = courseHomeMetaQuery.data?.courseAccess?.hasAccess;
+
+  useEffect(() => {
+    if (!courseId) {
+      return;
+    }
+    if (metadataPending || outlinePending || courseHomePending) {
+      dispatch(fetchCourseRequest({ courseId }));
+      return;
+    }
+    if (metadataSuccess && courseHomeSuccess) {
+      if (hasAccess && outlineSuccess) {
+        dispatch(fetchCourseSuccess({ courseId }));
+      } else {
+        dispatch(fetchCourseDenied({ courseId }));
+      }
+      return;
+    }
+    const { status, data } = courseHomeError?.response ?? {};
+    if (status === 403 && data) {
+      dispatch(fetchCourseFailure({ courseId, errorMessage: data.detail, errorCode: data.error_code }));
+    } else {
+      dispatch(fetchCourseFailure({ courseId }));
+    }
+  }, [courseId, metadataPending, outlinePending, courseHomePending,
+    metadataSuccess, courseHomeSuccess, outlineSuccess, hasAccess, courseHomeError, dispatch]);
+};
+
+// The CourseExit variant: no outline query, and it takes its queries as params because
+// CourseExit also feeds them to its own TabPage gating. Same transitional job — keeps the slice
+// `courseId`/`courseStatus` written for the exit page's still-Redux children.
+export const useCourseExitStatusBridge = (
+  courseId: string | undefined,
+  metadataQuery: ReturnType<typeof useCoursewareMetadata>,
+  courseHomeMetaQuery: ReturnType<typeof useCourseHomeMeta>,
+) => {
+  const dispatch = useDispatch();
+
+  const { isPending: metadataPending, isSuccess: metadataSuccess } = metadataQuery;
+  const { isPending: courseHomePending, isSuccess: courseHomeSuccess, error: courseHomeError } = courseHomeMetaQuery;
+  const hasAccess = courseHomeMetaQuery.data?.courseAccess?.hasAccess;
+
+  useEffect(() => {
+    if (!courseId) {
+      return;
+    }
+    if (metadataPending || courseHomePending) {
+      dispatch(fetchCourseRequest({ courseId }));
+      return;
+    }
+    if (metadataSuccess && courseHomeSuccess) {
+      if (hasAccess) {
+        dispatch(fetchCourseSuccess({ courseId }));
+      } else {
+        dispatch(fetchCourseDenied({ courseId }));
+      }
+      return;
+    }
+    const { status, data } = courseHomeError?.response ?? {};
+    if (status === 403 && data) {
+      dispatch(fetchCourseFailure({ courseId, errorMessage: data.detail, errorCode: data.error_code }));
+    } else {
+      dispatch(fetchCourseFailure({ courseId }));
+    }
+  }, [courseId, metadataPending, courseHomePending, metadataSuccess, courseHomeSuccess,
+    hasAccess, courseHomeError, dispatch]);
+};

--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -1,25 +1,16 @@
-import { logError, logInfo } from '@edx/frontend-platform/logging';
-import { getCourseHomeCourseMetadata } from '../../course-home/data/api';
-import {
-  addModel, addModelsMap, updateModel, updateModels, updateModelsMap,
-} from '../../generic/model-store';
+import { logError } from '@edx/frontend-platform/logging';
+import { updateModel, updateModels } from '../../generic/model-store';
 import {
   getBlockCompletion,
   getCourseDiscussionConfig,
-  getCourseMetadata,
   getCourseOutline,
   getCourseTopics,
   getCoursewareOutlineSidebarToggles,
-  getLearningSequencesOutline,
   getSequenceMetadata,
   postIntegritySignature,
   postSequencePosition,
 } from './api';
 import {
-  fetchCourseDenied,
-  fetchCourseFailure,
-  fetchCourseRequest,
-  fetchCourseSuccess,
   fetchSequenceFailure,
   fetchSequenceRequest,
   fetchSequenceSuccess,
@@ -30,117 +21,23 @@ import {
   updateCourseOutlineCompletion,
 } from './slice';
 
+// Transitional — `fetchCourse` is being dismantled; its work is moving to React Query.
+// What it used to do, and what replaced it:
+//   - metadata / outline / courseHomeMeta fetches → the `useCoursewareMetadata` /
+//     `useCoursewareOutline` / `useCourseHomeMeta` query hooks (+ the model-store bridge)
+//   - deriving/dispatching `courseStatus` → `useCourseStatusBridge`
+// Only the sidebar-toggles fetch is left; it stays on Redux until #2013 converts it and
+// deletes `fetchCourse`.
 export function fetchCourse(courseId) {
   return async (dispatch) => {
-    dispatch(fetchCourseRequest({ courseId }));
-    Promise.allSettled([
-      getCourseMetadata(courseId),
-      getLearningSequencesOutline(courseId),
-      getCourseHomeCourseMetadata(courseId, 'courseware'),
-      getCoursewareOutlineSidebarToggles(courseId),
-    ]).then(([
-      courseMetadataResult,
-      learningSequencesOutlineResult,
-      courseHomeMetadataResult,
-      coursewareOutlineSidebarTogglesResult]) => {
-      const fetchedMetadata = courseMetadataResult.status === 'fulfilled';
-      const fetchedCourseHomeMetadata = courseHomeMetadataResult.status === 'fulfilled';
-      const fetchedOutline = learningSequencesOutlineResult.status === 'fulfilled';
-      const fetchedCoursewareOutlineSidebarTogglesResult = coursewareOutlineSidebarTogglesResult.status === 'fulfilled';
-
-      if (fetchedMetadata) {
-        dispatch(addModel({
-          modelType: 'coursewareMeta',
-          model: courseMetadataResult.value,
-        }));
-      }
-
-      if (fetchedCourseHomeMetadata) {
-        dispatch(addModel({
-          modelType: 'courseHomeMeta',
-          model: {
-            id: courseId,
-            ...courseHomeMetadataResult.value,
-          },
-        }));
-      }
-
-      if (fetchedOutline) {
-        const {
-          courses, sections, sequences,
-        } = learningSequencesOutlineResult.value;
-
-        // This updates the course with a sectionIds array from the Learning Sequence data.
-        dispatch(updateModelsMap({
-          modelType: 'coursewareMeta',
-          modelsMap: courses,
-        }));
-        dispatch(addModelsMap({
-          modelType: 'sections',
-          modelsMap: sections,
-        }));
-        // We update for sequences because the sequence metadata may have come back first.
-        dispatch(updateModelsMap({
-          modelType: 'sequences',
-          modelsMap: sequences,
-        }));
-      }
-
-      if (fetchedCoursewareOutlineSidebarTogglesResult) {
-        const {
-          enable_completion_tracking: enableCompletionTracking,
-        } = coursewareOutlineSidebarTogglesResult.value;
-        dispatch(setCoursewareOutlineSidebarToggles(
-          { enableCompletionTracking },
-        ));
-      }
-
-      // Log errors for each request if needed. Outline failures may occur
-      // even if the course metadata request is successful
-      if (!fetchedOutline) {
-        const { response } = learningSequencesOutlineResult.reason;
-        if (response && response.status === 403) {
-          // 403 responses are normal - they happen when the learner is logged out.
-          // We'll redirect them in a moment to the outline tab by calling fetchCourseDenied() below.
-          logInfo(learningSequencesOutlineResult.reason);
-        } else {
-          logError(learningSequencesOutlineResult.reason);
-        }
-      }
-      if (!fetchedMetadata) {
-        logError(courseMetadataResult.reason);
-      }
-      if (!fetchedCourseHomeMetadata) {
-        logError(courseHomeMetadataResult.reason);
-      }
-      if (!fetchedCoursewareOutlineSidebarTogglesResult) {
-        logError(coursewareOutlineSidebarTogglesResult.reason);
-      }
-      if (fetchedMetadata && fetchedCourseHomeMetadata) {
-        if (courseHomeMetadataResult.value.courseAccess.hasAccess && fetchedOutline) {
-          // User has access
-          dispatch(fetchCourseSuccess({ courseId }));
-          return;
-        }
-        // User either doesn't have access or only has partial access
-        // (can't access course blocks)
-        dispatch(fetchCourseDenied({ courseId }));
-        return;
-      }
-
-      // Definitely an error happening
-      // Extract error details from 403 responses
-      let errorMessage = null;
-      let errorCode = null;
-      if (!fetchedCourseHomeMetadata) {
-        const error = courseHomeMetadataResult.reason;
-        if (error?.response?.status === 403 && error?.response?.data) {
-          errorMessage = error.response.data.detail || null;
-          errorCode = error.response.data.error_code || null;
-        }
-      }
-      dispatch(fetchCourseFailure({ courseId, errorMessage, errorCode }));
-    });
+    try {
+      const {
+        enable_completion_tracking: enableCompletionTracking,
+      } = await getCoursewareOutlineSidebarToggles(courseId);
+      dispatch(setCoursewareOutlineSidebarToggles({ enableCompletionTracking }));
+    } catch (error) {
+      logError(error);
+    }
   };
 }
 

--- a/src/data/http-error.ts
+++ b/src/data/http-error.ts
@@ -1,0 +1,15 @@
+export interface RequestError {
+  response?: { status?: number; data?: { detail?: string; error_code?: string } };
+}
+
+export const getResponseStatus = (error: unknown): number | undefined => (
+  (error as RequestError | null)?.response?.status
+);
+
+export class NonRetryableError extends Error {
+  nonRetryable = true;
+}
+
+export const isNonRetryable = (error: unknown): boolean => (
+  (error as NonRetryableError | null)?.nonRetryable === true
+);

--- a/src/data/modelStoreBridge.test.ts
+++ b/src/data/modelStoreBridge.test.ts
@@ -94,6 +94,31 @@ describe('modelStoreBridge', () => {
     expect(units.u2).toEqual({ id: 'u2', complete: false });
   });
 
+  it('updateModel merges a single model by id (via source)', async () => {
+    store.dispatch(addModelsMap({
+      modelType: 'coursewareMeta',
+      modelsMap: { 'course-1': { id: 'course-1', title: 'Old', tabs: ['outline'] } },
+    }));
+
+    await runQuery(
+      queryClient,
+      () => ({ course: { id: 'course-1', title: 'New' } }),
+      { models: [{ modelType: 'coursewareMeta', strategy: 'updateModel', source: 'course' }] },
+    );
+
+    expect(modelsOf(store).coursewareMeta['course-1']).toEqual({ id: 'course-1', title: 'New', tabs: ['outline'] });
+  });
+
+  it('ignores an unrecognized strategy', async () => {
+    await runQuery(
+      queryClient,
+      () => ({ id: 'course-1' }),
+      { models: [{ modelType: 'coursewareMeta', strategy: 'nope' }] },
+    );
+
+    expect(store.getState().models).toEqual({});
+  });
+
   it('does nothing when a query has no model-store meta', async () => {
     await runQuery(queryClient, () => ({ foo: 'bar' }), {});
 

--- a/src/data/modelStoreBridge.ts
+++ b/src/data/modelStoreBridge.ts
@@ -1,21 +1,57 @@
 import type { Query } from '@tanstack/react-query';
 import { Store } from 'redux';
 
-import { addModel } from '@src/generic/model-store';
+import {
+  addModel,
+  addModelsMap,
+  updateModel,
+  updateModels,
+  updateModelsMap,
+} from '@src/generic/model-store';
+
+type MirrorStrategy =
+  | 'addModel'
+  | 'updateModel'
+  | 'addModelsMap'
+  | 'updateModelsMap'
+  | 'updateModels';
+
+interface ModelMirror {
+  modelType: string;
+  strategy: MirrorStrategy;
+  source?: string;
+}
 
 interface ModelStoreMeta {
   modelType?: string;
   courseId?: string;
+  models?: ModelMirror[];
 }
 
 // Transitional (#1977): bridge a React Query result into the model store so existing
 // `useModel(...)` readers (the shared TabPage/LoadedTabPage and not-yet-converted tabs)
-// keep working until the model store is dissolved. A query opts in by tagging itself with
-// `meta: { modelType, courseId }`. This is wired as the app QueryCache's `onSuccess` (see
-// src/queryClient.ts), so it runs before observers re-render.
+// keep working until the model store is dissolved. A query opts in via `meta`, either:
+//   `{ modelType, courseId }`            — the whole result as one model keyed by courseId
+//   `{ models: [{ modelType, strategy, source? }] }` — one or more mirrors, each running a
+//     model-store action (`source` selects a key of the result; omitted = the whole result)
+// This is wired as the app QueryCache's `onSuccess` (see src/queryClient.ts), so it runs
+// before observers re-render.
 export const bridgeToModelStore = (store: Store, data: unknown, query: Query<unknown, unknown>) => {
-  const { modelType, courseId } = (query.meta ?? {}) as ModelStoreMeta;
+  const { modelType, courseId, models } = (query.meta ?? {}) as ModelStoreMeta;
+
   if (modelType) {
     store.dispatch(addModel({ modelType, model: { id: courseId, ...(data as Record<string, unknown>) } }));
   }
+
+  models?.forEach(({ modelType: type, strategy, source }) => {
+    const payload = source ? (data as Record<string, unknown>)[source] : data;
+    switch (strategy) {
+      case 'addModel': store.dispatch(addModel({ modelType: type, model: payload })); break;
+      case 'updateModel': store.dispatch(updateModel({ modelType: type, model: payload })); break;
+      case 'addModelsMap': store.dispatch(addModelsMap({ modelType: type, modelsMap: payload })); break;
+      case 'updateModelsMap': store.dispatch(updateModelsMap({ modelType: type, modelsMap: payload })); break;
+      case 'updateModels': store.dispatch(updateModels({ modelType: type, models: payload })); break;
+      default: break;
+    }
+  });
 };

--- a/src/data/modelStoreBridge.ts
+++ b/src/data/modelStoreBridge.ts
@@ -22,11 +22,11 @@ interface ModelMirror {
   source?: string;
 }
 
-interface ModelStoreMeta {
+export type ModelStoreMeta = {
   modelType?: string;
   courseId?: string;
   models?: ModelMirror[];
-}
+};
 
 // Transitional (#1977): bridge a React Query result into the model store so existing
 // `useModel(...)` readers (the shared TabPage/LoadedTabPage and not-yet-converted tabs)
@@ -37,7 +37,7 @@ interface ModelStoreMeta {
 // This is wired as the app QueryCache's `onSuccess` (see src/queryClient.ts), so it runs
 // before observers re-render.
 export const bridgeToModelStore = (store: Store, data: unknown, query: Query<unknown, unknown>) => {
-  const { modelType, courseId, models } = (query.meta ?? {}) as ModelStoreMeta;
+  const { modelType, courseId, models } = query.meta ?? {};
 
   if (modelType) {
     store.dispatch(addModel({ modelType, model: { id: courseId, ...(data as Record<string, unknown>) } }));

--- a/src/generic/CourseAccessErrorPage.jsx
+++ b/src/generic/CourseAccessErrorPage.jsx
@@ -14,7 +14,7 @@ const CourseAccessErrorPage = () => {
   const { courseId } = useParams();
 
   const activeEnterpriseAlert = useActiveEnterpriseAlert(courseId);
-  const metadataQuery = useCourseHomeMeta(courseId);
+  const metadataQuery = useCourseHomeMeta(courseId, 'outline');
 
   if (metadataQuery.isPending) {
     return (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,9 +23,7 @@ import CoursewareRedirectLandingPage from './courseware/CoursewareRedirectLandin
 import DatesTab from './course-home/dates-tab';
 import GoalUnsubscribe from './course-home/goal-unsubscribe';
 import ProgressTab from './course-home/progress-tab/ProgressTab';
-import { TabContainer } from './tab-page';
 
-import { fetchCourse } from './courseware/data';
 import { store } from './store';
 import { createQueryClient } from './queryClient';
 import NoticesProvider from './generic/notices';
@@ -116,9 +114,7 @@ subscribe(APP_READY, () => {
                         path={DECODE_ROUTES.COURSE_END}
                         element={(
                           <DecodePageRoute>
-                            <TabContainer tab="courseware" fetch={fetchCourse} slice="courseware">
-                              <CourseExit />
-                            </TabContainer>
+                            <CourseExit />
                           </DecodePageRoute>
                       )}
                       />

--- a/src/product-tours/ProductTours.test.jsx
+++ b/src/product-tours/ProductTours.test.jsx
@@ -272,17 +272,19 @@ describe('Courseware Tour', () => {
 
     component = (
       <AppProvider store={store}>
-        <UserMessagesProvider>
-          <Routes>
-            {DECODE_ROUTES.COURSEWARE.map((route) => (
-              <Route
-                key={route}
-                path={route}
-                element={<CoursewareContainer />}
-              />
-            ))}
-          </Routes>
-        </UserMessagesProvider>
+        <QueryClientProvider client={createTestQueryClient(store)}>
+          <UserMessagesProvider>
+            <Routes>
+              {DECODE_ROUTES.COURSEWARE.map((route) => (
+                <Route
+                  key={route}
+                  path={route}
+                  element={<CoursewareContainer />}
+                />
+              ))}
+            </Routes>
+          </UserMessagesProvider>
+        </QueryClientProvider>
       </AppProvider>
     );
   });

--- a/src/product-tours/data/apiHooks.ts
+++ b/src/product-tours/data/apiHooks.ts
@@ -8,7 +8,6 @@ export const useTourData = (username: string, enabled: boolean) => useQuery({
   queryKey: tourQueryKeys.user(username),
   queryFn: () => getTourData(username),
   enabled,
-  refetchOnWindowFocus: false,
 });
 
 export const useEndCourseHomeTour = () => {

--- a/src/queryClient.test.ts
+++ b/src/queryClient.test.ts
@@ -2,7 +2,8 @@ import { QueryClient } from '@tanstack/react-query';
 import { configureStore } from '@reduxjs/toolkit';
 
 import { reducer as modelsReducer } from './generic/model-store';
-import { createAppQueryCache } from './queryClient';
+import { createAppQueryCache, createQueryClient, shouldRetryQuery } from './queryClient';
+import { NonRetryableError } from './data/http-error';
 import { initializeMockApp } from './setupTest';
 
 const { loggingService } = initializeMockApp();
@@ -20,6 +21,7 @@ describe('app query cache', () => {
       queryCache: createAppQueryCache(store),
     });
     loggingService.logError.mockReset();
+    loggingService.logInfo.mockReset();
   });
 
   it('reports query errors through onError', async () => {
@@ -32,6 +34,18 @@ describe('app query cache', () => {
     expect(loggingService.logError).toHaveBeenCalledWith(error, undefined);
   });
 
+  it('logs a status listed in `logStatusAs` at that level instead of as an error', async () => {
+    const error = { response: { status: 403 } };
+    await queryClient.fetchQuery({
+      queryKey: ['forbidden'],
+      queryFn: () => Promise.reject(error),
+      meta: { logStatusAs: { 403: 'info' } },
+    }).catch(() => {});
+
+    expect(loggingService.logInfo).toHaveBeenCalledWith(error, undefined);
+    expect(loggingService.logError).not.toHaveBeenCalled();
+  });
+
   it('bridges successful results into the model store through onSuccess', async () => {
     await queryClient.fetchQuery({
       queryKey: ['ok'],
@@ -41,5 +55,69 @@ describe('app query cache', () => {
 
     const models = store.getState().models as Record<string, Record<string, unknown>>;
     expect(models.widget['course-1']).toEqual({ id: 'course-1', value: 42 });
+  });
+});
+
+describe('shouldRetryQuery', () => {
+  const httpError = (status: number) => ({ response: { status } });
+
+  it.each([400, 401, 403, 404, 422])('does not retry client error %s', (status) => {
+    expect(shouldRetryQuery(0, httpError(status))).toBe(false);
+  });
+
+  it('does not retry a NonRetryableError (our own deterministic throw)', () => {
+    expect(shouldRetryQuery(0, new NonRetryableError('bad response'))).toBe(false);
+  });
+
+  it.each([500, 502, 503])('retries server error %s until 3 attempts', (status) => {
+    expect(shouldRetryQuery(0, httpError(status))).toBe(true);
+    expect(shouldRetryQuery(2, httpError(status))).toBe(true);
+    expect(shouldRetryQuery(3, httpError(status))).toBe(false);
+  });
+
+  it('retries network (undefined-status) errors until 3 attempts', () => {
+    const networkError = new Error('Network Error');
+    expect(shouldRetryQuery(0, networkError)).toBe(true);
+    expect(shouldRetryQuery(2, networkError)).toBe(true);
+    expect(shouldRetryQuery(3, networkError)).toBe(false);
+  });
+
+  it('is wired in as the default query retry policy on createQueryClient', () => {
+    const store = configureStore({ reducer: { models: modelsReducer } });
+    expect(createQueryClient(store).getDefaultOptions().queries?.retry).toBe(shouldRetryQuery);
+  });
+});
+
+describe('createQueryClient retry behavior (integration)', () => {
+  const attemptsFor = async (error: unknown): Promise<number> => {
+    const store = configureStore({ reducer: { models: modelsReducer } });
+    const queryFn = jest.fn().mockRejectedValue(error);
+    await createQueryClient(store).fetchQuery({
+      queryKey: ['retry-test'], queryFn, retryDelay: 0,
+    }).catch(() => {});
+    return queryFn.mock.calls.length;
+  };
+
+  it('does not retry a 4xx (1 attempt)', async () => {
+    expect(await attemptsFor({ response: { status: 403 } })).toBe(1);
+  });
+
+  it('does not retry a NonRetryableError (1 attempt)', async () => {
+    expect(await attemptsFor(new NonRetryableError('bad response'))).toBe(1);
+  });
+
+  it('retries a 5xx server error (4 attempts: 1 + 3 retries)', async () => {
+    expect(await attemptsFor({ response: { status: 500 } })).toBe(4);
+  });
+
+  it('retries a network error (4 attempts: 1 + 3 retries)', async () => {
+    expect(await attemptsFor(new Error('network'))).toBe(4);
+  });
+});
+
+describe('createQueryClient defaults', () => {
+  it('disables refetchOnWindowFocus (parity with the pre-RQ no-focus-refetch behavior)', () => {
+    const store = configureStore({ reducer: { models: modelsReducer } });
+    expect(createQueryClient(store).getDefaultOptions().queries?.refetchOnWindowFocus).toBe(false);
   });
 });

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -1,16 +1,44 @@
-import { logError } from '@edx/frontend-platform/logging';
+import { logError, logInfo } from '@edx/frontend-platform/logging';
 import { QueryCache, QueryClient } from '@tanstack/react-query';
 import { Store } from 'redux';
 
-import { bridgeToModelStore } from './data/modelStoreBridge';
+import { bridgeToModelStore, type ModelStoreMeta } from './data/modelStoreBridge';
+import { getResponseStatus, isNonRetryable } from './data/http-error';
+
+const loggers = { error: logError, info: logInfo };
+export type LogLevel = keyof typeof loggers;
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    queryMeta: ModelStoreMeta & { logStatusAs?: Record<number, LogLevel> };
+  }
+}
 
 // `onSuccess` bridges results into the model store (transitional, #1977); the `store` param
 // exists only to feed it and goes away when the bridge is removed.
 export const createAppQueryCache = (store: Store) => new QueryCache({
   onSuccess: (data, query) => bridgeToModelStore(store, data, query),
-  onError: (error) => logError(error),
+  onError: (error, query) => {
+    const status = getResponseStatus(error);
+    const level = (status !== undefined && query.meta?.logStatusAs?.[status]) || 'error';
+    loggers[level](error);
+  },
 });
+
+export const shouldRetryQuery = (failureCount: number, error: unknown): boolean => {
+  if (isNonRetryable(error)) {
+    return false;
+  }
+  const status = getResponseStatus(error);
+  if (status !== undefined && status >= 400 && status < 500) {
+    return false;
+  }
+  return failureCount < 3;
+};
 
 export const createQueryClient = (store: Store) => new QueryClient({
   queryCache: createAppQueryCache(store),
+  defaultOptions: {
+    queries: { retry: shouldRetryQuery, refetchOnWindowFocus: false },
+  },
 });

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -15,14 +15,18 @@ import { reducer as specialExamsReducer } from '@edx/frontend-lib-special-exams'
 import { AppProvider } from '@edx/frontend-platform/react';
 import { reducer as courseHomeReducer } from './course-home/data';
 import { createAppQueryCache } from './queryClient';
-import { reducer as coursewareReducer } from './courseware/data/slice';
-import { reducer as modelsReducer } from './generic/model-store';
+import { reducer as coursewareReducer, fetchCourseSuccess } from './courseware/data/slice';
+import {
+  reducer as modelsReducer, addModel, addModelsMap, updateModelsMap,
+} from './generic/model-store';
 import { UserMessagesProvider } from './generic/user-messages';
 import { ToastProvider } from './generic/ToastContext';
 
 import messages from './i18n';
 import { fetchCourse, fetchSequence } from './courseware/data';
 import { getCourseOutlineStructure } from './courseware/data/thunks';
+import { getCourseMetadata, getLearningSequencesOutline } from './courseware/data/api';
+import { getCourseHomeCourseMetadata } from './course-home/data/api';
 import { appendBrowserTimezoneToUrl, executeThunk } from './utils';
 import buildSimpleCourseAndSequenceMetadata from './courseware/data/__factories__/sequenceMetadata.factory';
 import { buildOutlineFromBlocks } from './courseware/data/__factories__/learningSequencesOutline.factory';
@@ -171,6 +175,21 @@ export function logUnhandledRequests(axiosMock) {
 
 let globalStore;
 
+export async function seedCoursewareModels(store, courseId) {
+  const [metadata, outline, homeMetadata] = await Promise.all([
+    getCourseMetadata(courseId),
+    getLearningSequencesOutline(courseId),
+    getCourseHomeCourseMetadata(courseId, 'courseware'),
+  ]);
+  store.dispatch(addModel({ modelType: 'coursewareMeta', model: metadata }));
+  store.dispatch(addModel({ modelType: 'courseHomeMeta', model: { id: courseId, ...homeMetadata } }));
+  store.dispatch(updateModelsMap({ modelType: 'coursewareMeta', modelsMap: outline.courses }));
+  store.dispatch(addModelsMap({ modelType: 'sections', modelsMap: outline.sections }));
+  store.dispatch(updateModelsMap({ modelType: 'sequences', modelsMap: outline.sequences }));
+  store.dispatch(fetchCourseSuccess({ courseId }));
+  await executeThunk(fetchCourse(courseId), store.dispatch);
+}
+
 export async function initializeTestStore(options = {}, overrideStore = true) {
   const store = configureStore({
     reducer: {
@@ -227,8 +246,9 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
 
   logUnhandledRequests(axiosMock);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-  !options.excludeFetchCourse && await executeThunk(fetchCourse(courseMetadata.id), store.dispatch);
+  if (!options.excludeFetchCourse) {
+    await seedCoursewareModels(store, courseMetadata.id);
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   !options.excludeFetchOutlineSidebar && await executeThunk(
@@ -247,7 +267,7 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
 export function createTestQueryClient(store) {
   return new QueryClient({
     defaultOptions: {
-      queries: { retry: false },
+      queries: { retry: false, refetchOnWindowFocus: false },
       mutations: { retry: false },
     },
     ...(store ? { queryCache: createAppQueryCache(store) } : {}),


### PR DESCRIPTION
## Summary

Convert the courseware metadata fetch (`fetchCourse`) to React Query, and extend the model-store bridge to mirror **collection** results. Part of the Redux → React Query migration (#1946), the #1976 courseware decomposition (Target 1); stacked on the `CoursewareContainer` de-class (#2020) and TypeScript (#2021) layers as the new top of the stack. Two commits — **#2009** (bridge → collections) and **#2010** (courseware metadata). Closes #2009, #2010.

`fetchCourse` fetched four things (course metadata, the learning-sequences outline, course-home metadata, sidebar toggles) and derived `courseStatus`. This moves the three data fetches to query hooks (mirrored into the model store via the bridge so the existing `useModel` readers keep working), moves the status derivation into transitional bridge hooks, and thins `fetchCourse` to just the un-converted sidebar-toggles fetch.

## What changed

- **`courseware/data/apiHooks.ts` / `queryKeys.ts`** (new) — `useCoursewareMetadata` (`getCourseMetadata`) and `useCoursewareOutline` (`getLearningSequencesOutline`), tagged with `meta.models` so the bridge fans each result into the right model(s). `courseId` is `string | undefined` (from `useParams`) with an `enabled` guard; key factories stay strict `string`.
- **`course-home/data/modelStoreBridge.ts`** (#2009) — the bridge's `meta` gains a `models: [{ modelType, strategy, source? }]` list form, so one query result can fan out to several model targets with the right add-vs-merge semantics (the outline writes three: `coursewareMeta`/`sections`/`sequences`).
- **`courseware/data/statusBridge.ts`** (new) — `useCourseStatusBridge` (container) and `useCourseExitStatusBridge` (CourseExit) run the queries and mirror their combined state into `state.courseware.courseStatus`/`courseId`, so the still-Redux readers (redirect helpers, selectors, `TabPage`'s string status, the exit-page children) keep working. Transitional — removed when those readers move to React Query.
- **`CoursewareContainer.tsx`** — calls `useCourseStatusBridge(routeCourseId)`; the memoized `checkFetchCourse` guard is byte-identical to base (it now dispatches the thinned `fetchCourse`).
- **`CourseExit.jsx`** — self-wrapping on the query hooks via `useCourseExitStatusBridge`, rendering `TabPage` itself.
- **`courseware/data/thunks.js`** — `fetchCourse` thinned to just the sidebar-toggles fetch (its full conversion is #2013); its model writes move to the bridge and its status derivation to the status bridges.
- **`queryClient.ts` / `data/http-error.ts`** — the app `QueryCache`'s `onError` logs query failures; a query overrides the level per HTTP status via `meta.logStatusAs: { <status>: <level> }` (the outline's expected 403 → `logInfo`). `meta` is typed globally via a `Register.queryMeta` augmentation, so `onError` and the bridge read it cast-free. Implements the last piece of #2022.
- **`useIFrameBehavior.ts`** — the post-event refetch invalidates the courseware queries instead of dispatching `fetchCourse`.
- **`index.jsx`** — the courseware route drops the `<TabContainer fetch={fetchCourse}>` wrapper for a bare `<CourseExit />`.

## Behavior

No user-facing change. Metadata/outline/courseHomeMeta now load via React Query and populate the model store through the bridge; `courseStatus`/`courseId` are still written (transitionally, by the status bridges) so the redirects, gating, and `TabPage` behave as before. The sidebar toggles still load via the thinned `fetchCourse`. Query error logging is preserved, including the outline's `403 → logInfo` (a logged-out learner's expected redirect is logged at info level, not surfaced as an error).

## Testing

`npm run types`, `npm run lint`, and the full `npm test` suite pass (109 suites / 912 passing / 3 pre-existing skips at PR-open; the fix below adds `courseware/data/apiHooks.test.tsx`, +1 suite / +1 test). `queryClient.test.ts` covers `onError` (default `logError`, `logStatusAs` override) and the model-store bridge; `modelStoreBridge.test.ts` covers the list-form fan-out; the container / CourseExit / useIFrameBehavior / ProductTours tests render through the bridged query client; `setupTest`'s `seedCoursewareModels` replaces the `executeThunk(fetchCourse)` seed.

**Manual browser verification is done** (tutor local, DemoX), confirming no user-facing change: cold load / hard reload, the full set of URL → redirect rules, prev/next sequence navigation (within and across sequences), unit completion, the course-exit / celebration page, and preview mode all behave as before. The sequence-navigation data path is additionally covered by a new `courseware/data/apiHooks.test.tsx`, which asserts the `coursewareMeta` mirror preserves `sectionIds` regardless of query-resolution order (see the `coursewareMeta` mirror note in the decision log). Items needing a specific user/backend state (access-denied, the outline's expected 403 telemetry, a forced 5xx, sidebar toggles) are left to the automated suite. Full checklist below.

<details>
<summary>Manual testing checklist &amp; findings</summary>

Run against a live backend (tutor local, DemoX). Since this conversion claims no
user-facing change, the pass confirms equivalence end-to-end with real data, a real unit
iframe, and real redirects — what the jest suite can't fully exercise.

**Verified by hand:**
- Cold load + hard reload on a unit URL — the bridge fans the outline into
  `coursewareMeta`/`sections`/`sequences` and the metadata into
  `coursewareMeta`/`courseHomeMeta`; page renders fully (title/header, unit content,
  outline sidebar, iframe) with no flash of missing structure.
- Resume redirect (course root → last-active unit, or first sequence if fresh) —
  `checkResumeRedirect`.
- Section-in-URL → the section's first sequence (`checkSectionToSequenceRedirect`), then
  that sequence's `activeUnitIndex` unit (saved-position resume, unchanged by #2023);
  a never-visited chapter deterministically lands on the sequence's unit 1.
- Section + unit → drops the section and resolves the unit to its real parent sequence
  (`checkSectionUnitToUnitRedirect` → `checkUnitToSequenceUnitRedirect`).
- Unit-only redirect → fills in the parent sequence (`checkUnitToSequenceUnitRedirect`).
- Unit markers `/first` and `/last` → first / last unit of the sequence.
- Sequence + unit navigation (prev/next, within and across sequences) — structure and
  order match the outline.
- Unit completion after interaction — the unit iframe is not torn down by the
  invalidation. The completion checkmark updates on navigation, not instantly:
  confirmed **not a regression** — the checkmark reads `units[].complete` from the
  sequence metadata (`fetchSequence`), which neither the old `dispatch(fetchCourse)` nor
  the new invalidation refetches; #2023 invalidates exactly the three queries
  `fetchCourse` used to (courseware metadata, outline, course-home metadata).
- Course exit / celebration — `CourseExit` (self-wrapping via `useCourseExitStatusBridge`)
  renders the correct state.
- Preview mode — renders; identical to the normal URL, which is **expected**: #2023
  touches no preview-sensitive path (`isPreview` only affects `fetchSequence` and the
  `CoursewareContainer` redirect prefix).

**Not exercised by hand (need a specific user/backend state; covered by the suite):**
- Access-denied / unenrolled learner gating (`courseHomeMeta.courseAccess`).
- Outline expected 403 → `logInfo` telemetry (logged-out learner).
- Genuine failure (5xx) → error UI + `logError`.
- Sidebar toggles (the one fetch not converted — thinned `fetchCourse`).

**Covered by the automated suite instead:**
- Bridge fan-out (list-form add-vs-merge) — `modelStoreBridge.test.ts`.
- Status-bridge derivation — `statusBridge.test.ts`.
- `onError` default + `logStatusAs` override — `queryClient.test.ts`.
- Redirect-helper branches — `CoursewareContainer.test.jsx` (70 tests).
- `CourseExit` / `useIFrameBehavior` / `ProductTours` render paths — their suites via the
  bridged client.
- Thinned `fetchCourse` (sidebar toggles) — `redux.test.js`.

</details>

## Decisions

<details>
<summary>Full decision log</summary>

# Decisions — courseware metadata → React Query (+ bridge collections) (#2009 + #2010)

Working notes for this PR (part of the wider Redux → React Query migration,
#1946). **Not checked in** — referenced when opening the PR. Part of the #1976
courseware decomposition (Target 1). Stacked on the de-class (#2020) and the TS
conversion (#2021).

**Why #2009 and #2010 are one PR (two commits).** #2009 (the bridge extension) has
**no runtime effect on its own** — nothing uses the new `meta` form until #2010 wires
a query to it — and we expect to tweak the bridge while doing #2010. Landing them
together ships a "real" chunk (courseware metadata actually on React Query) instead of
a dormant infra PR followed by its only consumer. Two commits keep the concerns
legible: **commit 1** = bridge, **commit 2** = the metadata conversion.

---

# Part 1 — extend the model-store bridge to collections (#2009, commit 1)

Extend the transitional bridge (`src/course-home/data/modelStoreBridge.ts`) so a query
can mirror **collection** results (and several model targets) into the `models` store,
not just a single `addModel`.

## Why: the courseware producers write collections, and one fetch → many models

`fetchCourse` writes four model types with mixed strategies; the outline endpoint alone
writes three from one response:

| source | model type | action |
|---|---|---|
| `getCourseMetadata` | `coursewareMeta` | `addModel` (data has its own id) |
| `getCourseHomeCourseMetadata` | `courseHomeMeta` | `addModel` keyed by courseId |
| `getLearningSequencesOutline` → `.courses` | `coursewareMeta` | `updateModelsMap` (merge sectionIds) |
| `getLearningSequencesOutline` → `.sections` | `sections` | `addModelsMap` |
| `getLearningSequencesOutline` → `.sequences` | `sequences` | `updateModelsMap` (merge) |

The bridge runs in the QueryCache `onSuccess`, which receives the query's **raw**
result, so a query whose result is `{ courses, sections, sequences }` must fan that one
result out to three mirrors.

## Contract: keep the single form, add a `models` list

- **`{ modelType, courseId }`** (unchanged) — mirror the whole result as one model keyed
  by courseId. The course-home tabs use this; byte-compatible.
- **`{ models: [{ modelType, strategy, source? }] }`** (new) — one or more mirrors.
  `strategy` is a model-store action (`addModel` / `updateModel` / `addModelsMap` /
  `updateModelsMap` / `updateModels`); `source` selects a key of the result (omitted =
  the whole result). Lets one query populate several targets with the right add-vs-merge
  semantics; `source` is what avoids splitting the outline into 3 fetches.

## Alternatives considered

- **Single-target + a `collection` flag.** Rejected: the bridge sees the raw result and
  `meta` is one-target-per-query, so the outline's 3-in-1 shape couldn't be expressed
  without 3 separate fetches (3× network) or a bespoke `onSuccess`.
- **Bespoke per-query handlers.** Same objection — abandons the shared bridge.

## North star

The bridge is throwaway scaffolding, deleted with the model store in #1977. After that,
readers stop calling `useModel(...)` and read from the RQ hooks directly. A couple of
models are assembled from two endpoints (`sequences` = outline shallow +
`getSequenceMetadata` full; `coursewareMeta` = `getCourseMetadata` + outline
`sectionIds`), so those readers combine the relevant hooks — a #2011/#2013/#1977
concern, not this PR.

## Tests

`modelStoreBridge.test.ts` drives real queries through `createModelStoreQueryCache(store)`
and asserts the resulting `models` state: single form, list-form fan-out via `source`,
`updateModelsMap` merging (not clobbering), `updateModels` over an array, and the no-op
when meta is absent.

---

# Part 2 — convert courseware metadata to React Query (#2010, commit 2)

Convert the courseware metadata fetch (`fetchCourse`) to React Query, mirroring into the
model store via the Part-1 bridge so the ~14 `useModel` readers keep working.

## Scope: convert the metadata/outline/courseHomeMeta fetches; thin `fetchCourse` in place

`fetchCourse` did four fetches (metadata, outline, courseHomeMeta, sidebar toggles) + set
`courseStatus`. Its consumers: `CoursewareContainer` (player), the **CourseExit** route
(`<TabContainer fetch={fetchCourse}>`), `useIFrameBehavior` (refetch on an iframe event), and
`setupTest`'s `initializeTestStore`. **Decision: move the three data fetches to RQ hooks and
the status derivation into the container, then _thin_ `fetchCourse` in place** so it does only
the un-converted remainder (the sidebar toggles) — rather than deleting it and adding a new
`fetchCoursewareOutlineSidebarToggles` thunk.

- **Why thin, not delete+recreate:** #2013 removes the toggles (its last responsibility) and
  deletes `fetchCourse` then. Renaming/replacing it now is churn for a transitional step —
  `CoursewareContainer`'s guard (`checkFetchCourse` → `dispatch(fetchCourse(id))`) stays
  **byte-identical to the base**, and `fetchCourse` visibly shrinks (4 fetches → 1) across
  layers until it's gone. Transitional cost: `fetchCourse` is briefly a misnomer (it only
  fetches toggles now).
- Converting **all** consumers (not just the player) avoids the query hooks and
  `useIFrameBehavior` double-populating models on the player.

## The query hooks (new `courseware/data/apiHooks.ts` + `queryKeys.ts`)

- `useCoursewareMetadata(courseId)` → `getCourseMetadata`,
  `meta: { models: [{ modelType: 'coursewareMeta', strategy: 'addModel' }] }` (result has its own id).
  - *Why the array form here and not the single `{ modelType, courseId }` form (as
    `useCourseHomeMeta` uses)?* The single form (bridge line 44) does
    `addModel({ model: { id: courseId, ...data } })` — its purpose is to **inject `courseId`
    as the id**, which `courseHomeMeta` needs because its payload has no id of its own.
    `coursewareMeta`'s payload **has its own id**, and `fetchCourse` stored it with
    `addModel({ model: metadata })` (no injection). The array form + `strategy: 'addModel'`
    (no `source`) maps exactly to that. The two happen to produce the same stored value here
    (in `{ id: courseId, ...data }` the spread wins, and `data.id === courseId` on this
    route), so the single form wouldn't break — but the array form (a) expresses the real
    intent ("store by the model's own id") instead of relying on the spread-override
    coincidence, (b) is the byte-analog of `fetchCourse`'s call, and (c) keeps both courseware
    hooks on one contract (the outline hook *must* use the array form to fan out to 3 targets).
- `useCoursewareOutline(courseId)` → `getLearningSequencesOutline`,
  `meta: { models: [ courses→coursewareMeta/updateModelsMap, sections→addModelsMap, sequences→updateModelsMap ] }`.
- **Reuse `useCourseHomeMeta`** for `courseHomeMeta` — don't re-fetch it.
  - *Faithfulness note:* `useCourseHomeMeta` fetches the `'outline'` rootSlug variant;
    `fetchCourse` used `'courseware'`. `rootSlug` only renames the courseware tab's `slug`
    in the normalized `tabs`; `courseAccess` (what the gating reads) is identical. So
    reuse is faithful for gating; the only difference is that tab's slug.

## `courseId` typing: guarded hooks, strict keys (a migration-wide convention)

`useParams()` types every route param as `string | undefined` — React Router can't prove
which route a component renders under — even though `:courseId` is always present on the
courseware/course-exit routes. This bit only surfaces now because #2010 adds the **first
typed (`.tsx`) caller** of these hooks (`CoursewareContainer`); the existing course-home
callers are all `.jsx`, so the argument was never type-checked. Every future `.tsx`
conversion hits the same thing, so we picked one convention:

- **Hooks take `string | undefined` + `enabled: !!courseId`.** The hook honestly tolerates
  the `useParams` type by *not firing* when the id is absent (the standard React Query
  idiom for "param may not be ready"). Call sites pass `useParams` straight through — no
  casts or guards proliferating across the migration. No-op for the 6 existing `.jsx`
  callers, since courseId is never actually undefined there.
- **Key factories take `string` (never `undefined`).** A query key is a real identity; a
  key on `undefined` is meaningless. So `queryKeys.ts` stays strict.
- **The seam is a `!` at the key call inside the hook** — `coursewareQueryKeys.metadata(courseId!)`.
  This is deliberate, not sloppy: **`queryKey` is evaluated eagerly** (React Query computes
  it every render regardless of `enabled`), so the factory is still called when the query
  is disabled. The `!` says "keys are built from real ids"; the adjacent `enabled: !!courseId`
  is what actually makes the never-happens undefined case safe (no fetch). Runtime-wise the
  `!` is purely type-level.

Alternative considered — **narrow `courseId` to `string` once at the `.tsx` boundary**
(then keys *and* hooks are `string`, no `enabled`, no `!`). Rejected: it relocates the
`useParams` undefined into a guard/assertion at every typed boundary — the
cast-in-the-wrong-place friction from #2019 — instead of handling it once, idiomatically,
in the hook. (This also reverts a `string`→`string | undefined` widening of
`useCourseHomeMeta`/`courseHomeQueryKeys.metadata` that #2010 briefly introduced before we
settled on this convention.)

## Error logging: global `QueryCache.onError` + the outline's 403 nuance

`fetchCourse` logged each endpoint independently: `logError` on failed metadata/courseHomeMeta/
toggles, and for the outline a `403 ? logInfo : logError` split (a 403 there is the expected
access-denied case — the learner is redirected — so it's logged via `logInfo`, not `logError`,
which would surface it as a *noticed error*).

React Query v5 removed `onError` from `useQuery` (it's only on `useMutation` and the
`QueryCache`), so per-hook query logging isn't possible. The home for query error logging is the
global **`QueryCache.onError`** — permanent app infra, introduced with the QueryCache in #1987
and tracked by #2022. By default it `logError`s.

**What #2010 adds** — the courseware outline is the one query that surfaces a 403 *as an error*
(its getter throws it; the course-home tab getters swallow 401/403/404 → `{}`, so their query
errors are only genuine failures). So:

- `useCoursewareOutline` tags `meta: { logStatusAs: { 403: 'info' } }`.
- `onError` reads `query.meta.logStatusAs` — a **status → `LogLevel` map, defaulting to
  `error`** (it says *how* to log each status, not a "quiet" flag). So an outline 403 →
  `logInfo`, restoring `fetchCourse`'s behavior; anything else → `logError`. `LogLevel`
  (`'error' | 'info'`) derives from a `{ error: logError, info: logInfo }` map — the only two
  loggers platform exposes.
- The toggles keep their logging via the thinned `fetchCourse`'s `catch → logError`.

**Typed `meta`, no casts.** `meta` is typed globally via a `Register.queryMeta` augmentation
(`ModelStoreMeta & { logStatusAs?: Record<number, LogLevel> }`), so both `onError` and the
model-store bridge read `query.meta` without a cast, and `meta` literals are checked at the
write site. `getResponseStatus` (`data/http-error.ts`) reads the error's status. At #1977 the
augmentation drops its `ModelStoreMeta` half along with the bridge.

*Migration-wide context (#2022):* other converted queries dropped their thunks' `logError` too,
but their getters swallow 401/403/404, so the global `onError` (plain `logError`) already covers
their genuine failures without per-query `meta`. The outline is the exception that needs the
`logStatusAs` tag.

## Access-gating + status: a transitional `useCourseStatusBridge`

The old `fetchCourse` derived `courseStatus` (request → success/denied/failure) from
`courseAccess.hasAccess` + outline success and dispatched `fetchCourse{Request,Success,
Denied,Failure}`. That derivation moves out of the thunk into a **transitional bridge hook**,
`useCourseStatusBridge` (`courseware/data/statusBridge.ts`): it runs the three query hooks and
mirrors their combined state into `state.courseware.courseStatus` via the same status actions,
so the still-Redux readers (the container's redirect helpers/selectors, `TabPage`'s string
status, `useContextId`) keep working. `CoursewareContainer` just calls
`useCourseStatusBridge(routeCourseId)`.

*Why a bridge, and why a component hook (not the model-store one):* it's the same "keep Redux
populated from RQ transitionally" idea as the model-store bridge, but `courseStatus` is a
derivation *across all three queries* — which a per-query `QueryCache.onSuccess` can't express —
so it's a component-level hook, not part of the centralized bridge. Deleted when those readers
move to RQ.

The status reducers stay. `fetchCourse` is *thinned*, not deleted (see the scope section), so
`checkFetchCourse` stays too — it just dispatches the thinned `fetchCourse` (toggles only). RQ
auto-fetches on courseId change, so no separate metadata-fetch guard is needed.

## CourseExit route → self-wrapping (+ transitional slice write for the exit children)

`<TabContainer tab="courseware" fetch={fetchCourse}>` becomes `CourseExit` self-wrapping
on the query hooks (rendering `TabPage` itself), matching the course-home tab pattern.

**Why the transitional slice write:** the course-exit *children* (`CourseCelebration`,
`CourseNonPassing`, `CourseInProgress`, and the recommendation/upgrade helpers) read
`courseId` from `state.courseware` — which `fetchCourse` used to set on this route. Without the
thunk, that slice field would be unset on the CourseExit route, so `useModel('courseHomeMeta',
undefined)` would return `{}` and `tabs.find(...)` would throw. Rather than convert all ~7 children off
the slice (that's #1976's job), `CourseExit` writes `courseId`/`courseStatus` to the slice
**transitionally** via `useCourseExitStatusBridge` (`courseware/data/statusBridge.ts`) — the
CourseExit sibling of `useCourseStatusBridge` (2 queries, no outline). CourseExit *owns* the
two queries (it also feeds them to its own `TabPage` gating), so it passes them **into** the
bridge rather than the bridge returning them. The children keep reading the slice until they
convert.

## `useIFrameBehavior` refetch → query invalidation

The iframe `POST_EVENT` handler's `postEvent.mutate` `onSuccess` did
`dispatch(fetchCourse(courseId))`; it now `queryClient.invalidateQueries` the three query keys
(`coursewareQueryKeys.metadata`, `coursewareQueryKeys.outline`, `courseHomeQueryKeys.metadata`)
via `useQueryClient`, so the refetch goes through RQ.

`fetchCourse` refetched a fourth thing — the sidebar toggles — but we deliberately **don't**
invalidate those here, and nothing else is needed for them: `enableCompletionTracking` is a
static course-level setting, and this trigger is a unit-level learner action (`POST_EVENT`)
that can't change it, so refetching it on every event was redundant. The three invalidated
queries cover exactly the data such an event can change (completion / gating / access), and
`courseStatus` re-derives via `useCourseStatusBridge` once those queries resettle.

## Sidebar toggles peeled aside (to #2013)

`getCoursewareOutlineSidebarToggles` → `setCoursewareOutlineSidebarToggles` feeds only
the outline sidebar. It's the one fetch left in the thinned `fetchCourse` (which the
container still dispatches via the unchanged `checkFetchCourse` guard), so the setting keeps
loading until the sidebar layer (#2013) converts it and deletes `fetchCourse`. Not folded
into the query hooks here.

### Align the toggle + outline-data peels with #1920's data split

Upstream PR #1920 ("Course outline restructure") splits the outline sidebar hook into
`useCourseOutlineData()` (the **data**: `sections`/`sequences`/`units`/`courseOutlineStatus`/
`activeSequenceId`/`sequenceStatus`, **plus `isEnabledCompletionTracking`** and
`isActiveEntranceExam`) and `useCourseOutlineSidebar()` (just open/collapse UI state). Notably
it **moves `isEnabledCompletionTracking` from `useCourseOutlineSidebar()` to
`useCourseOutlineData()`** — i.e. the completion-tracking toggle is treated as *outline data*,
not sidebar chrome.

Implication for our decomposition (not #2010 — the transitional thunk just writes the slice,
which #1920 still reads via `useSelector`, so there's no conflict): when we convert these to
React Query, group the **toggle conversion (#2013)** with the **outline-data conversion**
(sections/sequences/units/status) so both feed `useCourseOutlineData`. Don't structure the
toggle as its own sidebar-flavored peel. Aligned that way, the eventual rebase over #1920 is
just "point `useCourseOutlineData` at the query hooks." (#1920 is UI-only — no `data/`/thunk/
slice files — and currently stalled/red, so we align the split now and rebase whenever it moves.)

## Test seeding (`setupTest.js`)

`initializeTestStore` (used by ~37 test files) seeds via `executeThunk(fetchCourse)`.
Replace that with direct model-store dispatches replicating `fetchCourse`'s writes
(coursewareMeta / courseHomeMeta / sections / sequences) from the same mocked data, so
the 37 callers keep working unchanged. Contained to `setupTest.js`.

---

# Model-store mirror strategy

## The `coursewareMeta` mirror merges, not replaces

**Decision.** `useCoursewareMetadata` mirrors its result into the `coursewareMeta` model
with `strategy: 'updateModel'` (merge), not `addModel` (replace).

**Why.** `coursewareMeta[courseId]` is written by two independent queries: the metadata
query (`getCourseMetadata`, whose payload has **no** `sectionIds`) and the outline query
(`getLearningSequencesOutline`, the **only** source of `sectionIds`, mirrored via
`updateModelsMap` on `courses`). `addModel` is a full replace (`state[type][id] = model`),
so when the metadata query resolved *after* the outline, it wiped the `sectionIds` the
outline had merged in. `sequenceIdsSelector` then returned `[]`, so
`useSequenceNavigationMetadata` computed `sequenceIndex = -1` → `previousSequenceId = null`
(couldn't go back a sequence) and `isLastUnit` true → next went to `/course-end`.
Intermittent, because it was a network-order race, re-rolled by the unit-completion query
invalidation. The old `fetchCourse` was immune: after `Promise.allSettled` it dispatched
`addModel(metadata)` then `updateModelsMap(courses)` synchronously, so the `sectionIds`
merge always ran last (there was even a comment saying so). `updateModel` restores that
guarantee regardless of resolution order; the payload carries `id`, and the bridge already
supports the strategy.

**Tested.** `courseware/data/apiHooks.test.tsx` renders both hooks through the bridged
query client with the metadata response deferred so its mirror lands last, then asserts
`coursewareMeta.sectionIds` and `sequenceIdsSelector` survive — RED with `addModel`, GREEN
with `updateModel`.

## Audit: no other model-store mirror has the same exposure

**Decision.** Only the `coursewareMeta` metadata mirror needed the fix; the other mirrors
are correct as-is.

**The rule.** A replace-style mirror (`addModel` / `addModelsMap`) is only unsafe when
another writer contributes a field that the replacing query's **own endpoint does not
return** — a cross-source field. `coursewareMeta.sectionIds` was the unique case (metadata
query replaces the model; `sectionIds` only ever comes from the outline endpoint).

**Findings.**
- `sections` — `addModelsMap` (replace-per-section), but the outline is the only runtime
  writer, so nothing else's fields can be clobbered. Safe.
- `sequences` — outline `updateModelsMap` + `fetchSequence` `updateModel`, both merge (the
  old code deliberately merged here: "sequence metadata may have come back first"). Safe.
- `coursewareMeta` — after the fix, all three runtime writers (metadata mirror, outline
  mirror, a `updateModel` in `thunks.js`) merge. Safe.
- `courseHomeMeta` (pre-existing, not #2023) — same *shape* (`useCourseHomeMeta` `addModel`
  replace vs celebration/streak `updateModel`), but benign: `celebrations` is part of the
  course-home metadata response (`normalizeCourseHomeCourseMetadata` spreads the whole
  payload) and is server-persisted (`postCelebrationComplete`), so a replace-refetch
  restores it — the field is same-source, unlike `sectionIds`. `refetchOnWindowFocus` is
  also `false`. No action.

</details>

