### PR TITLE
Associate search input with visible heading label

### DIFF
--- a/src/course-home/courseware-search/CoursewareSearch.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.jsx
@@ -110,12 +110,13 @@ const CoursewareSearchModal = ({ ...sectionProps }) => {
       <div className="courseware-search__outer-content">
         <div className="courseware-search__content" data-testid="courseware-search-content">
           <div className="courseware-search__form">
-            <h1 className="h2">{formatMessage(messages.searchModuleTitle)}</h1>
+            <h1 className="h2" id="courseware-search-title">{formatMessage(messages.searchModuleTitle)}</h1>
             <CoursewareSearchForm
               searchTerm={searchKeyword}
               onSubmit={handleSubmit}
               onChange={handleOnChange}
               placeholder={formatMessage(messages.searchBarPlaceholderText)}
+              labelledBy="courseware-search-title"
             />
             <div className="courseware-search__close">
               <Button

--- a/src/course-home/courseware-search/CoursewareSearch.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearch.test.jsx
@@ -109,6 +109,12 @@ describe('CoursewareSearch', () => {
       const section = screen.getByTestId('courseware-search-dialog');
       expect(section.style.getPropertyValue('--modal-top-position')).toBe(`${tabsTopPosition}px`);
     });
+
+    it('should expose the visible heading as the search input\'s accessible name', async () => {
+      renderComponent();
+      const input = await screen.findByRole('searchbox', { name: /search this course/i });
+      expect(input).toBeInTheDocument();
+    });
   });
 
   describe('when clicking on the "Close" button', () => {

--- a/src/course-home/courseware-search/CoursewareSearchForm.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchForm.jsx
@@ -8,6 +8,7 @@ const CoursewareSearchForm = ({
   onSubmit,
   onChange,
   placeholder,
+  labelledBy,
 }) => {
   const { formatMessage } = useIntl();
 
@@ -25,8 +26,8 @@ const CoursewareSearchForm = ({
       }}
     >
       <div className="pgn__searchfield_wrapper" data-testid="courseware-search-form">
-        <SearchField.Label />
-        <SearchField.Input placeholder={placeholder} autoFocus />
+        {/* The visible "Search this course" heading is the accessible label via aria-labelledby. */}
+        <SearchField.Input placeholder={placeholder} aria-labelledby={labelledBy} autoFocus />
         <SearchField.ClearButton />
       </div>
       <SearchField.SubmitButton
@@ -43,6 +44,7 @@ CoursewareSearchForm.propTypes = {
   onSubmit: PropTypes.func,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  labelledBy: PropTypes.string,
 };
 
 CoursewareSearchForm.defaultProps = {
@@ -50,6 +52,7 @@ CoursewareSearchForm.defaultProps = {
   onSubmit: undefined,
   onChange: undefined,
   placeholder: undefined,
+  labelledBy: undefined,
 };
 
 export default CoursewareSearchForm;

--- a/src/course-home/courseware-search/CoursewareSearchForm.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchForm.test.jsx
@@ -62,9 +62,10 @@ describe('CoursewareSearchToggle', () => {
   });
 
   it('should not render a visually-hidden duplicate "Search" label', async () => {
-    await act(async () => renderComponent(placeholderText, onSubmitHandlerMock, onChangeHandlerMock, 'external-id'));
+    let container;
+    await act(async () => { container = renderComponent(placeholderText, onSubmitHandlerMock, onChangeHandlerMock, 'external-id'); });
     // Guards against re-introducing <SearchField.Label />, which renders an sr-only duplicate label.
-    expect(document.querySelector('label .sr-only')).toBeNull();
+    expect(container.querySelector('label.sr-only, label .sr-only')).toBeNull();
   });
 
   afterEach(() => {

--- a/src/course-home/courseware-search/CoursewareSearchForm.test.jsx
+++ b/src/course-home/courseware-search/CoursewareSearchForm.test.jsx
@@ -9,11 +9,12 @@ import {
 } from '../../setupTest';
 import CoursewareSearchForm from './CoursewareSearchForm';
 
-function renderComponent(placeholder, onSubmit, onChange) {
+function renderComponent(placeholder, onSubmit, onChange, labelledBy) {
   const { container } = render(<CoursewareSearchForm
     placeholder={placeholder}
     onSubmit={onSubmit}
     onChange={onChange}
+    labelledBy={labelledBy}
   />);
   return container;
 }
@@ -52,6 +53,18 @@ describe('CoursewareSearchToggle', () => {
       fireEvent.click(element);
       expect(onSubmitHandlerMock).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('should associate the input with an external label via aria-labelledby', async () => {
+    await act(async () => renderComponent(placeholderText, onSubmitHandlerMock, onChangeHandlerMock, 'external-id'));
+    const input = await screen.findByRole('searchbox');
+    expect(input).toHaveAttribute('aria-labelledby', 'external-id');
+  });
+
+  it('should not render a visually-hidden duplicate "Search" label', async () => {
+    await act(async () => renderComponent(placeholderText, onSubmitHandlerMock, onChangeHandlerMock, 'external-id'));
+    // Guards against re-introducing <SearchField.Label />, which renders an sr-only duplicate label.
+    expect(document.querySelector('label .sr-only')).toBeNull();
   });
 
   afterEach(() => {

--- a/src/course-home/courseware-search/messages.ts
+++ b/src/course-home/courseware-search/messages.ts
@@ -33,8 +33,8 @@ const messages = defineMessages({
   },
   searchBarPlaceholderText: {
     id: 'learn.coursewareSearch.searchBarPlaceholderText',
-    defaultMessage: 'Search',
-    description: 'Placeholder text for the Courseware Search input control',
+    defaultMessage: 'Find topics across this course',
+    description: 'Placeholder hint shown inside the Courseware Search input describing what can be searched.',
   },
   loading: {
     id: 'learn.coursewareSearch.loading',


### PR DESCRIPTION
## Description

Fixes an accessibility issue in the Courseware Search modal where the search input had a visually-hidden `"Search"` label that duplicated the placeholder, while the visible `"Search this course"` heading was **not** programmatically associated with the input. Screen reader users heard redundant label information and missed the more descriptive visible title.

#### Problem

- The search field had a visually hidden label (`"Search"`) rendered by `<SearchField.Label />` that repeated the placeholder text — screen readers announced the same label twice.
- The visible `<h1>Search this course</h1>` above the input was **not** connected to it via `for`/`id` or `aria-labelledby`, so assistive tech users never received that context.
- The placeholder text (`"Search"`) was also non-informative — it just repeated the hidden label instead of hinting at what could be searched.

#### Fix

Associate the visible heading with the input via `aria-labelledby`, remove the redundant hidden label, and repurpose the placeholder as a real hint describing what the search covers.

#### Testing

1. Open a course and launch the Courseware Search modal.
2. With a screen reader, focus the search input.
3. Expected: the input is announced once with the name "Search this course, search" (name from the visible heading, role searchbox), followed by the placeholder hint. No duplicate "Search" announcement.
4. Inspect the input in DevTools — confirm aria-labelledby="courseware-search-title" and no sibling <label> element with an sr-only child.

#### Screenshots

<img width="865" height="334" alt="Screenshot 2026-08-28 at 12 28 23 PM" src="https://github.com/user-attachments/assets/ddf42c86-d0f8-4019-ae34-cce10daea535" />

#### AI usage notice
Used Claude Opus 4.7 to assist on this creation of this pr.