### PR TITLE
fix: surface tab-data errors instead of silently swallowing them on access denial

### DIFF
--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -126,12 +126,6 @@ export async function getDatesTabData(courseId) {
       // courseAccess in the metadata call, so just ignore this status for now.
       return {};
     }
-    if (httpErrorStatus === 403) {
-      // The backend sends this if there is a course access error and the user should be redirected. The redirect
-      // info is included in the course metadata request and will be handled there as long as this call returns
-      // without an error
-      return {};
-    }
     throw error;
   }
 }
@@ -184,12 +178,6 @@ export async function getProgressTabData(courseId, targetUserId) {
     if (httpErrorStatus === 401) {
       // The backend sends this for unenrolled and unauthenticated learners, but we handle those cases by examining
       // courseAccess in the metadata call, so just ignore this status for now.
-      return {};
-    }
-    if (httpErrorStatus === 403) {
-      // The backend sends this if there is a course access error and the user should be redirected. The redirect
-      // info is included in the course metadata request and will be handled there as long as this call returns
-      // without an error
       return {};
     }
     throw error;
@@ -253,26 +241,8 @@ export function getTimeOffsetMillis(headerDate, requestTime, responseTime) {
 export async function getOutlineTabData(courseId) {
   const url = `${getConfig().LMS_BASE_URL}/api/course_home/outline/${courseId}`;
   const requestTime = Date.now();
-  let tabData;
-  try {
-    tabData = await getAuthenticatedHttpClient().get(url);
-  } catch (error) {
-    const httpErrorStatus = error?.response?.status;
-    if (httpErrorStatus === 403) {
-      // The backend sends this if there is a course access error and the user should be redirected. The redirect
-      // info is included in the course metadata request and will be handled there as long as this call returns
-      // without an error
-      return {};
-    }
-    throw error;
-  }
-
+  const { data, headers } = await getAuthenticatedHttpClient().get(url);
   const responseTime = Date.now();
-
-  const {
-    data,
-    headers,
-  } = tabData;
 
   const accessExpiration = camelCaseObject(data.access_expiration);
   const certData = camelCaseObject(data.cert_data);

--- a/src/course-home/data/api.test.js
+++ b/src/course-home/data/api.test.js
@@ -194,9 +194,9 @@ describe('getDatesTabData', () => {
     await expect(getDatesTabData(courseId)).resolves.toEqual({});
   });
 
-  it('swallows a 403 and resolves to an empty object', async () => {
+  it('re-throws a 403 (access is handled via the metadata request, but tab data must still fail)', async () => {
     axiosMock.onGet(datesUrl).reply(403);
-    await expect(getDatesTabData(courseId)).resolves.toEqual({});
+    await expect(getDatesTabData(courseId)).rejects.toThrow();
   });
 
   it('re-throws other errors', async () => {

--- a/src/course-home/data/apiHooks.test.tsx
+++ b/src/course-home/data/apiHooks.test.tsx
@@ -8,8 +8,8 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { initializeMockApp } from '../../setupTest';
 import { ToastProvider, useToast } from '../../generic/ToastContext';
 import {
-  useOutlineTabData, useLiveTabData, useProgressTabData, useResetDeadlines, usePostEvent, useRequestCert,
-  useDismissWelcomeMessage, useSaveWeeklyLearningGoal,
+  useDatesTabData, useOutlineTabData, useLiveTabData, useProgressTabData, useResetDeadlines, usePostEvent,
+  useRequestCert, useDismissWelcomeMessage, useSaveWeeklyLearningGoal,
 } from './apiHooks';
 
 const { loggingService } = initializeMockApp();
@@ -173,16 +173,36 @@ describe('course-home apiHooks', () => {
     });
   });
 
+  describe('useDatesTabData', () => {
+    const datesUrl = `${getConfig().LMS_BASE_URL}/api/course_home/dates/course-1`;
+
+    it('resolves to an empty object on a 401 (access is handled via the metadata request)', async () => {
+      axiosMock.onGet(datesUrl).reply(401, {});
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useDatesTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual({});
+    });
+
+    it('surfaces the error on a 403 (course access errors like embargo must still block tab content)', async () => {
+      axiosMock.onGet(datesUrl).reply(403, {});
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useDatesTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+  });
+
   describe('useOutlineTabData', () => {
     const outlineUrl = `${getConfig().LMS_BASE_URL}/api/course_home/outline/course-1`;
 
-    it('resolves to an empty object on a 403 (access is handled via the metadata request)', async () => {
+    it('surfaces the error on a 403 (course access errors like embargo must still block tab content)', async () => {
       axiosMock.onGet(outlineUrl).reply(403, {});
       const { wrapper } = buildWrapper();
       const { result } = renderHook(() => useOutlineTabData('course-1'), { wrapper });
 
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data).toEqual({});
+      await waitFor(() => expect(result.current.isError).toBe(true));
     });
 
     it('surfaces the error on a non-403 failure', async () => {
@@ -256,17 +276,22 @@ describe('course-home apiHooks', () => {
       expect(axiosMock.history.get[0].url).toEqual(`${progressUrl}/7/`);
     });
 
-    it.each([401, 403])(
-      'resolves to an empty object on a %s (access is handled via the metadata request)',
-      async (status) => {
-        axiosMock.onGet(progressUrl).reply(status, {});
-        const { wrapper } = buildWrapper();
-        const { result } = renderHook(() => useProgressTabData('course-1'), { wrapper });
+    it('resolves to an empty object on a 401 (access is handled via the metadata request)', async () => {
+      axiosMock.onGet(progressUrl).reply(401, {});
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useProgressTabData('course-1'), { wrapper });
 
-        await waitFor(() => expect(result.current.isSuccess).toBe(true));
-        expect(result.current.data).toEqual({});
-      },
-    );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual({});
+    });
+
+    it('surfaces the error on a 403 (course access errors like embargo must still block tab content)', async () => {
+      axiosMock.onGet(progressUrl).reply(403, {});
+      const { wrapper } = buildWrapper();
+      const { result } = renderHook(() => useProgressTabData('course-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
 
     it('redirects to the legacy progress page and resolves to an empty object on a 404', async () => {
       // jsdom's location.replace is non-configurable, so we swap the whole location for the

--- a/src/tab-page/TabPage.test.jsx
+++ b/src/tab-page/TabPage.test.jsx
@@ -183,21 +183,73 @@ describe('Tab Page', () => {
       expect(screen.queryByTestId('LoadedTabPage')).not.toBeInTheDocument();
     });
 
-    it('does not render tab content when access is denied', async () => {
-      const testStore = await initializeTestStore({ excludeFetchCourse: true, excludeFetchSequence: true }, false);
-      testStore.dispatch(addModel({
-        modelType: 'courseHomeMeta',
-        model: { id: 'test-course', courseAccess: { hasAccess: false } },
-      }));
-      render(
-        <TabPage
-          {...mockData}
-          activeTabSlug="dates"
-          courseStatus={{ metadataQuery: { data: { courseAccess: { hasAccess: false } } }, tabDataQuery: {} }}
-        />,
-        { store: testStore, wrapWithRouter: true },
-      );
-      expect(screen.queryByTestId('LoadedTabPage')).not.toBeInTheDocument();
+    describe('when access is denied', () => {
+      let testStore;
+
+      beforeAll(async () => {
+        testStore = await initializeTestStore({ excludeFetchCourse: true, excludeFetchSequence: true }, false);
+        testStore.dispatch(addModel({
+          modelType: 'courseHomeMeta',
+          model: { id: 'test-course', courseAccess: { hasAccess: false } },
+        }));
+      });
+
+      it.each([
+        {
+          // A denied learner on a tab with a real redirect target (e.g. dates) is redirected
+          // when tab data succeeds too - the baseline case, unaffected by tab-data outcome.
+          name: 'does not render tab content when there is a redirect target and the tab-data query succeeds',
+          activeTabSlug: 'dates',
+          tabDataQuery: {},
+          expectLoaded: false,
+          expectError: false,
+        },
+        {
+          // A denied learner on a tab with a real redirect target must still be redirected
+          // even if the tab-data query also failed - the redirect must win over isError.
+          name: 'redirects instead of showing an error when there is a redirect target and the tab-data query also fails',
+          activeTabSlug: 'dates',
+          tabDataQuery: { isError: true },
+          expectLoaded: false,
+          expectError: false,
+        },
+        {
+          // Denied-with-no-redirect (outline) must still render content when tab data is fine -
+          // isError from a failing tab-data query must not leak into this case.
+          name: 'renders tab content when there is no redirect target and the tab-data query succeeds',
+          activeTabSlug: 'outline',
+          tabDataQuery: {},
+          expectLoaded: true,
+          expectError: false,
+        },
+        {
+          // The outline tab renders content for denied learners with no redirect URL, but that
+          // content must actually be there - a failed tab-data fetch (e.g. embargo also blocking
+          // the outline API itself) must win over "denied", not fall through to LoadedTabPage
+          // with no data to render.
+          name: 'displays the error message when there is no redirect target and the tab-data query also fails',
+          activeTabSlug: 'outline',
+          tabDataQuery: { isError: true },
+          expectLoaded: false,
+          expectError: true,
+        },
+      ])('$name', ({
+        activeTabSlug, tabDataQuery, expectLoaded, expectError,
+      }) => {
+        render(
+          <TabPage
+            {...mockData}
+            activeTabSlug={activeTabSlug}
+            courseStatus={{
+              metadataQuery: { data: { courseAccess: { hasAccess: false } } },
+              tabDataQuery,
+            }}
+          />,
+          { store: testStore, wrapWithRouter: true },
+        );
+        expect(!!screen.queryByTestId('LoadedTabPage')).toBe(expectLoaded);
+        expect(!!screen.queryByText('There was an error loading this course.')).toBe(expectError);
+      });
     });
   });
 });

--- a/src/tab-page/TabPage.tsx
+++ b/src/tab-page/TabPage.tsx
@@ -61,9 +61,14 @@ const deriveView = (courseStatus: CourseStatus): TabView => {
   if (metadataQuery.isError) { return { ...view, isError: true }; }
   if (metadataQuery.isPending) { return { ...view, isLoading: true }; }
   if (tabDataQuery?.isPending) { return { ...view, isLoading: true }; }
-  if (!metadataQuery.data?.courseAccess?.hasAccess) { return { ...view, isDenied: true }; }
-  if (tabDataQuery?.isError) { return { ...view, isError: true }; }
-  return view;
+  // isDenied and isError aren't mutually exclusive: a denied learner with a redirect target
+  // navigates away before either is read, but one without a redirect (the outline tab's
+  // "show the page anyway" case) still needs tab data, so a failed fetch must set isError.
+  return {
+    ...view,
+    isDenied: !metadataQuery.data?.courseAccess?.hasAccess,
+    isError: !!tabDataQuery?.isError,
+  };
 };
 
 const TabPage = ({


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Course tab pages (dates, progress, outline) silently swallowed HTTP 403 responses from their tab-data endpoints, returning an empty object instead of surfacing an error. That assumed 403 always meant "course access denied, handled by the metadata request's redirect" — but a 403 can also come from something like an embargo block on the tab-data endpoint itself, unrelated to the metadata call. Learners hit that case saw a blank/broken tab with no explanation.

- `api.js`: 403 now re-throws like any other error on `getDatesTabData`, `getProgressTabData`, `getOutlineTabData`.
- `TabPage.tsx`: `deriveView()` now derives `isDenied` and `isError` as independent flags instead of mutually-exclusive branches, so:
  - a denied learner with a real redirect target still redirects, even if tab-data also failed
  - a denied learner with no redirect target (the outline tab's "show the page anyway" case) now shows an error instead of silently rendering with no data

<details>
<summary><b>Implementation details</b></summary>
<br>

`getDatesTabData`/`getProgressTabData` still swallow HTTP 401 the same way 403 used to be swallowed - left alone in this PR since removing it changes user-visible behavior beyond this fix's scope. Flagging it here as a known follow-up, not fixed now.
</details>

### How can this be tested?
`npx jest src/tab-page/TabPage.test.jsx src/course-home/data/api.test.js src/course-home/data/apiHooks.test.tsx` - 55/55 passing, including new cases covering: 403 re-thrown at the API layer, the hook surfacing `isError` for dates/progress/outline, and `TabPage` rendering the right outcome across the redirect-target x tab-data-outcome matrix.

### Additional Context
No UI/visual change - same error page, just reachable from a case it previously silently swallowed.
