### PR TITLE
feat: redirect to the embargo blocked-message page on error_code 'embargo'

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const ROUTES = {
   DASHBOARD: 'dashboard',
   ENTERPRISE_LEARNER_DASHBOARD: 'enterprise-learner-dashboard',
   CONSENT: 'consent',
+  EMBARGO: 'embargo',
 } as const satisfies Readonly<{ [k: string]: string }>;
 
 export const REDIRECT_MODES = {
@@ -37,6 +38,7 @@ export const REDIRECT_MODES = {
   CONSENT_REDIRECT: 'consent-redirect',
   HOME_REDIRECT: 'home-redirect',
   SURVEY_REDIRECT: 'survey-redirect',
+  EMBARGO_REDIRECT: 'embargo-redirect',
 } as const satisfies Readonly<{ [k: string]: string }>;
 
 export const VERIFIED_MODES = [

--- a/src/courseware/CoursewareRedirectLandingPage.jsx
+++ b/src/courseware/CoursewareRedirectLandingPage.jsx
@@ -38,6 +38,10 @@ const CoursewareRedirectLandingPage = () => (
         element={<PageWrap><RedirectPage mode={REDIRECT_MODES.CONSENT_REDIRECT} /></PageWrap>}
       />
       <Route
+        path={ROUTES.EMBARGO}
+        element={<PageWrap><RedirectPage pattern="/embargo/blocked-message/courseware/default/" mode={REDIRECT_MODES.EMBARGO_REDIRECT} /></PageWrap>}
+      />
+      <Route
         path={DECODE_ROUTES.REDIRECT_HOME}
         element={<DecodePageRoute><RedirectPage pattern="/course/:courseId/home" mode={REDIRECT_MODES.HOME_REDIRECT} /></DecodePageRoute>}
       />

--- a/src/courseware/CoursewareRedirectLandingPage.test.jsx
+++ b/src/courseware/CoursewareRedirectLandingPage.test.jsx
@@ -48,4 +48,16 @@ describe('CoursewareRedirectLandingPage', () => {
 
     expect(redirectUrl).toHaveBeenCalledWith('http://localhost:8734');
   });
+
+  it('Redirects to the embargo blocked-message page', () => {
+    render(
+      <Router initialEntries={['/embargo']}>
+        <CoursewareRedirectLandingPage />
+      </Router>,
+    );
+
+    // generatePath() strips the trailing slash for a static pattern; Django's APPEND_SLASH
+    // restores it with a redirect, one harmless extra hop on a full-page navigation.
+    expect(redirectUrl).toHaveBeenCalledWith('http://localhost:18000/embargo/blocked-message/courseware/default');
+  });
 });

--- a/src/shared/access.js
+++ b/src/shared/access.js
@@ -30,6 +30,13 @@ export function getAccessDeniedRedirectUrl(courseId, activeTabSlug, courseAccess
     case 'unfulfilled_milestones':
       url = '/redirect/dashboard';
       break;
+    case 'embargo':
+      // Unlike enrollment_required/authentication_required (default, below), there's no
+      // "preview" concept for a sanctions block - redirect away from every tab, including
+      // the outline tab, to the same generic embargo "blocked message" page the legacy
+      // courseware view redirects to.
+      url = '/redirect/embargo';
+      break;
     case 'authentication_required':
     case 'enrollment_required':
     default:

--- a/src/shared/access.test.js
+++ b/src/shared/access.test.js
@@ -1,0 +1,13 @@
+import { getAccessDeniedRedirectUrl } from './access';
+
+describe('getAccessDeniedRedirectUrl', () => {
+  it('redirects an embargoed learner away from the outline tab, unlike enrollment_required', () => {
+    const courseAccess = { errorCode: 'embargo' };
+    expect(getAccessDeniedRedirectUrl('test-course', 'outline', courseAccess)).toBe('/redirect/embargo');
+  });
+
+  it('redirects an embargoed learner away from a non-outline tab too', () => {
+    const courseAccess = { errorCode: 'embargo' };
+    expect(getAccessDeniedRedirectUrl('test-course', 'dates', courseAccess)).toBe('/redirect/embargo');
+  });
+});


### PR DESCRIPTION
## Summary

`course_access.errorCode` can now come back as `embargo` (a country-embargo block, reported by the LMS `course_metadata` endpoint - companion backend change: openedx/openedx-platform#39079). It previously fell into `getAccessDeniedRedirectUrl`'s `default` case: `dates`/`progress` redirected to course home, but the outline tab rendered anyway - the "show the page anyway" behavior that's correct for `enrollment_required` (so an unenrolled learner can preview the outline), but wrong for a sanctions block, which has no preview concept.

Supersedes #2054, which took a different (data-layer) approach to a related embargo-MFE gap; closed in favor of this PR once the backend PR was scoped down to the `course_metadata` endpoint only.

## What changed

- **`src/shared/access.js`** - adds a dedicated `'embargo'` case to `getAccessDeniedRedirectUrl` that redirects every tab, including outline, to `/redirect/embargo`.
- **`src/constants.ts`** / **`src/courseware/CoursewareRedirectLandingPage.jsx`** - registers that route using the existing `/redirect/*` landing-page pattern (`RedirectPage` + `CoursewareRedirectLandingPage`, the same mechanism `dashboard`/`consent`/`survey` redirects already use), pointing at the legacy embargo "blocked message" page (`/embargo/blocked-message/courseware/default/`) so an embargoed learner sees the same sanctions-specific copy the legacy courseware view already redirects to.

<details>
<summary><b>Implementation details</b></summary>
<br>

The redirect target is hardcoded to the generic default blocked-message path rather than passed dynamically from the backend. `RestrictedCourse` supports a per-course custom embargo message, which this won't respect - a deliberate scope trade-off (avoids new backend-to-frontend plumbing for a feature not currently in use), not an oversight.

`generatePath()` strips the trailing slash from the static pattern before the redirect; Django's `APPEND_SLASH` restores it with a 301, one harmless extra hop on what's already a full-page navigation.
</details>

## Testing

`npx jest src/shared/access.test.js src/courseware/CoursewareRedirectLandingPage.test.jsx` - all passing, including new cases covering the embargo redirect for both the outline tab and a non-outline tab, and the landing-page route itself.

<details>
<summary><b>Manual testing</b></summary>

Requires the companion backend PR (openedx/openedx-platform#39079) running - this PR alone has no effect, since nothing produces `errorCode: 'embargo'` without it.

Mark results as you go - `[x]` pass, `[!]` problem (add a note).

1. Check out both branches in a local devstack: this PR here, and openedx/openedx-platform#39079 for `edx-platform`.
2. In a Django/LMS shell (or `/admin/embargo/globalrestrictedcountry/`), add a country to `GlobalRestrictedCountry`:
   ```python
   from openedx.core.djangoapps.embargo.models import Country, GlobalRestrictedCountry
   country, _ = Country.objects.get_or_create(country='IR')
   GlobalRestrictedCountry.objects.get_or_create(country=country)
   ```
3. Confirm `settings.EMBARGO` is `True` for your devstack (it defaults `True` under `lms.envs.tutor.development`; `False` in general `envs/common.py`).
4. Set a test learner's profile country to the same code - easiest via shell, since IP-header spoofing needs browser tooling:
   ```python
   from django.contrib.auth import get_user_model
   from django.core.cache import cache
   user = get_user_model().objects.get(username='<test-learner>')
   user.profile.country = 'IR'
   user.profile.save()
   cache.clear()
   ```
5. Log in as that learner and visit any Learning MFE course tab, e.g. `.../learning/course/<course_id>/home`.
   - [ ] Redirected to the LMS's `/embargo/blocked-message/courseware/default/`, showing "This Course Unavailable In Your Country" - from the outline/home tab specifically (previously rendered the course anyway).
   - [ ] Same redirect from `dates` and `progress` tabs.
6. Log in as a course team member / staff for the same course.
   - [ ] Course loads normally - staff/course-author bypass is unaffected.
7. Clean up: remove the `GlobalRestrictedCountry` row and reset the test learner's `profile.country`.

</details>

## Additional Context

Depends on / must merge after openedx/openedx-platform#39079 (the backend change is what actually produces `errorCode: 'embargo'` - this PR only changes how the frontend reacts to it).
